### PR TITLE
Create singleton federators in broker syncer

### DIFF
--- a/pkg/syncer/broker/syncer_test.go
+++ b/pkg/syncer/broker/syncer_test.go
@@ -163,15 +163,9 @@ var _ = Describe("Broker Syncer", func() {
 		})
 	})
 
-	When("GetBrokerFederatorFor is called for a valid resource type", func() {
+	When("GetBrokerFederatorFor is called", func() {
 		It("should return the Federator", func() {
-			Expect(syncer.GetBrokerFederatorFor(resource)).ToNot(BeNil())
-		})
-	})
-
-	When("GetBrokerFederatorFor is called for an invalid resource type", func() {
-		It("should return nil", func() {
-			Expect(syncer.GetBrokerFederatorFor(&corev1.Service{})).To(BeNil())
+			Expect(syncer.GetBrokerFederator()).ToNot(BeNil())
 		})
 	})
 })


### PR DESCRIPTION
Previously it created a remote and local federators per resource syncer and stored the remote federators per resource type. However a federator isn't specific to a resource type so we can create singleton instances and reuse for each syncer.

Signed-off-by: Tom Pantelis <tompantelis@gmail.com>