### PR TITLE
Ensure proper ResourceVersion in CreateOrUpdate

### DIFF
--- a/pkg/util/create_or_update.go
+++ b/pkg/util/create_or_update.go
@@ -77,11 +77,14 @@ func CreateOrUpdate(client dynamic.ResourceInterface, obj *unstructured.Unstruct
 		}
 
 		copy := existing.DeepCopyObject()
+		resourceVersion := existing.GetResourceVersion()
 
 		toUpdate, err := mutate(existing)
 		if err != nil {
 			return err
 		}
+
+		toUpdate.SetResourceVersion(resourceVersion)
 
 		if equality.Semantic.DeepEqual(toUpdate, copy) {
 			return nil
@@ -129,4 +132,10 @@ func SetBackoff(b wait.Backoff) wait.Backoff {
 	backOff = b
 
 	return prev
+}
+
+func Replace(with *unstructured.Unstructured) MutateFn {
+	return func(existing *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+		return with, nil
+	}
 }

--- a/pkg/util/create_or_update_test.go
+++ b/pkg/util/create_or_update_test.go
@@ -51,6 +51,8 @@ var _ = Describe("", func() {
 			Resource: "pods",
 		}).Namespace("test").(*fake.DynamicResourceClient)
 
+		client.CheckResourceVersionOnUpdate = true
+
 		pod = test.NewPod("")
 
 		origBackoff = util.SetBackoff(wait.Backoff{
@@ -134,10 +136,9 @@ var _ = Describe("", func() {
 
 		BeforeEach(func() {
 			mutateFn = func(existing *unstructured.Unstructured) (*unstructured.Unstructured, error) {
-				newSpec, _, _ := unstructured.NestedFieldNoCopy(test.ToUnstructured(pod).Object, "spec")
-				_ = unstructured.SetNestedField(existing.Object, newSpec, "spec")
-
-				return existing, nil
+				obj := test.ToUnstructured(pod)
+				obj.SetUID(existing.GetUID())
+				return util.Replace(obj)(nil)
 			}
 		})
 

--- a/pkg/util/util_suite_test.go
+++ b/pkg/util/util_suite_test.go
@@ -20,7 +20,12 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"k8s.io/klog"
 )
+
+func init() {
+	klog.InitFlags(nil)
+}
 
 func TestUtil(t *testing.T) {
 	RegisterFailHandler(Fail)


### PR DESCRIPTION
For Update, the incoming `ResourceVersion` must match the existing one so ensure that in case the `MutateFn` returns an instance with a different version. This also enables the caller to pass a `MutateFn` that simply replaces the existing w/o having to specifically preserve the `ResourceVersion`.
