### PR TITLE
Federator should sync the "status" field

### DIFF
--- a/pkg/syncer/broker/federator.go
+++ b/pkg/syncer/broker/federator.go
@@ -86,7 +86,6 @@ func (f *federator) prepareResourceForSync(resource *unstructured.Unstructured) 
 		}
 	}
 
-	unstructured.RemoveNestedField(resource.Object, "status")
 	resource.SetNamespace(f.brokerNamespace)
 }
 

--- a/pkg/syncer/broker/federator_test.go
+++ b/pkg/syncer/broker/federator_test.go
@@ -58,6 +58,20 @@ func testDistribute() {
 			})
 		})
 
+		When("the resource contains Status data", func() {
+			BeforeEach(func() {
+				resource.Status = corev1.PodStatus{
+					Phase:   "PodRunning",
+					Message: "Pod is running",
+				}
+			})
+
+			It("should create the resource with the Status data", func() {
+				Expect(f.Distribute(resource)).To(Succeed())
+				test.VerifyResource(resourceClient, resource, test.RemoteNamespace, localClusterID)
+			})
+		})
+
 		When("create fails", func() {
 			JustBeforeEach(func() {
 				resourceClient.FailOnCreate = apierrors.NewServiceUnavailable("fake")

--- a/pkg/syncer/test/util.go
+++ b/pkg/syncer/test/util.go
@@ -57,6 +57,7 @@ func VerifyResource(resourceInterface dynamic.ResourceInterface, expected *corev
 	Expect(actual.GetNamespace()).To(Equal(expNamespace))
 	Expect(actual.GetAnnotations()).To(Equal(expected.GetAnnotations()))
 	Expect(actual.Spec).To(Equal(expected.Spec))
+	Expect(actual.Status).To(Equal(expected.Status))
 
 	Expect(actual.GetUID()).NotTo(Equal(expected.GetUID()))
 	Expect(actual.GetResourceVersion()).NotTo(Equal(expected.GetResourceVersion()))


### PR DESCRIPTION
The broker Federator previously stripped out the "status" field to
avoid potential performance issues but lighthouse needs it synced.
Instead of automatically stripping it, we can defer to the TransformFunc
or add a flag to do it later if needed.

Signed-off-by: Tom Pantelis <tompantelis@gmail.com>