### PR TITLE
 Add staticcheck initialisms

### DIFF
--- a/staticcheck.conf
+++ b/staticcheck.conf
@@ -1,0 +1,1 @@
+initialisms = ["inherit", "CNI", "IPAM", "IPSec", "NAT", "NATT"]


### PR DESCRIPTION
Add below initialisations in addition to the defaults

CNI
IPAM
IPSec
NAT
NATT

The defaults come from https://staticcheck.io/docs/#configuration

Signed-off-by: Janki Chhatbar jchhatba@redhat.com