### PR TITLE
Reconcile existing resources in broker syncer

### DIFF
--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -25,4 +25,6 @@ type Interface interface {
 	GetResource(name, namespace string) (runtime.Object, bool, error)
 
 	ListResources() ([]runtime.Object, error)
+
+	Reconcile(resourceLister func() []runtime.Object)
 }


### PR DESCRIPTION
Added a `Reconcile` method to the resource syncer that takes a list of resources and, if a resource does not exist in the source Store cache, it is enqueued for deletion.

The broker syncer uses this method for reconciling in both sync directions. For `RemoteToLocal`, it lists the local resources obtained from the `LocalToRemote` syncer cache. It passes the list to the `Reconcile` method on the `RemoteToLocal` syncer which only checks for remote resources, ie those with a cluster ID label set. Similarly, for `LocalToRemote`, it lists the remote resources obtained from the `RemoteToLocal` syncer cache and checks for synced local resources.

There's special consideration if the source namespace is `NamespaceAll` for reconciling `LocalToRemote`. In this case, it needs to know the namespace of the originating local resource. To handle this, when syncing, it adds a label to store the originating namespace.

Fixes #85 
Related to submariner-io/submariner#1244

**Note**: this is initially a draft b/c I want to test it with _submariner_ and _lighthouse_  but I welcome reviews in the meantime.