### PR TITLE
Pass Scheme to NewDynamicClient

### DIFF
--- a/pkg/fake/dynamic_client.go
+++ b/pkg/fake/dynamic_client.go
@@ -13,7 +13,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/fake"
-	"k8s.io/client-go/kubernetes/scheme"
 )
 
 type dynamicClient struct {
@@ -41,8 +40,8 @@ type DynamicResourceClient struct {
 	PersistentFailOnGet    atomic.Value
 }
 
-func NewDynamicClient(objects ...runtime.Object) dynamic.Interface {
-	f := fake.NewSimpleDynamicClient(scheme.Scheme, objects...)
+func NewDynamicClient(scheme *runtime.Scheme, objects ...runtime.Object) dynamic.Interface {
+	f := fake.NewSimpleDynamicClient(scheme, objects...)
 
 	return &dynamicClient{
 		Interface:              f,

--- a/pkg/syncer/broker/federator_test.go
+++ b/pkg/syncer/broker/federator_test.go
@@ -14,6 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/scheme"
 )
 
 var _ = Describe("Federator", func() {
@@ -256,7 +257,7 @@ func testDelete() {
 func setupFederator(resource *corev1.Pod, initObjs []runtime.Object, localClusterID, federatorNS, targetNS string,
 	keepMetadataField ...string) (federate.Federator,
 	*fake.DynamicResourceClient) {
-	dynClient := fake.NewDynamicClient(test.PrepInitialClientObjs("", localClusterID, initObjs...)...)
+	dynClient := fake.NewDynamicClient(scheme.Scheme, test.PrepInitialClientObjs("", localClusterID, initObjs...)...)
 	restMapper, gvr := test.GetRESTMapperAndGroupVersionResourceFor(resource)
 	f := broker.NewFederator(dynClient, restMapper, federatorNS, localClusterID, keepMetadataField...)
 

--- a/pkg/syncer/broker/syncer_test.go
+++ b/pkg/syncer/broker/syncer_test.go
@@ -13,6 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
 )
 
 var _ = Describe("Broker Syncer", func() {
@@ -48,8 +49,8 @@ var _ = Describe("Broker Syncer", func() {
 	JustBeforeEach(func() {
 		restMapper, gvr := test.GetRESTMapperAndGroupVersionResourceFor(resource)
 
-		localDynClient := fake.NewDynamicClient(test.PrepInitialClientObjs("", "", initialResources...)...)
-		brokerDynClient := fake.NewDynamicClient()
+		localDynClient := fake.NewDynamicClient(scheme.Scheme, test.PrepInitialClientObjs("", "", initialResources...)...)
+		brokerDynClient := fake.NewDynamicClient(scheme.Scheme)
 
 		localClient = localDynClient.Resource(*gvr).Namespace(config.ResourceConfigs[0].LocalSourceNamespace).(*fake.DynamicResourceClient)
 		brokerClient = brokerDynClient.Resource(*gvr).Namespace(config.BrokerNamespace).(*fake.DynamicResourceClient)


### PR DESCRIPTION
Tests usually need to create their own Scheme to avoid race conditions with the shared Scheme.
