### PR TITLE
Make watcher more testable from consumer projects

### DIFF
--- a/pkg/watcher/resource_watcher_test.go
+++ b/pkg/watcher/resource_watcher_test.go
@@ -79,16 +79,16 @@ var _ = Describe("Resource Watcher", func() {
 	JustBeforeEach(func() {
 		Expect(corev1.AddToScheme(config.Scheme)).To(Succeed())
 
-		restMapper := test.GetRESTMapperFor(&corev1.Pod{}, &corev1.Service{})
+		config.RestMapper = test.GetRESTMapperFor(&corev1.Pod{}, &corev1.Service{})
 
-		localDynClient := fake.NewDynamicClient(config.Scheme)
+		config.Client = fake.NewDynamicClient(config.Scheme)
 
-		pods = localDynClient.Resource(*test.GetGroupVersionResourceFor(restMapper, &corev1.Pod{})).Namespace(
+		pods = config.Client.Resource(*test.GetGroupVersionResourceFor(config.RestMapper, &corev1.Pod{})).Namespace(
 			config.ResourceConfigs[0].SourceNamespace)
-		services = localDynClient.Resource(*test.GetGroupVersionResourceFor(restMapper, &corev1.Service{})).Namespace(
+		services = config.Client.Resource(*test.GetGroupVersionResourceFor(config.RestMapper, &corev1.Service{})).Namespace(
 			config.ResourceConfigs[0].SourceNamespace)
 
-		resourceWatcher, err := watcher.NewWithDetail(config, restMapper, localDynClient)
+		resourceWatcher, err := watcher.New(config)
 		Expect(err).To(Succeed())
 
 		Expect(resourceWatcher.Start(stopCh)).To(Succeed())

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -6,6 +6,7 @@ import (
 	. "github.com/onsi/gomega"
 	testV1 "github.com/submariner-io/admiral/test/apis/admiral.submariner.io/v1"
 	_ "github.com/submariner-io/admiral/test/e2e/syncer"
+	_ "github.com/submariner-io/admiral/test/e2e/watcher"
 	"github.com/submariner-io/shipyard/test/e2e"
 	"github.com/submariner-io/shipyard/test/e2e/framework"
 	"k8s.io/client-go/kubernetes/scheme"

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -1,0 +1,97 @@
+package util
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/syncer/test"
+	testV1 "github.com/submariner-io/admiral/test/apis/admiral.submariner.io/v1"
+	"github.com/submariner-io/shipyard/test/e2e/framework"
+	metaapi "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+func ToasterGVR() *schema.GroupVersionResource {
+	return &schema.GroupVersionResource{
+		Group:    testV1.SchemeGroupVersion.Group,
+		Version:  testV1.SchemeGroupVersion.Version,
+		Resource: "toasters",
+	}
+}
+
+func DeleteAllToasters(client dynamic.Interface, namespace, clusterName string) {
+	DeleteAllOf(client, ToasterGVR(), namespace, clusterName)
+}
+
+func DeleteAllOf(client dynamic.Interface, gvr *schema.GroupVersionResource, namespace, clusterName string) {
+	By(fmt.Sprintf("Deleting all %s in namespace %q from %q", gvr.Resource, namespace, clusterName))
+
+	resource := client.Resource(*gvr).Namespace(namespace)
+	Expect(resource.DeleteCollection(nil, metav1.ListOptions{})).To(Succeed())
+
+	framework.AwaitUntil(fmt.Sprintf("list %s in namespace %q from %q", gvr.Resource, namespace, clusterName), func() (i interface{},
+		e error) {
+		return resource.List(metav1.ListOptions{})
+	}, func(result interface{}) (bool, string, error) {
+		list := result.(*unstructured.UnstructuredList)
+		if len(list.Items) != 0 {
+			return false, fmt.Sprintf("%d %s still remain", len(list.Items), gvr.Resource), nil
+		}
+
+		return true, "", nil
+	})
+}
+
+func CreateToaster(client dynamic.Interface, toaster *testV1.Toaster, clusterName string) *testV1.Toaster {
+	By(fmt.Sprintf("Creating Toaster %q in namespace %q in %q", toaster.Name, toaster.Namespace, clusterName))
+
+	obj, err := client.Resource(*ToasterGVR()).Namespace(toaster.Namespace).Create(test.ToUnstructured(toaster),
+		metav1.CreateOptions{})
+	Expect(err).To(Succeed())
+
+	newToaster := &testV1.Toaster{}
+	Expect(scheme.Scheme.Convert(obj, newToaster, nil)).To(Succeed())
+
+	return newToaster
+}
+
+func DeleteToaster(client dynamic.Interface, toDelete runtime.Object, clusterName string) {
+	meta, err := metaapi.Accessor(toDelete)
+	Expect(err).To(Succeed())
+
+	By(fmt.Sprintf("Deleting Toaster %q in namespace %q from %q", meta.GetName(), meta.GetNamespace(), clusterName))
+
+	msg := fmt.Sprintf("delete Toaster %q in namespace %q from %q", meta.GetName(), meta.GetNamespace(), clusterName)
+	framework.AwaitUntil(msg, func() (i interface{}, e error) {
+		return nil, client.Resource(*ToasterGVR()).Namespace(meta.GetNamespace()).Delete(meta.GetName(), nil)
+	}, framework.NoopCheckResult)
+}
+
+func AddLabel(toaster *testV1.Toaster, key, value string) *testV1.Toaster {
+	if toaster.Labels == nil {
+		toaster.Labels = map[string]string{}
+	}
+
+	toaster.Labels[key] = value
+
+	return toaster
+}
+
+func NewToaster(name, namespace string) *testV1.Toaster {
+	return &testV1.Toaster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: testV1.ToasterSpec{
+			Manufacturer: "Cuisinart",
+			ModelNumber:  "1234T",
+		},
+	}
+}

--- a/test/e2e/watcher/watcher.go
+++ b/test/e2e/watcher/watcher.go
@@ -1,0 +1,93 @@
+package syncer
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/watcher"
+	testV1 "github.com/submariner-io/admiral/test/apis/admiral.submariner.io/v1"
+	"github.com/submariner-io/admiral/test/e2e/util"
+	"github.com/submariner-io/shipyard/test/e2e/framework"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic"
+)
+
+var _ = Describe("[watcher] Resource watcher tests", func() {
+	t := newTestDriver()
+
+	When(" a Toaster resource is created and deleted", func() {
+		It("should notify the handler of each event", func() {
+			clusterName := framework.TestContext.ClusterIDs[framework.ClusterA]
+			toaster := util.CreateToaster(t.client, util.NewToaster("test-toaster", t.framework.Namespace), clusterName)
+			Eventually(t.created).Should(Receive(Equal(toaster)))
+
+			util.DeleteToaster(t.client, toaster, clusterName)
+			Eventually(t.deleted).Should(Receive(Equal(toaster.Name)))
+		})
+	})
+})
+
+type testDriver struct {
+	framework *framework.Framework
+	created   chan *testV1.Toaster
+	deleted   chan string
+	client    dynamic.Interface
+	stopCh    chan struct{}
+}
+
+func newTestDriver() *testDriver {
+	f := framework.NewFramework("watcher")
+
+	t := &testDriver{framework: f}
+
+	BeforeEach(func() {
+		t.stopCh = make(chan struct{})
+		t.created = make(chan *testV1.Toaster, 100)
+		t.deleted = make(chan string, 100)
+	})
+
+	JustBeforeEach(func() {
+		toasterWatcher := t.newWatcher(framework.ClusterA)
+
+		var err error
+
+		t.client, err = dynamic.NewForConfig(framework.RestConfigs[framework.ClusterA])
+		Expect(err).To(Succeed())
+
+		Expect(toasterWatcher.Start(t.stopCh)).To(Succeed())
+	})
+
+	JustAfterEach(func() {
+		close(t.stopCh)
+
+		util.DeleteAllToasters(t.client, t.framework.Namespace, framework.TestContext.ClusterIDs[framework.ClusterA])
+	})
+
+	return t
+}
+
+func (t *testDriver) newWatcher(cluster framework.ClusterIndex) watcher.Interface {
+	watcherObj, err := watcher.New(&watcher.Config{
+		RestConfig: framework.RestConfigs[cluster],
+		ResourceConfigs: []watcher.ResourceConfig{
+			{
+				Name:         "Toaster watcher",
+				ResourceType: &testV1.Toaster{},
+				Handler: watcher.EventHandlerFuncs{
+					OnCreateFunc: func(obj runtime.Object) bool {
+						t.created <- obj.(*testV1.Toaster)
+						return false
+					},
+					OnDeleteFunc: func(obj runtime.Object) bool {
+						t.deleted <- obj.(*testV1.Toaster).Name
+						return false
+					},
+				},
+				SourceNamespace: t.framework.Namespace,
+			},
+		},
+	})
+
+	Expect(err).To(Succeed())
+
+	return watcherObj
+}


### PR DESCRIPTION
Watcher now accepts a dynclien and restmapper in the Config structure
as optional parameters.

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>