### PR TITLE
Make the resource watcher selectors resource specific

### DIFF
--- a/pkg/watcher/resource_watcher.go
+++ b/pkg/watcher/resource_watcher.go
@@ -45,14 +45,6 @@ type ResourceConfig struct {
 	// to compare the old and new resources. If true is returned, the update is ignored, otherwise the update is processed.
 	// By default all updates are processed.
 	ResourcesEquivalent syncer.ResourceEquivalenceFunc
-}
-
-type Config struct {
-	// Name of this watcher used for logging.
-	Name string
-
-	// RestConfig the REST config used to access the resources to watch.
-	RestConfig *rest.Config
 
 	// SourceNamespace the namespace of the resources to watch.
 	SourceNamespace string
@@ -62,6 +54,14 @@ type Config struct {
 
 	// SourceFieldSelector optional selector to restrict the resources to watch by their fields.
 	SourceFieldSelector string
+}
+
+type Config struct {
+	// Name of this watcher used for logging.
+	Name string
+
+	// RestConfig the REST config used to access the resources to watch.
+	RestConfig *rest.Config
 
 	// WaitForCacheSync if true, waits for the informer cache to sync on Start. Default is true.
 	WaitForCacheSync *bool
@@ -106,9 +106,9 @@ func NewWithDetail(config *Config, restMapper meta.RESTMapper, client dynamic.In
 		s, err := syncer.NewResourceSyncer(&syncer.ResourceSyncerConfig{
 			Name:                config.Name,
 			SourceClient:        client,
-			SourceNamespace:     config.SourceNamespace,
-			SourceLabelSelector: config.SourceLabelSelector,
-			SourceFieldSelector: config.SourceFieldSelector,
+			SourceNamespace:     rc.SourceNamespace,
+			SourceLabelSelector: rc.SourceLabelSelector,
+			SourceFieldSelector: rc.SourceFieldSelector,
 			Direction:           syncer.RemoteToLocal,
 			RestMapper:          restMapper,
 			Federator:           federate.NewNoopFederator(),

--- a/pkg/watcher/resource_watcher_test.go
+++ b/pkg/watcher/resource_watcher_test.go
@@ -36,12 +36,12 @@ var _ = Describe("Resource Watcher", func() {
 		resource = test.NewPod("")
 
 		config = &watcher.Config{
-			Name:            "Pod watcher",
-			SourceNamespace: test.LocalNamespace,
-			Scheme:          runtime.NewScheme(),
+			Name:   "Pod watcher",
+			Scheme: runtime.NewScheme(),
 			ResourceConfigs: []watcher.ResourceConfig{
 				{
-					ResourceType: &corev1.Pod{},
+					SourceNamespace: test.LocalNamespace,
+					ResourceType:    &corev1.Pod{},
 					Handler: watcher.EventHandlerFuncs{
 						OnCreateFunc: func(obj runtime.Object) bool {
 							created <- obj.(*corev1.Pod)
@@ -67,7 +67,7 @@ var _ = Describe("Resource Watcher", func() {
 		restMapper, gvr := test.GetRESTMapperAndGroupVersionResourceFor(resource)
 
 		localDynClient := fake.NewDynamicClient(config.Scheme)
-		client = localDynClient.Resource(*gvr).Namespace(config.SourceNamespace)
+		client = localDynClient.Resource(*gvr).Namespace(config.ResourceConfigs[0].SourceNamespace)
 
 		resourceWatcher, err := watcher.NewWithDetail(config, restMapper, localDynClient)
 		Expect(err).To(Succeed())


### PR DESCRIPTION
The following fields have been moved to ResourceConfig
* SourceNamespace
* SourceLabelSelector
* SourceFieldSelector

in a way that multiple resources can be watched from different
namespaces, and with different selectors.

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>