### PR TITLE
Create a metric gauge in broker.syncer and send it to resource syncer

### DIFF
--- a/pkg/syncer/broker/syncer.go
+++ b/pkg/syncer/broker/syncer.go
@@ -86,8 +86,8 @@ type ResourceConfig struct {
 	// Default is 0.
 	BrokerResyncPeriod time.Duration
 
-	// MetricOpts used to pass name and help text to resource syncer Gauge
-	MetricOpts *prometheus.GaugeOpts
+	// SyncCounterOpts used to pass name and help text to resource syncer Gauge
+	SyncCounterOpts *prometheus.GaugeOpts
 }
 
 type SyncerConfig struct {
@@ -174,9 +174,9 @@ func NewSyncer(config SyncerConfig) (*Syncer, error) {
 
 	for _, rc := range config.ResourceConfigs {
 		var syncCounter *prometheus.GaugeVec
-		if rc.MetricOpts != nil {
+		if rc.SyncCounterOpts != nil {
 			syncCounter = prometheus.NewGaugeVec(
-				*rc.MetricOpts,
+				*rc.SyncCounterOpts,
 				[]string{
 					syncer.DirectionLabel,
 					syncer.OperationLabel,
@@ -204,7 +204,7 @@ func NewSyncer(config SyncerConfig) (*Syncer, error) {
 			WaitForCacheSync:    rc.LocalWaitForCacheSync,
 			Scheme:              config.Scheme,
 			ResyncPeriod:        rc.LocalResyncPeriod,
-			MetricGauge:         syncCounter,
+			SyncCounter:         syncCounter,
 		})
 
 		if err != nil {
@@ -236,7 +236,7 @@ func NewSyncer(config SyncerConfig) (*Syncer, error) {
 			WaitForCacheSync:    waitForCacheSync,
 			Scheme:              config.Scheme,
 			ResyncPeriod:        rc.BrokerResyncPeriod,
-			MetricGauge:         syncCounter,
+			SyncCounter:         syncCounter,
 		})
 
 		if err != nil {

--- a/pkg/syncer/broker/syncer.go
+++ b/pkg/syncer/broker/syncer.go
@@ -204,7 +204,7 @@ func NewSyncer(config SyncerConfig) (*Syncer, error) {
 			WaitForCacheSync:    rc.LocalWaitForCacheSync,
 			Scheme:              config.Scheme,
 			ResyncPeriod:        rc.LocalResyncPeriod,
-			SyncCounter:         syncCounter,
+			MetricGauge:         syncCounter,
 		})
 
 		if err != nil {
@@ -236,7 +236,7 @@ func NewSyncer(config SyncerConfig) (*Syncer, error) {
 			WaitForCacheSync:    waitForCacheSync,
 			Scheme:              config.Scheme,
 			ResyncPeriod:        rc.BrokerResyncPeriod,
-			SyncCounter:         syncCounter,
+			MetricGauge:         syncCounter,
 		})
 
 		if err != nil {

--- a/pkg/syncer/broker/syncer.go
+++ b/pkg/syncer/broker/syncer.go
@@ -173,6 +173,19 @@ func NewSyncer(config SyncerConfig) (*Syncer, error) {
 	brokerSyncer.localFederator = NewFederator(config.LocalClient, config.RestMapper, config.LocalNamespace, "")
 
 	for _, rc := range config.ResourceConfigs {
+		var syncCounter *prometheus.GaugeVec
+		if rc.MetricOpts != nil {
+			syncCounter = prometheus.NewGaugeVec(
+				*rc.MetricOpts,
+				[]string{
+					syncer.DirectionLabel,
+					syncer.OperationLabel,
+					syncer.SyncerNameLabel,
+				},
+			)
+			prometheus.MustRegister(syncCounter)
+		}
+
 		localSyncer, err := syncer.NewResourceSyncer(&syncer.ResourceSyncerConfig{
 			Name:                fmt.Sprintf("local -> broker for %T", rc.LocalResourceType),
 			SourceClient:        config.LocalClient,
@@ -191,7 +204,7 @@ func NewSyncer(config SyncerConfig) (*Syncer, error) {
 			WaitForCacheSync:    rc.LocalWaitForCacheSync,
 			Scheme:              config.Scheme,
 			ResyncPeriod:        rc.LocalResyncPeriod,
-			MetricOpts:          rc.MetricOpts,
+			SyncCounter:         syncCounter,
 		})
 
 		if err != nil {
@@ -223,7 +236,7 @@ func NewSyncer(config SyncerConfig) (*Syncer, error) {
 			WaitForCacheSync:    waitForCacheSync,
 			Scheme:              config.Scheme,
 			ResyncPeriod:        rc.BrokerResyncPeriod,
-			MetricOpts:          rc.MetricOpts,
+			SyncCounter:         syncCounter,
 		})
 
 		if err != nil {

--- a/pkg/syncer/resource_syncer.go
+++ b/pkg/syncer/resource_syncer.go
@@ -156,13 +156,13 @@ type ResourceSyncerConfig struct {
 	// ResyncPeriod if non-zero, the period at which resources will be re-synced regardless if anything changed. Default is 0.
 	ResyncPeriod time.Duration
 
-	// MetricOpts if specified, used to create a gauge to record counter metrics.
-	// Alternatively the gauge can be created directly and passed via the MetricGauge field,
-	// in which case MetricOpts is ignored.
-	MetricOpts *prometheus.GaugeOpts
+	// SyncCounterOpts if specified, used to create a gauge to record counter metrics.
+	// Alternatively the gauge can be created directly and passed via the SyncCounter field,
+	// in which case SyncCounterOpts is ignored.
+	SyncCounterOpts *prometheus.GaugeOpts
 
-	// MetricGauge if specified, used to record counter metrics.
-	MetricGauge *prometheus.GaugeVec
+	// SyncCounter if specified, used to record counter metrics.
+	SyncCounter *prometheus.GaugeVec
 }
 
 type resourceSyncer struct {
@@ -200,11 +200,11 @@ func NewResourceSyncer(config *ResourceSyncerConfig) (Interface, error) {
 		return nil, err
 	}
 
-	if syncer.config.MetricGauge != nil {
-		syncer.syncCounter = syncer.config.MetricGauge
-	} else if syncer.config.MetricOpts != nil {
+	if syncer.config.SyncCounter != nil {
+		syncer.syncCounter = syncer.config.SyncCounter
+	} else if syncer.config.SyncCounterOpts != nil {
 		syncer.syncCounter = prometheus.NewGaugeVec(
-			*syncer.config.MetricOpts,
+			*syncer.config.SyncCounterOpts,
 			[]string{
 				DirectionLabel,
 				OperationLabel,


### PR DESCRIPTION
If a resource syncer is created from broker.syncer, create one gauge
on the broker and pass it to use in resource syncer

Related issue #136

Signed-off-by: Maayan Friedman <maafried@redhat.com>