### PR TITLE
Add dependabot ignore for submariner

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,4 @@ updates:
       - dependency-name: k8s.io/client-go
         versions:
           - "> 0.17.0"
+      - dependency-name: github.com/submariner-io/*


### PR DESCRIPTION
Updates to submariner dependencies is done via our release process.

