### PR TITLE
Add ShouldProcess function to ResourceSyncer

### DIFF
--- a/pkg/syncer/broker/syncer.go
+++ b/pkg/syncer/broker/syncer.go
@@ -58,6 +58,9 @@ type ResourceConfig struct {
 	// for more details.
 	LocalResourcesEquivalent syncer.ResourceEquivalenceFunc
 
+	// LocalShouldProcess function invoked to determine if a local resource should be processed.
+	LocalShouldProcess syncer.ShouldProcessFunc
+
 	// LocalWaitForCacheSync if true, waits for the local informer cache to sync on Start. Default is true.
 	LocalWaitForCacheSync *bool
 
@@ -180,6 +183,7 @@ func NewSyncer(config SyncerConfig) (*Syncer, error) {
 			Transform:           rc.LocalTransform,
 			OnSuccessfulSync:    rc.LocalOnSuccessfulSync,
 			ResourcesEquivalent: rc.LocalResourcesEquivalent,
+			ShouldProcess:       rc.LocalShouldProcess,
 			WaitForCacheSync:    rc.LocalWaitForCacheSync,
 			Scheme:              config.Scheme,
 			ResyncPeriod:        rc.LocalResyncPeriod,

--- a/pkg/watcher/resource_watcher.go
+++ b/pkg/watcher/resource_watcher.go
@@ -64,6 +64,9 @@ type ResourceConfig struct {
 	// By default all updates are processed.
 	ResourcesEquivalent syncer.ResourceEquivalenceFunc
 
+	// ShouldProcess function invoked to determine if a resource should be processed.
+	ShouldProcess syncer.ShouldProcessFunc
+
 	// SourceNamespace the namespace of the resources to watch.
 	SourceNamespace string
 
@@ -151,6 +154,7 @@ func New(config *Config) (Interface, error) {
 				return nil, false
 			},
 			ResourcesEquivalent: rc.ResourcesEquivalent,
+			ShouldProcess:       rc.ShouldProcess,
 			WaitForCacheSync:    config.WaitForCacheSync,
 			Scheme:              config.Scheme,
 			ResyncPeriod:        config.ResyncPeriod,

--- a/pkg/watcher/resource_watcher_test.go
+++ b/pkg/watcher/resource_watcher_test.go
@@ -21,6 +21,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/submariner-io/admiral/pkg/fake"
+	"github.com/submariner-io/admiral/pkg/syncer"
 	"github.com/submariner-io/admiral/pkg/syncer/test"
 	"github.com/submariner-io/admiral/pkg/util"
 	"github.com/submariner-io/admiral/pkg/watcher"
@@ -170,6 +171,21 @@ var _ = Describe("Resource Watcher", func() {
 				test.UpdateResource(pods, pod)
 
 				Consistently(updatedPods, 300*time.Millisecond).ShouldNot(Receive())
+			})
+		})
+	})
+
+	When("a ShouldProcess function is specified that returns false", func() {
+		BeforeEach(func() {
+			config.ResourceConfigs[0].ShouldProcess = func(obj *unstructured.Unstructured, op syncer.Operation) bool {
+				return false
+			}
+		})
+
+		When("a Pod is created", func() {
+			It("should not notify of the event", func() {
+				test.CreateResource(pods, pod)
+				Consistently(createdPods, 300*time.Millisecond).ShouldNot(Receive())
 			})
 		})
 	})


### PR DESCRIPTION
Allows the user to ignore resources so they're not even queued.
