### PR TITLE
Pin actions/checkout GHA to v2

### DIFF
--- a/.github/workflows/upgrade-e2e.yml
+++ b/.github/workflows/upgrade-e2e.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
 
       - name: Reclaim free space!
         run: |


### PR DESCRIPTION
To avoid breakages from changes to dependencies' master branches, we
should pin to (at least major) versions.

This also follows guidance from GitHub:

https://docs.github.com/en/actions/reference/
workflow-syntax-for-github-actions#jobsjob_idstepsuses

I raised an Issue asking for updated releases for the tim-actions/* GHAs
that still pin to master.

https://github.com/tim-actions/dco/issues/4

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>