### PR TITLE
Add operation param to syncer TransformFunc

### DIFF
--- a/pkg/syncer/broker/syncer_test.go
+++ b/pkg/syncer/broker/syncer_test.go
@@ -4,6 +4,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/submariner-io/admiral/pkg/fake"
+	sync "github.com/submariner-io/admiral/pkg/syncer"
 	"github.com/submariner-io/admiral/pkg/syncer/test"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -128,7 +129,7 @@ var _ = Describe("Broker Syncer", func() {
 	When("a local transform function is specified", func() {
 		BeforeEach(func() {
 			transformed = test.NewPodWithImage(config.LocalNamespace, "transformed")
-			config.ResourceConfigs[0].LocalTransform = func(from runtime.Object) (runtime.Object, bool) {
+			config.ResourceConfigs[0].LocalTransform = func(from runtime.Object, op sync.Operation) (runtime.Object, bool) {
 				return transformed, false
 			}
 		})
@@ -146,7 +147,7 @@ var _ = Describe("Broker Syncer", func() {
 	When("a broker transform function is specified", func() {
 		BeforeEach(func() {
 			transformed = test.NewPodWithImage(config.LocalNamespace, "transformed")
-			config.ResourceConfigs[0].BrokerTransform = func(from runtime.Object) (runtime.Object, bool) {
+			config.ResourceConfigs[0].BrokerTransform = func(from runtime.Object, op sync.Operation) (runtime.Object, bool) {
 				return transformed, false
 			}
 		})

--- a/test/e2e/syncer/broker.go
+++ b/test/e2e/syncer/broker.go
@@ -7,6 +7,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/syncer"
 	"github.com/submariner-io/admiral/pkg/syncer/broker"
 	"github.com/submariner-io/admiral/pkg/syncer/test"
 	testV1 "github.com/submariner-io/admiral/test/apis/admiral.submariner.io/v1"
@@ -46,7 +47,7 @@ func testWithLocalTransform() {
 
 	BeforeEach(func() {
 		t.brokerResourceType = &testV1.ExportedToaster{}
-		t.localTransform = func(from runtime.Object) (runtime.Object, bool) {
+		t.localTransform = func(from runtime.Object, op syncer.Operation) (runtime.Object, bool) {
 			toaster := from.(*testV1.Toaster)
 			return &testV1.ExportedToaster{
 				ObjectMeta: metav1.ObjectMeta{
@@ -73,7 +74,7 @@ func testWithLocalTransform() {
 type testDriver struct {
 	framework            *framework.Framework
 	localSourceNamespace string
-	localTransform       func(from runtime.Object) (runtime.Object, bool)
+	localTransform       func(from runtime.Object, op syncer.Operation) (runtime.Object, bool)
 	brokerResourceType   runtime.Object
 	clusterClients       []dynamic.Interface
 	stopCh               chan struct{}


### PR DESCRIPTION
Lighthouse has a use case to have the operation - _Create_, _Update_, or _Delete_ - passed into the TransformFunc.

Signed-off-by: Tom Pantelis <tompantelis@gmail.com>