### PR TITLE
Fix MD lint violations

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,2 @@
+line-length:
+  line_length: 140

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-# admiral
-Admiral provides a control plane and APIs for federating resources to submariner data planes running in multiple clusters. 
+# Admiral
+
+Admiral provides a control plane and APIs for federating resources to submariner data planes running in multiple clusters.


### PR DESCRIPTION
Configure custom maximum line length of 140 chars to match Go linting.

Will be tested by the verify job once it's update in Shipyard.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>