### PR TITLE
Fix CI validate failure

### DIFF
--- a/scripts/validate
+++ b/scripts/validate
@@ -19,4 +19,4 @@ if [[ $(goimports -l ${PACKAGES} | wc -l) -gt 0 ]]; then
     exit 1
 fi
 
-golangci-lint run
+golangci-lint run --timeout 5m


### PR DESCRIPTION
The bump to a new golangci-lint version is causing a timeout - need to bump
the timeout as was done in other projects.

Signed-off-by: Tom Pantelis <tompantelis@gmail.com>