### PR TITLE
Add NoopFederator

### DIFF
--- a/pkg/federate/federator.go
+++ b/pkg/federate/federator.go
@@ -23,3 +23,18 @@ type Federator interface {
 	// failed.
 	Delete(resource runtime.Object) error
 }
+
+type noopFederator struct {
+}
+
+func NewNoopFederator() Federator {
+	return &noopFederator{}
+}
+
+func (n noopFederator) Distribute(resource runtime.Object) error {
+	return nil
+}
+
+func (n noopFederator) Delete(resource runtime.Object) error {
+	return nil
+}


### PR DESCRIPTION
A `Federator` implementation that does nothing. This will be useful for syncers that only watch resources and don't actually sync anything.

