### PR TITLE
Revert "Remove Dockerfile.dapper"

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,0 +1,11 @@
+ARG BASE_BRANCH
+FROM quay.io/submariner/shipyard-dapper-base:${BASE_BRANCH}
+
+ENV DAPPER_ENV="MAKEFLAGS REPO TAG" \
+    DAPPER_SOURCE=/go/src/github.com/submariner-io/admiral DAPPER_DOCKER_SOCKET=true
+ENV DAPPER_OUTPUT=${DAPPER_SOURCE}/output
+
+WORKDIR ${DAPPER_SOURCE}
+
+ENTRYPOINT ["/opt/shipyard/scripts/entry"]
+CMD ["ci"]


### PR DESCRIPTION
This reverts commit 5d1dd96042acd00d3d11450a48633ac295d777b7.

Removing Dockerfile.dapper breaks consuming tests in Shipyard; see
<https://github.com/submariner-io/shipyard/pull/566/checks?check_run_id=2728806310> for an example.

We need to be able to override the tag used for the base Shipyard
image.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
