### PR TITLE
golangci-lint: switch to fieldalignment

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,10 +12,11 @@ linters-settings:
     min-complexity: 15
   golint:
     min-confidence: 0
+  govet:
+    enable:
+      - fieldalignment
   lll:
     line-length: 140
-  maligned:
-    suggest-new: true
 linters:
   disable-all: true
   enable:
@@ -41,7 +42,6 @@ linters:
     - interfacer
     - lll
     - misspell
-    - maligned
     - nakedret
     - prealloc
     - staticcheck
@@ -81,3 +81,9 @@ issues:
         - golint
       text: "should not use dot imports"
       source: ". \"github.com/onsi/ginkgo\""
+
+    # Ignore pointer bytes in struct alignment tests (this is a very
+    # minor optimisation)
+    - linters:
+        - govet
+      text: "pointer bytes could be"


### PR DESCRIPTION
fieldalignment replaces maligned. Errors related to pointer ordering
(for GC) are ignored; see https://github.com/golang/go/issues/44877
for details.

Signed-off-by: Stephen Kitt <skitt@redhat.com>