### PR TITLE
Add golangci-lint config file, add linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,51 @@
+linters-settings:
+  gocritic:
+    enabled-tags:
+      - diagnostic
+      #- opinionated
+      #- performance
+      #- style
+    disabled-checks:
+      - unlambda
+  gocyclo:
+    min-complexity: 15
+  lll:
+    line-length: 140
+  maligned:
+    suggest-new: true
+linters:
+  disable-all: true
+  enable:
+    - bodyclose
+    - deadcode
+    - depguard
+    - dupl
+    - errcheck
+    - exportloopref
+    #- funlen
+    #- gochecknoglobals
+    #- gochecknoinits
+    - gocritic
+    - gocyclo
+    #- gofmt
+    - goimports
+    #- golint
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - interfacer
+    #- lll
+    - misspell
+    - maligned
+    - nakedret
+    - staticcheck
+    - structcheck
+    #- stylecheck
+    #- testpackage
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+    - whitespace


### PR DESCRIPTION
Explicitly enable linters to be run by golangci-lint. Makes testing more
explicit/consistent and also allows us to add non-default linters.

Enables these extra linters over the defaults:

* bodyclose: checks whether HTTP response body is closed successfully
* depguard: Go linter that checks if package imports are in a list of
  acceptable packages
* dupl: Tool for code clone detection
* exportloopref: An analyzer that finds exporting pointers for loop
  variables
* gocyclo: Computes and checks the cyclomatic complexity of functions
* goimports: Goimports does everything that gofmt does. Additionally it
  checks unused imports
* gosec (gas): Inspects source code for security problems
* interfacer: Linter that suggests narrower interface types
* maligned: Tool to detect Go structs that would take less memory if
  their fields were sorted
* misspell: Finds commonly misspelled English words in comments
* nakedret: Finds naked returns in functions greater than a specified
  function length
* unconvert: Remove unnecessary type conversions
* unparam: Reports unused function parameters
* whitespace: Tool for detection of leading and trailing whitespace

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>