### PR TITLE
Migrate CRDs to apiextensions v1

### DIFF
--- a/test/e2e/deploy/crds.yaml
+++ b/test/e2e/deploy/crds.yaml
@@ -1,23 +1,51 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: toasters.admiral.submariner.io
 spec:
   group: admiral.submariner.io
-  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              manufacturer:
+                type: string
+              modelNumber:
+                type: string
   names:
     kind: Toaster
     plural: toasters
   scope: Namespaced
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: exportedtoasters.admiral.submariner.io
 spec:
   group: admiral.submariner.io
-  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              manufacturer:
+                type: string
+              modelNumber:
+                type: string
   names:
     kind: ExportedToaster
     plural: exportedtoasters


### PR DESCRIPTION
The apiextensions.k8s.io/v1beta1 version of CustomResourceDefinition
is deprecated in Kubernetes v1.16 and will no longer be served in
v1.19. Use apiextensions.k8s.io/v1 instead.

Signed-off-by: Stephen Kitt <skitt@redhat.com>