### PR TITLE
Add commit message validations

### DIFF
--- a/.github/workflows/gitlint.yaml
+++ b/.github/workflows/gitlint.yaml
@@ -1,0 +1,18 @@
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+    tags:
+      - 'v**'
+
+name: Commit Message Validations
+jobs:
+  gitlint:
+    name: Gitlint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+        with:
+          fetch-depth: 0
+      - run: make gitlint

--- a/.gitlint
+++ b/.gitlint
@@ -1,0 +1,9 @@
+[general]
+# body-is-missing: Allow commit messages with only a title
+# body-min-length: Allow short body lines, like "Relates-to: #issue"
+ignore=body-is-missing,body-min-length
+
+[ignore-by-body]
+# Dependabot doesn't follow our conventions, unfortunately
+regex=^Signed-off-by: dependabot-preview\[bot\](.*)
+ignore=all


### PR DESCRIPTION
Add GHA to run commit message linting via shared Shipyard make target.

Allow commit messages with only a title, no body.

Allow short body lines, for example GH's "Relates-to"/"Closes".

Ignore commits from Dependabot, as it doesn't follow our conventions.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>