### PR TITLE
Add CII badge, remove PR-triggered badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,7 @@
 # Admiral
 
 <!-- markdownlint-disable line-length -->
-[![End to End Tests](https://github.com/submariner-io/admiral/workflows/End%20to%20End%20Tests/badge.svg)](https://github.com/submariner-io/admiral/actions?query=workflow%3A%22End+to+End+Tests%22)
-[![Unit Tests](https://github.com/submariner-io/admiral/workflows/Unit%20Tests/badge.svg)](https://github.com/submariner-io/admiral/actions?query=workflow%3A%22Unit+Tests%22)
-[![Linting](https://github.com/submariner-io/admiral/workflows/Linting/badge.svg)](https://github.com/submariner-io/admiral/actions?query=workflow%3ALinting)
-[![Upgrade](https://github.com/submariner-io/admiral/workflows/Upgrade/badge.svg)](https://github.com/submariner-io/admiral/actions?query=workflow%3AUpgrade)
+[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/4865/badge)](https://bestpractices.coreinfrastructure.org/projects/4865)
 [![Periodic](https://github.com/submariner-io/admiral/workflows/Periodic/badge.svg)](https://github.com/submariner-io/admiral/actions?query=workflow%3APeriodic)
 [![Flake Finder](https://github.com/submariner-io/admiral/workflows/Flake%20Finder/badge.svg)](https://github.com/submariner-io/admiral/actions?query=workflow%3A%22Flake+Finder%22)
 <!-- markdownlint-enable line-length -->


### PR DESCRIPTION
Add Submariner's CII Best Practices badge to the README.

Remove badges for workflows triggered by PRs, as their status reflects
tests against proposed/WIP code, not merged code. This causes false red
flags, reducing the utility of the badges overall. Leave badges for
workflows run against merged code.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>