### PR TITLE
Separate admiral logs from lib-consumer logs, and sanitize levels

### DIFF
--- a/pkg/log/loglevels.go
+++ b/pkg/log/loglevels.go
@@ -17,9 +17,13 @@ const (
 	// DEBUG : used to provide logs for often occurring events that could be helpful
 	//        for debugging errors.
 	DEBUG = 2
+	// LIBDEBUG:  like DEBUG but for submariner internal libraries like admiral.
+	LIBDEBUG = 3
 	// TRACE : used for logging that occurs often or may dump a lot of information
 	//         which generally would be less useful for debugging but can be useful
 	//         in some cases, for example tracing function entry/exit, parameters,
 	//         structures, etc..
-	TRACE = 3
+	TRACE = 4
+	// LIBTRACE:  like TRACE but for submariner internal libraries like admiral.
+	LIBTRACE = 5
 )

--- a/pkg/syncer/broker/federator.go
+++ b/pkg/syncer/broker/federator.go
@@ -39,7 +39,7 @@ func NewFederator(dynClient dynamic.Interface, restMapper meta.RESTMapper, targe
 }
 
 func (f *federator) Distribute(resource runtime.Object) error {
-	klog.V(log.DEBUG).Infof("In Distribute for %#v", resource)
+	klog.V(log.LIBTRACE).Infof("In Distribute for %#v", resource)
 
 	toDistribute, resourceClient, err := f.toUnstructured(resource)
 	if err != nil {
@@ -70,7 +70,7 @@ func (f *federator) Delete(resource runtime.Object) error {
 		return err
 	}
 
-	klog.V(log.DEBUG).Infof("Deleting resource: %#v", toDelete)
+	klog.V(log.LIBTRACE).Infof("Deleting resource: %#v", toDelete)
 
 	return resourceClient.Delete(toDelete.GetName(), &metav1.DeleteOptions{})
 }

--- a/pkg/util/create_or_update.go
+++ b/pkg/util/create_or_update.go
@@ -29,11 +29,11 @@ func CreateOrUpdate(client dynamic.ResourceInterface, obj *unstructured.Unstruct
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		existing, err := client.Get(obj.GetName(), metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
-			klog.V(log.DEBUG).Infof("Creating resource: %#v", obj)
+			klog.V(log.LIBTRACE).Infof("Creating resource: %#v", obj)
 
 			_, err := client.Create(obj, metav1.CreateOptions{})
 			if apierrors.IsAlreadyExists(err) {
-				klog.V(log.DEBUG).Infof("Resource %q already exists - retrying", obj.GetName())
+				klog.V(log.LIBDEBUG).Infof("Resource %q already exists - retrying", obj.GetName())
 				return apierrors.NewConflict(schema.GroupResource{Resource: obj.GetKind()}, obj.GetName(), err)
 			}
 
@@ -60,7 +60,7 @@ func CreateOrUpdate(client dynamic.ResourceInterface, obj *unstructured.Unstruct
 			return nil
 		}
 
-		klog.V(log.DEBUG).Infof("Updating resource: %#v", obj)
+		klog.V(log.LIBTRACE).Infof("Updating resource: %#v", obj)
 
 		result = OperationResultUpdated
 		_, err = client.Update(toUpdate, metav1.UpdateOptions{})

--- a/pkg/workqueue/queue.go
+++ b/pkg/workqueue/queue.go
@@ -49,7 +49,7 @@ func (q *queueType) Enqueue(obj interface{}) {
 		return
 	}
 
-	klog.V(log.TRACE).Infof("%s: enqueueing key %q for %T object", q.name, key, obj)
+	klog.V(log.LIBTRACE).Infof("%s: enqueueing key %q for %T object", q.name, key, obj)
 	q.AddRateLimited(key)
 }
 
@@ -85,7 +85,7 @@ func (q *queueType) processNextWorkItem(process ProcessFunc) bool {
 
 	if requeue {
 		q.AddRateLimited(key)
-		klog.V(log.DEBUG).Infof("%s: enqueued %q for retry - # of times re-queued: %d", q.name, key, q.NumRequeues(key))
+		klog.V(log.LIBDEBUG).Infof("%s: enqueued %q for retry - # of times re-queued: %d", q.name, key, q.NumRequeues(key))
 	} else {
 		q.Forget(key)
 	}


### PR DESCRIPTION
Some of the admiral syncer libraries are extra-verbose and while
they would be helpful in multiple situations during normal debugging
can produce a cumbersome amount of logs.

Two extra levels of logging have been created for admiral: LIBDEBUG
and LIBTRACE.

Also, some object dumping log entries have been moved into LIBTRACE too.

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>