### PR TITLE
Remove redundant type specification

### DIFF
--- a/pkg/util/create_or_update.go
+++ b/pkg/util/create_or_update.go
@@ -62,7 +62,7 @@ func Update(ctx context.Context, client resource.Interface, obj runtime.Object, 
 
 func maybeCreateOrUpdate(ctx context.Context, client resource.Interface, obj runtime.Object, mutate MutateFn,
 	doCreate bool) (OperationResult, error) {
-	var result OperationResult = OperationResultNone
+	result := OperationResultNone
 
 	objMeta := resource.ToMeta(obj)
 


### PR DESCRIPTION
Go can infer the type here:

	var result OperationResult = OperationResultNone

Use a short-hand declaration instead.

This is flagged by gocritic in golangci-lint 1.41.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
