### PR TITLE
Pin shipyard dapper image to release-0.8 & fix linters (backport)

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -51,6 +51,7 @@ jobs:
         with:
           config-file: ".markdownlinkcheck.json"
           check-modified-files-only: "yes"
+          base-branch: ${{ github.base_ref }}
 
   markdownlint:
     name: Markdown

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM quay.io/submariner/shipyard-dapper-base:0.8.0
+FROM quay.io/submariner/shipyard-dapper-base:release-0.8
 
 ENV DAPPER_ENV=REPO DAPPER_ENV=TAG \
     DAPPER_SOURCE=/go/src/github.com/submariner-io/admiral DAPPER_DOCKER_SOCKET=true


### PR DESCRIPTION
Updates the dapper image version

Includes the following backports:
* e122fb0 Use the PR base branch as reference when linting

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>
