### PR TITLE
Check whether the CA trust chain is needed

### DIFF
--- a/pkg/syncer/broker/config.go
+++ b/pkg/syncer/broker/config.go
@@ -16,7 +16,7 @@ type brokerSpecification struct {
 	Ca              string
 }
 
-func BuildBrokerConfigFromEnv() (*rest.Config, string, error) {
+func BuildBrokerConfigFromEnv(useTokenCAForEndpoint bool) (*rest.Config, string, error) {
 	brokerSpec := brokerSpecification{}
 	err := envconfig.Process("broker_k8s", &brokerSpec)
 	if err != nil {
@@ -26,7 +26,7 @@ func BuildBrokerConfigFromEnv() (*rest.Config, string, error) {
 	tlsClientConfig := rest.TLSClientConfig{}
 	if brokerSpec.Insecure {
 		tlsClientConfig.Insecure = true
-	} else {
+	} else if useTokenCAForEndpoint {
 		caDecoded, err := base64.StdEncoding.DecodeString(brokerSpec.Ca)
 		if err != nil {
 			return nil, "", fmt.Errorf("error decoding CA data: %v", err)


### PR DESCRIPTION
The trust anchor stored in the broker information reflects the trust
chain of the token, not necessarily the trust chain of the API
endpoint; but we're using it for the latter in all cases.

This changes NewSyncer to check whether the clientset can be used,
by retrieving the first resource that's supposed to be synchronised.
This allows the configuration to be verified, and switched to use the
stored trust anchor if necessary.