### PR TITLE
Add CI badges to README

### DIFF
--- a/.markdownlinkcheck.json
+++ b/.markdownlinkcheck.json
@@ -4,6 +4,9 @@
       "pattern": "^https://github.com/\\S+/\\S+/(issues|pull)/[0-9]+"
     },
     {
+      "pattern": "^https://github.com/submariner-io/admiral/workflows/(.*)/badge.svg"
+    },
+    {
       "pattern": "^http://localhost:"
     }
   ]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
 # Admiral
 
+<!-- markdownlint-disable line-length -->
+[![End to End Tests](https://github.com/submariner-io/admiral/workflows/End%20to%20End%20Tests/badge.svg)](https://github.com/submariner-io/admiral/actions?query=workflow%3A%22End+to+End+Tests%22)
+[![Unit Tests](https://github.com/submariner-io/admiral/workflows/Unit%20Tests/badge.svg)](https://github.com/submariner-io/admiral/actions?query=workflow%3A%22Unit+Tests%22)
+[![Linting](https://github.com/submariner-io/admiral/workflows/Linting/badge.svg)](https://github.com/submariner-io/admiral/actions?query=workflow%3ALinting)
+[![Upgrade](https://github.com/submariner-io/admiral/workflows/Upgrade/badge.svg)](https://github.com/submariner-io/admiral/actions?query=workflow%3AUpgrade)
+[![Periodic](https://github.com/submariner-io/admiral/workflows/Periodic/badge.svg)](https://github.com/submariner-io/admiral/actions?query=workflow%3APeriodic)
+[![Flake Finder](https://github.com/submariner-io/admiral/workflows/Flake%20Finder/badge.svg)](https://github.com/submariner-io/admiral/actions?query=workflow%3A%22Flake+Finder%22)
+<!-- markdownlint-enable line-length -->
+
 Admiral provides a control plane and APIs for federating resources to submariner data planes running in multiple clusters.


### PR DESCRIPTION
Also ignore GH badges in MD link checks. Link linting sometimes incorrectly fails on GitHub CI badge URLs.