### PR TITLE
Make metadata fields to preserve configurable in broker Federator

### DIFF
--- a/pkg/syncer/test/util.go
+++ b/pkg/syncer/test/util.go
@@ -60,6 +60,7 @@ func VerifyResource(resourceInterface dynamic.ResourceInterface, expected *corev
 	Expect(actual.GetName()).To(Equal(expected.GetName()))
 	Expect(actual.GetNamespace()).To(Equal(expNamespace))
 	Expect(actual.GetAnnotations()).To(Equal(expected.GetAnnotations()))
+	Expect(actual.GetOwnerReferences()).To(Equal(expected.GetOwnerReferences()))
 	Expect(actual.Spec).To(Equal(expected.Spec))
 	Expect(actual.Status).To(Equal(expected.Status))
 


### PR DESCRIPTION
There are cases where additional fields need to be preserved so make it configurable. An example is `OwnerReferences` when syncing local -> local.

