### PR TITLE
Remove ctx parameter from For... functions

### DIFF
--- a/pkg/resource/kubernetes.go
+++ b/pkg/resource/kubernetes.go
@@ -89,7 +89,7 @@ func ForPod(client kubernetes.Interface, namespace string) Interface {
 }
 
 //nolint:dupl //false positive - lines are similar but not duplicated
-func ForService(ctx context.Context, client kubernetes.Interface, namespace string) Interface {
+func ForService(client kubernetes.Interface, namespace string) Interface {
 	return &InterfaceFuncs{
 		GetFunc: func(ctx context.Context, name string, options metav1.GetOptions) (runtime.Object, error) {
 			return client.CoreV1().Services(namespace).Get(ctx, name, options)
@@ -107,7 +107,7 @@ func ForService(ctx context.Context, client kubernetes.Interface, namespace stri
 }
 
 //nolint:dupl //false positive - lines are similar but not duplicated
-func ForServiceAccount(ctx context.Context, client kubernetes.Interface, namespace string) Interface {
+func ForServiceAccount(client kubernetes.Interface, namespace string) Interface {
 	return &InterfaceFuncs{
 		GetFunc: func(ctx context.Context, name string, options metav1.GetOptions) (runtime.Object, error) {
 			return client.CoreV1().ServiceAccounts(namespace).Get(ctx, name, options)
@@ -181,7 +181,7 @@ func ForRole(client kubernetes.Interface, namespace string) Interface {
 }
 
 //nolint:dupl //false positive - lines are similar but not duplicated
-func ForRoleBinding(ctx context.Context, client kubernetes.Interface, namespace string) Interface {
+func ForRoleBinding(client kubernetes.Interface, namespace string) Interface {
 	return &InterfaceFuncs{
 		GetFunc: func(ctx context.Context, name string, options metav1.GetOptions) (runtime.Object, error) {
 			return client.RbacV1().RoleBindings(namespace).Get(ctx, name, options)


### PR DESCRIPTION
It is never needed, the context is provided as an argument to the
various interface functions.

This is a breaking change for downstreams.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
