### PR TITLE
Remove kubefed code dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,6 @@ require (
 	k8s.io/klog v0.0.0-20181108234604-8139d8cb77af
 	k8s.io/kube-openapi v0.0.0-20200204173128-addea2498afe // indirect
 	sigs.k8s.io/controller-runtime v0.1.12
-	sigs.k8s.io/kubefed v0.1.0-rc3
 	sigs.k8s.io/testing_frameworks v0.1.1 // indirect
 	sigs.k8s.io/yaml v1.2.0 // indirect
 )

--- a/pkg/federate/kubefed/federator.go
+++ b/pkg/federate/kubefed/federator.go
@@ -14,6 +14,20 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const (
+	DefaultFederatedGroup   = "types.kubefed.k8s.io"
+	DefaultFederatedVersion = "v1beta1"
+	SpecField               = "spec"
+	TemplateField           = "template"
+	PlacementField          = "placement"
+	MatchLabelsField        = "matchLabels"
+	ClusterSelectorField    = "clusterSelector"
+	ApiEndpointField        = "apiEndpoint"
+	SecretRefField          = "secretRef"
+	NameField               = "name"
+	CaBundleField           = "caBundle"
+)
+
 var (
 	kubeFedNamespace string
 )

--- a/pkg/federate/kubefed/resource.go
+++ b/pkg/federate/kubefed/resource.go
@@ -12,8 +12,6 @@ import (
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	ctlutil "sigs.k8s.io/kubefed/pkg/controller/util"
-	kubefedopt "sigs.k8s.io/kubefed/pkg/kubefedctl/options"
 )
 
 const (
@@ -49,15 +47,15 @@ func (f *Federator) Distribute(resource runtime.Object) error {
 		// Replace the "spec" field in the existing object with the updated field from "fedResource". We preserve the
 		// existing metadata info, specifically the ResourceVersion which must be set on an update operation.
 		// Note - we set a valid "spec" field earlier in "fedResource" so no need to handle the other return values.
-		newSpec, _, _ := unstructured.NestedFieldNoCopy(fedResource.Object, ctlutil.SpecField)
+		newSpec, _, _ := unstructured.NestedFieldNoCopy(fedResource.Object, SpecField)
 
-		oldSpec, _, _ := unstructured.NestedFieldNoCopy(existing.Object, ctlutil.SpecField)
+		oldSpec, _, _ := unstructured.NestedFieldNoCopy(existing.Object, SpecField)
 		if reflect.DeepEqual(oldSpec, newSpec) {
 			// No need to issue the update if the spec didn't change
 			return nil
 		}
 
-		if setErr := unstructured.SetNestedField(existing.Object, newSpec, ctlutil.SpecField); setErr != nil {
+		if setErr := unstructured.SetNestedField(existing.Object, newSpec, SpecField); setErr != nil {
 			return fmt.Errorf(errorSettingFederatedFields, setErr)
 		}
 
@@ -107,13 +105,13 @@ func createFederatedResource(scheme *runtime.Scheme, resource runtime.Object) (*
 	removeUnwantedFields(targetResource)
 
 	// Adding the template field and including the targetResource's object as its content.
-	err = unstructured.SetNestedField(fedResource.Object, targetResource.Object, ctlutil.SpecField, ctlutil.TemplateField)
+	err = unstructured.SetNestedField(fedResource.Object, targetResource.Object, SpecField, TemplateField)
 	if err != nil {
 		return nil, fmt.Errorf(errorSettingFederatedFields, err)
 	}
 	// Adding an empty selector for the Placement field's MatchLabel. An empty selector means
 	// all clusters.
-	err = unstructured.SetNestedStringMap(fedResource.Object, map[string]string{}, ctlutil.SpecField, ctlutil.PlacementField, ctlutil.ClusterSelectorField, ctlutil.MatchLabelsField)
+	err = unstructured.SetNestedStringMap(fedResource.Object, map[string]string{}, SpecField, PlacementField, ClusterSelectorField, MatchLabelsField)
 	if err != nil {
 		return nil, fmt.Errorf(errorSettingFederatedFields, err)
 	}
@@ -127,8 +125,8 @@ func setBasicMetaFields(resource, base *unstructured.Unstructured) {
 
 	// TODO(mpeterson): Modify to get the type config and generalize this usage
 	gv := schema.GroupVersion{
-		Group:   kubefedopt.DefaultFederatedGroup,
-		Version: kubefedopt.DefaultFederatedVersion,
+		Group:   DefaultFederatedGroup,
+		Version: DefaultFederatedVersion,
 	}
 	resource.SetAPIVersion(gv.String())
 

--- a/pkg/federate/kubefed/resource_test.go
+++ b/pkg/federate/kubefed/resource_test.go
@@ -17,8 +17,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	ctlutil "sigs.k8s.io/kubefed/pkg/controller/util"
-	kubefedopt "sigs.k8s.io/kubefed/pkg/kubefedctl/options"
 )
 
 type fakeClientWithUpdateError struct {
@@ -126,14 +124,14 @@ func testCreateFederatedResource() {
 			expected, err := createFederatedResource(scheme, resource)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(expected.GroupVersionKind().Group).
-				To(Equal(kubefedopt.DefaultFederatedGroup))
+				To(Equal(DefaultFederatedGroup))
 		})
 
 		It("the returned resource's Version should be the default KubeFed FederatedVersion", func() {
 			expected, err := createFederatedResource(scheme, resource)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(expected.GroupVersionKind().Version).
-				To(Equal(kubefedopt.DefaultFederatedVersion))
+				To(Equal(DefaultFederatedVersion))
 		})
 
 		It("the returned resource's name should be the same as the input's object", func() {
@@ -249,9 +247,7 @@ func testDistribute() {
 				Expect(fedPodObj["spec"]).ToNot(BeEquivalentTo(expectObj["spec"]))
 
 				mapObj, _, _ := unstructured.NestedSlice(
-					fedPod.Object,
-					ctlutil.SpecField, ctlutil.TemplateField, "spec", "containers",
-				)
+					fedPod.Object, SpecField, TemplateField, "spec", "containers")
 				image := mapObj[0].(map[string]interface{})["image"]
 				Expect(image).To(BeEquivalentTo(expectedImage))
 			}
@@ -393,18 +389,11 @@ func newFederatorWithScheme(scheme *runtime.Scheme, client client.Client, initOb
 }
 
 func getTemplateField(resource *unstructured.Unstructured) (map[string]interface{}, bool, error) {
-	return unstructured.NestedMap(
-		resource.Object,
-		ctlutil.SpecField, ctlutil.TemplateField,
-	)
+	return unstructured.NestedMap(resource.Object, SpecField, TemplateField)
 }
 
 func getMatchLabelsField(resource *unstructured.Unstructured) (map[string]string, bool, error) {
-	return unstructured.NestedStringMap(
-		resource.Object,
-		ctlutil.SpecField, ctlutil.PlacementField,
-		ctlutil.ClusterSelectorField, ctlutil.MatchLabelsField,
-	)
+	return unstructured.NestedStringMap(resource.Object, SpecField, PlacementField, ClusterSelectorField, MatchLabelsField)
 }
 
 func getResourceFromAPI(kubeFedClient client.Client, resource *unstructured.Unstructured) (*unstructured.Unstructured, error) {


### PR DESCRIPTION
Modified code that referenced components in the kubefed project to
eliminate the dependency. The kubefed code base we're referencing is
a bit old and uses old k8s et al libs which will prevent us from
bumping to new versions of those libs (eg controller-runtime).

Specific changes:

- Redefine some constants instead of getting them from kubefed
- Use the dymanic client and Unstructured APIs to avoid having to
  reference the KubeFedCluster struct

Signed-off-by: Tom Pantelis <tompantelis@gmail.com>