### PR TITLE
Change Distribute interface to have optional arguments

### DIFF
--- a/pkg/federate/federator.go
+++ b/pkg/federate/federator.go
@@ -29,10 +29,12 @@ type Federator interface {
 	// The actual distribution may occur asynchronously in which case any returned error only indicates that the request
 	// failed.
 	//
+	// If clusterNames is not passed, the resource will be distributed to all clusters
+	//
 	// If the resource was previously distributed and the given resource differs, each previous cluster will receive the
 	// updated resource. If previously distributed and the given list of clusters differs, the resource will be
 	// distributed to any new clusters in the updated list and deleted from previous clusters not in the updated list.
-	Distribute(resource runtime.Object, clusterIDs []string) error
+	Distribute(resource runtime.Object, clusterNames ...string) error
 
 	// Delete stops distributing the given resource and deletes it from all clusters to which it was distributed.
 	// The actual deletion may occur asynchronously in which any returned error only indicates that the request

--- a/pkg/federate/kubefed/resource.go
+++ b/pkg/federate/kubefed/resource.go
@@ -8,7 +8,7 @@ const (
 //	federatedKindPrefix string = "Federated"
 )
 
-func (f *federator) Distribute(resource runtime.Object, clusterIDs []string) error {
+func (f *federator) Distribute(resource runtime.Object, clusterNames ...string) error {
 	panic("not implemented")
 }
 


### PR DESCRIPTION
This patch changes the cluster names argument's name to clusterNames and
it also makes it an optional argument to make it a cleaner call when it
needs to distribute to all clusters.