### PR TITLE
Enable golint and stylecheck linting, fix errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,6 +9,8 @@ linters-settings:
       - unlambda
   gocyclo:
     min-complexity: 15
+  golint:
+    min-confidence: 0
   lll:
     line-length: 140
   maligned:
@@ -29,7 +31,7 @@ linters:
     - gocyclo
     - gofmt
     - goimports
-    #- golint
+    - golint
     - gosec
     - gosimple
     - govet
@@ -41,7 +43,7 @@ linters:
     - nakedret
     - staticcheck
     - structcheck
-    #- stylecheck
+    - stylecheck
     #- testpackage
     - typecheck
     - unconvert
@@ -62,3 +64,17 @@ issues:
     - linters:
         - wsl
       text: "only one cuddle assignment allowed before if statement"
+
+    # Allow dot-imports for Gomega BDD directives per idiomatic Gomega
+    - linters:
+        - stylecheck
+        - golint
+      text: "should not use dot imports"
+      source: ". \"github.com/onsi/gomega\""
+
+    # Allow dot-imports for Ginkgo BDD directives per idiomatic Ginkgo
+    - linters:
+        - stylecheck
+        - golint
+      text: "should not use dot imports"
+      source: ". \"github.com/onsi/ginkgo\""

--- a/pkg/gomega/matchers.go
+++ b/pkg/gomega/matchers.go
@@ -19,7 +19,7 @@ func ContainErrorSubstring(expected error) gomegaTypes.GomegaMatcher {
 func (m *containErrorSubstring) Match(x interface{}) (bool, error) {
 	actual, ok := x.(error)
 	if !ok {
-		return false, fmt.Errorf("ContainErrorSubstring matcher requires an error.  Got:\n%s", format.Object(x, 1))
+		return false, fmt.Errorf("containErrorSubstring matcher requires an error.  Got:\n%s", format.Object(x, 1))
 	}
 
 	return strings.Contains(actual.Error(), m.expected.Error()), nil


### PR DESCRIPTION
Both linters flag the same dot imports in this repo, so fixing one fixes both.

Builds on https://github.com/submariner-io/admiral/pull/87.