### PR TITLE
Modify CreateOrUpdate/CreateAnew to use new generic resource interface

### DIFF
--- a/pkg/resource/dynamic.go
+++ b/pkg/resource/dynamic.go
@@ -1,0 +1,56 @@
+/*
+© 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package resource
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic"
+)
+
+type dynamicType struct {
+	client dynamic.ResourceInterface
+}
+
+func (d *dynamicType) Get(name string, options metav1.GetOptions) (runtime.Object, error) {
+	return d.client.Get(name, options)
+}
+
+func (d *dynamicType) Create(obj runtime.Object) (runtime.Object, error) {
+	raw, err := ToUnstructured(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	return d.client.Create(raw, metav1.CreateOptions{})
+}
+
+func (d *dynamicType) Update(obj runtime.Object) (runtime.Object, error) {
+	raw, err := ToUnstructured(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	return d.client.Update(raw, metav1.UpdateOptions{})
+}
+
+func (d *dynamicType) Delete(name string, options *metav1.DeleteOptions) error {
+	return d.client.Delete(name, options)
+}
+
+func ForDynamic(client dynamic.ResourceInterface) Interface {
+	return &dynamicType{client: client}
+}

--- a/pkg/resource/interface.go
+++ b/pkg/resource/interface.go
@@ -1,0 +1,51 @@
+/*
+© 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package resource
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type Interface interface {
+	Get(name string, options metav1.GetOptions) (runtime.Object, error)
+	Create(obj runtime.Object) (runtime.Object, error)
+	Update(obj runtime.Object) (runtime.Object, error)
+	Delete(name string, options *metav1.DeleteOptions) error
+}
+
+type InterfaceFuncs struct {
+	GetFunc    func(name string, options metav1.GetOptions) (runtime.Object, error)
+	CreateFunc func(obj runtime.Object) (runtime.Object, error)
+	UpdateFunc func(obj runtime.Object) (runtime.Object, error)
+	DeleteFunc func(name string, options *metav1.DeleteOptions) error
+}
+
+func (i *InterfaceFuncs) Get(name string, options metav1.GetOptions) (runtime.Object, error) {
+	return i.GetFunc(name, options)
+}
+
+func (i *InterfaceFuncs) Create(obj runtime.Object) (runtime.Object, error) {
+	return i.CreateFunc(obj)
+}
+
+func (i *InterfaceFuncs) Update(obj runtime.Object) (runtime.Object, error) {
+	return i.UpdateFunc(obj)
+}
+
+func (i *InterfaceFuncs) Delete(name string, options *metav1.DeleteOptions) error {
+	return i.DeleteFunc(name, options)
+}

--- a/pkg/resource/kubernetes.go
+++ b/pkg/resource/kubernetes.go
@@ -1,0 +1,169 @@
+/*
+© 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package resource
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+)
+
+//nolint:dupl //false positive - lines are similar but not duplicated
+func ForDeployment(client kubernetes.Interface, namespace string) Interface {
+	return &InterfaceFuncs{
+		GetFunc: func(name string, options metav1.GetOptions) (runtime.Object, error) {
+			return client.AppsV1().Deployments(namespace).Get(name, options)
+		},
+		CreateFunc: func(obj runtime.Object) (runtime.Object, error) {
+			return client.AppsV1().Deployments(namespace).Create(obj.(*appsv1.Deployment))
+		},
+		UpdateFunc: func(obj runtime.Object) (runtime.Object, error) {
+			return client.AppsV1().Deployments(namespace).Update(obj.(*appsv1.Deployment))
+		},
+		DeleteFunc: func(name string, options *metav1.DeleteOptions) error {
+			return client.AppsV1().Deployments(namespace).Delete(name, options)
+		},
+	}
+}
+
+//nolint:dupl //false positive - lines are similar but not duplicated
+func ForDaemonSet(client kubernetes.Interface, namespace string) Interface {
+	return &InterfaceFuncs{
+		GetFunc: func(name string, options metav1.GetOptions) (runtime.Object, error) {
+			return client.AppsV1().DaemonSets(namespace).Get(name, options)
+		},
+		CreateFunc: func(obj runtime.Object) (runtime.Object, error) {
+			return client.AppsV1().DaemonSets(namespace).Create(obj.(*appsv1.DaemonSet))
+		},
+		UpdateFunc: func(obj runtime.Object) (runtime.Object, error) {
+			return client.AppsV1().DaemonSets(namespace).Update(obj.(*appsv1.DaemonSet))
+		},
+		DeleteFunc: func(name string, options *metav1.DeleteOptions) error {
+			return client.AppsV1().DaemonSets(namespace).Delete(name, options)
+		},
+	}
+}
+
+//nolint:dupl //false positive - lines are similar but not duplicated
+func ForPod(client kubernetes.Interface, namespace string) Interface {
+	return &InterfaceFuncs{
+		GetFunc: func(name string, options metav1.GetOptions) (runtime.Object, error) {
+			return client.CoreV1().Pods(namespace).Get(name, options)
+		},
+		CreateFunc: func(obj runtime.Object) (runtime.Object, error) {
+			return client.CoreV1().Pods(namespace).Create(obj.(*corev1.Pod))
+		},
+		UpdateFunc: func(obj runtime.Object) (runtime.Object, error) {
+			return client.CoreV1().Pods(namespace).Update(obj.(*corev1.Pod))
+		},
+		DeleteFunc: func(name string, options *metav1.DeleteOptions) error {
+			return client.CoreV1().Pods(namespace).Delete(name, options)
+		},
+	}
+}
+
+//nolint:dupl //false positive - lines are similar but not duplicated
+func ForRole(client kubernetes.Interface, namespace string) Interface {
+	return &InterfaceFuncs{
+		GetFunc: func(name string, options metav1.GetOptions) (runtime.Object, error) {
+			return client.RbacV1().Roles(namespace).Get(name, options)
+		},
+		CreateFunc: func(obj runtime.Object) (runtime.Object, error) {
+			return client.RbacV1().Roles(namespace).Create(obj.(*rbacv1.Role))
+		},
+		UpdateFunc: func(obj runtime.Object) (runtime.Object, error) {
+			return client.RbacV1().Roles(namespace).Update(obj.(*rbacv1.Role))
+		},
+		DeleteFunc: func(name string, options *metav1.DeleteOptions) error {
+			return client.RbacV1().Roles(namespace).Delete(name, options)
+		},
+	}
+}
+
+//nolint:dupl //false positive - lines are similar but not duplicated
+func ForRoleBinding(client kubernetes.Interface, namespace string) Interface {
+	return &InterfaceFuncs{
+		GetFunc: func(name string, options metav1.GetOptions) (runtime.Object, error) {
+			return client.RbacV1().RoleBindings(namespace).Get(name, options)
+		},
+		CreateFunc: func(obj runtime.Object) (runtime.Object, error) {
+			return client.RbacV1().RoleBindings(namespace).Create(obj.(*rbacv1.RoleBinding))
+		},
+		UpdateFunc: func(obj runtime.Object) (runtime.Object, error) {
+			return client.RbacV1().RoleBindings(namespace).Update(obj.(*rbacv1.RoleBinding))
+		},
+		DeleteFunc: func(name string, options *metav1.DeleteOptions) error {
+			return client.RbacV1().RoleBindings(namespace).Delete(name, options)
+		},
+	}
+}
+
+//nolint:dupl //false positive - lines are similar but not duplicated
+func ForClusterRole(client kubernetes.Interface) Interface {
+	return &InterfaceFuncs{
+		GetFunc: func(name string, options metav1.GetOptions) (runtime.Object, error) {
+			return client.RbacV1().ClusterRoles().Get(name, options)
+		},
+		CreateFunc: func(obj runtime.Object) (runtime.Object, error) {
+			return client.RbacV1().ClusterRoles().Create(obj.(*rbacv1.ClusterRole))
+		},
+		UpdateFunc: func(obj runtime.Object) (runtime.Object, error) {
+			return client.RbacV1().ClusterRoles().Update(obj.(*rbacv1.ClusterRole))
+		},
+		DeleteFunc: func(name string, options *metav1.DeleteOptions) error {
+			return client.RbacV1().ClusterRoles().Delete(name, options)
+		},
+	}
+}
+
+//nolint:dupl //false positive - lines are similar but not duplicated
+func ForClusterRoleBinding(client kubernetes.Interface) Interface {
+	return &InterfaceFuncs{
+		GetFunc: func(name string, options metav1.GetOptions) (runtime.Object, error) {
+			return client.RbacV1().ClusterRoleBindings().Get(name, options)
+		},
+		CreateFunc: func(obj runtime.Object) (runtime.Object, error) {
+			return client.RbacV1().ClusterRoleBindings().Create(obj.(*rbacv1.ClusterRoleBinding))
+		},
+		UpdateFunc: func(obj runtime.Object) (runtime.Object, error) {
+			return client.RbacV1().ClusterRoleBindings().Update(obj.(*rbacv1.ClusterRoleBinding))
+		},
+		DeleteFunc: func(name string, options *metav1.DeleteOptions) error {
+			return client.RbacV1().ClusterRoleBindings().Delete(name, options)
+		},
+	}
+}
+
+//nolint:dupl //false positive - lines are similar but not duplicated
+func ForServiceAccount(client kubernetes.Interface, namespace string) Interface {
+	return &InterfaceFuncs{
+		GetFunc: func(name string, options metav1.GetOptions) (runtime.Object, error) {
+			return client.CoreV1().ServiceAccounts(namespace).Get(name, options)
+		},
+		CreateFunc: func(obj runtime.Object) (runtime.Object, error) {
+			return client.CoreV1().ServiceAccounts(namespace).Create(obj.(*corev1.ServiceAccount))
+		},
+		UpdateFunc: func(obj runtime.Object) (runtime.Object, error) {
+			return client.CoreV1().ServiceAccounts(namespace).Update(obj.(*corev1.ServiceAccount))
+		},
+		DeleteFunc: func(name string, options *metav1.DeleteOptions) error {
+			return client.CoreV1().ServiceAccounts(namespace).Delete(name, options)
+		},
+	}
+}

--- a/pkg/resource/util.go
+++ b/pkg/resource/util.go
@@ -1,0 +1,49 @@
+/*
+© 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package resource
+
+import (
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+func ToUnstructured(from runtime.Object) (*unstructured.Unstructured, error) {
+	switch f := from.(type) {
+	case *unstructured.Unstructured:
+		return f.DeepCopy(), nil
+	default:
+		to := &unstructured.Unstructured{}
+		err := scheme.Scheme.Convert(from, to, nil)
+		if err != nil {
+			return nil, errors.WithMessagef(err, "error converting %#v to unstructured.Unstructured", from)
+		}
+
+		return to, nil
+	}
+}
+
+func ToMeta(obj runtime.Object) metav1.Object {
+	objMeta, err := meta.Accessor(obj)
+	if err != nil {
+		panic(err)
+	}
+
+	return objMeta
+}

--- a/pkg/syncer/resource_syncer.go
+++ b/pkg/syncer/resource_syncer.go
@@ -24,6 +24,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/submariner-io/admiral/pkg/federate"
 	"github.com/submariner-io/admiral/pkg/log"
+	resourceUtil "github.com/submariner-io/admiral/pkg/resource"
 	"github.com/submariner-io/admiral/pkg/util"
 	"github.com/submariner-io/admiral/pkg/workqueue"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -440,7 +441,7 @@ func (r *resourceSyncer) transform(from *unstructured.Unstructured, key string,
 		return nil, nil, requeue
 	}
 
-	result, err := util.ToUnstructured(transformed)
+	result, err := resourceUtil.ToUnstructured(transformed)
 	if err != nil {
 		klog.Errorf("Syncer %q: error converting transform function result: %v", r.config.Name, err)
 		return nil, nil, false

--- a/pkg/syncer/test/util.go
+++ b/pkg/syncer/test/util.go
@@ -20,7 +20,7 @@ import (
 
 	. "github.com/onsi/gomega"
 	"github.com/submariner-io/admiral/pkg/federate"
-	"github.com/submariner-io/admiral/pkg/util"
+	resourceUtil "github.com/submariner-io/admiral/pkg/resource"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metaapi "k8s.io/apimachinery/pkg/api/meta"
@@ -194,7 +194,7 @@ func PrepInitialClientObjs(namespace, clusterID string, initObjs ...runtime.Obje
 }
 
 func ToUnstructured(obj runtime.Object) *unstructured.Unstructured {
-	raw, err := util.ToUnstructured(obj)
+	raw, err := resourceUtil.ToUnstructured(obj)
 	Expect(err).To(Succeed())
 
 	return raw

--- a/pkg/util/helpers.go
+++ b/pkg/util/helpers.go
@@ -19,12 +19,12 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
+	resourceUtil "github.com/submariner-io/admiral/pkg/resource"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
 	"k8s.io/klog"
@@ -51,7 +51,7 @@ func BuildRestMapper(restConfig *rest.Config) (meta.RESTMapper, error) {
 
 func ToUnstructuredResource(from runtime.Object, restMapper meta.RESTMapper) (*unstructured.Unstructured, *schema.GroupVersionResource,
 	error) {
-	to, err := ToUnstructured(from)
+	to, err := resourceUtil.ToUnstructured(from)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -62,21 +62,6 @@ func ToUnstructuredResource(from runtime.Object, restMapper meta.RESTMapper) (*u
 	}
 
 	return to, gvr, nil
-}
-
-func ToUnstructured(from runtime.Object) (*unstructured.Unstructured, error) {
-	switch f := from.(type) {
-	case *unstructured.Unstructured:
-		return f.DeepCopy(), nil
-	default:
-		to := &unstructured.Unstructured{}
-		err := scheme.Scheme.Convert(from, to, nil)
-		if err != nil {
-			return nil, errors.WithMessagef(err, "error converting %#v to unstructured.Unstructured", from)
-		}
-
-		return to, nil
-	}
 }
 
 func FindGroupVersionResource(from *unstructured.Unstructured, restMapper meta.RESTMapper) (*schema.GroupVersionResource, error) {


### PR DESCRIPTION
Added a generic CRUD interface that references `runtime.Object `which all generated types and `Unstructured` implement. Added implementations backed by the dynamic `ResourceInterface` and for some common k8s core V1 resource types.

This enables `CreateOrUpdate` and `CreateAnew` to work with any resource type/API.
