### PR TITLE
Move workqueue from submariner for reuse

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	go.uber.org/zap v1.10.0 // indirect
 	golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59 // indirect
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect
-	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
+	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	k8s.io/api v0.0.0-20190222213804-5cb15d344471
 	k8s.io/apiextensions-apiserver v0.0.0-20181213153335-0fe22c71c476 // indirect

--- a/pkg/workqueue/queue.go
+++ b/pkg/workqueue/queue.go
@@ -1,0 +1,91 @@
+package workqueue
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/submariner-io/admiral/pkg/log"
+	"golang.org/x/time/rate"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog"
+)
+
+type ProcessFunc func(name, namespace string) (bool, error)
+
+type Interface interface {
+	Enqueue(obj interface{})
+
+	Run(stopCh <-chan struct{}, process ProcessFunc)
+
+	ShutDown()
+}
+
+type queueType struct {
+	workqueue.RateLimitingInterface
+
+	name string
+}
+
+func New(name string) Interface {
+	return &queueType{
+		RateLimitingInterface: workqueue.NewNamedRateLimitingQueue(workqueue.NewMaxOfRateLimiter(
+			// exponential per-item rate limiter
+			workqueue.NewItemExponentialFailureRateLimiter(5*time.Millisecond, 30*time.Second),
+			// overall rate limiter (not per item)
+			&workqueue.BucketRateLimiter{Limiter: rate.NewLimiter(rate.Limit(10), 100)},
+		), name),
+		name: name,
+	}
+}
+
+func (q *queueType) Enqueue(obj interface{}) {
+	var key string
+	var err error
+	if key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(obj); err != nil {
+		utilruntime.HandleError(err)
+		return
+	}
+
+	klog.V(log.TRACE).Infof("%s: enqueueing key %q for %T object", q.name, key, obj)
+	q.AddRateLimited(key)
+}
+
+func (q *queueType) Run(stopCh <-chan struct{}, process ProcessFunc) {
+	go wait.Until(func() {
+		for q.processNextWorkItem(process) {
+		}
+	}, time.Second, stopCh)
+}
+
+func (q *queueType) processNextWorkItem(process ProcessFunc) bool {
+	key, shutdown := q.Get()
+	if shutdown {
+		return false
+	}
+
+	defer q.Done(key)
+
+	requeue, err := func() (bool, error) {
+		ns, name, err := cache.SplitMetaNamespaceKey(key.(string))
+		if err != nil {
+			return false, err
+		}
+
+		return process(name, ns)
+	}()
+
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("%s: Failed to process object with key %q: %v", q.name, key, err))
+	}
+
+	if requeue {
+		q.AddRateLimited(key)
+	} else {
+		q.Forget(key)
+	}
+
+	return true
+}

--- a/pkg/workqueue/queue.go
+++ b/pkg/workqueue/queue.go
@@ -83,6 +83,7 @@ func (q *queueType) processNextWorkItem(process ProcessFunc) bool {
 
 	if requeue {
 		q.AddRateLimited(key)
+		klog.V(log.DEBUG).Infof("%s: enqueued %q for retry - # of times re-queued: %d", q.name, key, q.NumRequeues(key))
 	} else {
 		q.Forget(key)
 	}


### PR DESCRIPTION
The idea here is to put reusable components into admiral to be used by submariner and lighthouse (and possibly others in the future). This avoids lighthouse having to depend on submariner and its release cadence. 

Another reusable component will be the generic datastoresyncer which will live in admiral.  This component will also want to use the workqueue wrapper - if we left it in submariner then we'd have a cross-dependency between the projects.