### PR TITLE
Provide package descriptions

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -76,6 +76,15 @@ jobs:
       - name: Run markdownlint
         run: make markdownlint
 
+  packagedoc-lint:
+    name: Package Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v2
+      - name: Run packagedoc-lint
+        run: make packagedoc-lint
+
   yaml-lint:
     name: YAML
     runs-on: ubuntu-latest

--- a/pkg/fake/delete_colection_reactor.go
+++ b/pkg/fake/delete_colection_reactor.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package fake
 
 import (

--- a/pkg/fake/doc.go
+++ b/pkg/fake/doc.go
@@ -16,27 +16,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package broker
-
-import (
-	"github.com/kelseyhightower/envconfig"
-)
-
-type brokerSpecification struct {
-	APIServer       string
-	APIServerToken  string
-	RemoteNamespace string
-	Insecure        bool `default:"false"`
-	Ca              string
-}
-
-func getBrokerSpecification() (*brokerSpecification, error) {
-	brokerSpec := brokerSpecification{}
-
-	err := envconfig.Process("broker_k8s", &brokerSpec)
-	if err != nil {
-		return nil, err
-	}
-
-	return &brokerSpec, nil
-}
+// Package fake provides fake dynamic clients and reactors for testing purposes.
+package fake

--- a/pkg/fake/dynamic_client.go
+++ b/pkg/fake/dynamic_client.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package fake
 
 import (

--- a/pkg/fake/failing_reactor.go
+++ b/pkg/fake/failing_reactor.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package fake
 
 import (

--- a/pkg/fake/watch_reactor.go
+++ b/pkg/fake/watch_reactor.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package fake
 
 import (

--- a/pkg/federate/base_federator.go
+++ b/pkg/federate/base_federator.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package federate
 
 import (

--- a/pkg/federate/cluster_informer.go
+++ b/pkg/federate/cluster_informer.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package federate
 
 import (

--- a/pkg/federate/create_federator.go
+++ b/pkg/federate/create_federator.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package federate
 
 import (

--- a/pkg/federate/create_or_update_federator.go
+++ b/pkg/federate/create_or_update_federator.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package federate
 
 import (

--- a/pkg/federate/doc.go
+++ b/pkg/federate/doc.go
@@ -16,27 +16,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package broker
-
-import (
-	"github.com/kelseyhightower/envconfig"
-)
-
-type brokerSpecification struct {
-	APIServer       string
-	APIServerToken  string
-	RemoteNamespace string
-	Insecure        bool `default:"false"`
-	Ca              string
-}
-
-func getBrokerSpecification() (*brokerSpecification, error) {
-	brokerSpec := brokerSpecification{}
-
-	err := envconfig.Process("broker_k8s", &brokerSpec)
-	if err != nil {
-		return nil, err
-	}
-
-	return &brokerSpec, nil
-}
+// Package federate provides an interface that abstracts the distribution
+// of Kubernetes resources.
+package federate

--- a/pkg/federate/fake/federator.go
+++ b/pkg/federate/fake/federator.go
@@ -15,6 +15,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+// Package fake provides a fake Federator for use in tests.
 package fake
 
 import (

--- a/pkg/federate/federator.go
+++ b/pkg/federate/federator.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package federate
 
 import (

--- a/pkg/federate/update_federator.go
+++ b/pkg/federate/update_federator.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package federate
 
 import (

--- a/pkg/gomega/matchers.go
+++ b/pkg/gomega/matchers.go
@@ -15,6 +15,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+// Package gomega provides Gomega matchers used in our tests.
 package gomega
 
 import (

--- a/pkg/log/loglevels.go
+++ b/pkg/log/loglevels.go
@@ -15,10 +15,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package log
 
-// Log levels defined for use with:
-//   klog.V(__).Info
+// Package log defines log levels for use with klog.V(...).Info
+package log
 
 const (
 	// INFO : This level is for anything which does not happen very often, and while

--- a/pkg/resource/doc.go
+++ b/pkg/resource/doc.go
@@ -16,27 +16,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package broker
-
-import (
-	"github.com/kelseyhightower/envconfig"
-)
-
-type brokerSpecification struct {
-	APIServer       string
-	APIServerToken  string
-	RemoteNamespace string
-	Insecure        bool `default:"false"`
-	Ca              string
-}
-
-func getBrokerSpecification() (*brokerSpecification, error) {
-	brokerSpec := brokerSpecification{}
-
-	err := envconfig.Process("broker_k8s", &brokerSpec)
-	if err != nil {
-		return nil, err
-	}
-
-	return &brokerSpec, nil
-}
+// Package resource provides a general CRUD interface for Kubernetes resources.
+package resource

--- a/pkg/resource/dynamic.go
+++ b/pkg/resource/dynamic.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package resource
 
 import (

--- a/pkg/resource/interface.go
+++ b/pkg/resource/interface.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package resource
 
 import (

--- a/pkg/resource/kubernetes.go
+++ b/pkg/resource/kubernetes.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package resource
 
 import (

--- a/pkg/resource/rest.go
+++ b/pkg/resource/rest.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package resource
 
 import (

--- a/pkg/resource/util.go
+++ b/pkg/resource/util.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package resource
 
 import (

--- a/pkg/stringset/stringset.go
+++ b/pkg/stringset/stringset.go
@@ -15,6 +15,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+// Package stringset provides a type storing sets of strings.
 package stringset
 
 import (

--- a/pkg/syncer/broker/doc.go
+++ b/pkg/syncer/broker/doc.go
@@ -16,27 +16,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package broker provides bi-directional synchronization of resources
+// between a local source and a central broker.
 package broker
-
-import (
-	"github.com/kelseyhightower/envconfig"
-)
-
-type brokerSpecification struct {
-	APIServer       string
-	APIServerToken  string
-	RemoteNamespace string
-	Insecure        bool `default:"false"`
-	Ca              string
-}
-
-func getBrokerSpecification() (*brokerSpecification, error) {
-	brokerSpec := brokerSpecification{}
-
-	err := envconfig.Process("broker_k8s", &brokerSpec)
-	if err != nil {
-		return nil, err
-	}
-
-	return &brokerSpec, nil
-}

--- a/pkg/syncer/broker/federator.go
+++ b/pkg/syncer/broker/federator.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package broker
 
 import (

--- a/pkg/syncer/broker/syncer.go
+++ b/pkg/syncer/broker/syncer.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package broker
 
 import (

--- a/pkg/syncer/doc.go
+++ b/pkg/syncer/doc.go
@@ -16,27 +16,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package broker
-
-import (
-	"github.com/kelseyhightower/envconfig"
-)
-
-type brokerSpecification struct {
-	APIServer       string
-	APIServerToken  string
-	RemoteNamespace string
-	Insecure        bool `default:"false"`
-	Ca              string
-}
-
-func getBrokerSpecification() (*brokerSpecification, error) {
-	brokerSpec := brokerSpecification{}
-
-	err := envconfig.Process("broker_k8s", &brokerSpec)
-	if err != nil {
-		return nil, err
-	}
-
-	return &brokerSpec, nil
-}
+// Package syncer provides synchronization tools for resources in multiple stores.
+package syncer

--- a/pkg/syncer/equivalence_funcs.go
+++ b/pkg/syncer/equivalence_funcs.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package syncer
 
 import (

--- a/pkg/syncer/resource_syncer.go
+++ b/pkg/syncer/resource_syncer.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package syncer
 
 import (

--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package syncer
 
 import "k8s.io/apimachinery/pkg/runtime"

--- a/pkg/syncer/test/util.go
+++ b/pkg/syncer/test/util.go
@@ -15,6 +15,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+// Package test provides test utilities for the Syncer.
 package test
 
 import (

--- a/pkg/util/condition.go
+++ b/pkg/util/condition.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package util
 
 import (

--- a/pkg/util/create_or_update.go
+++ b/pkg/util/create_or_update.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package util
 
 import (

--- a/pkg/util/doc.go
+++ b/pkg/util/doc.go
@@ -16,27 +16,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package broker
-
-import (
-	"github.com/kelseyhightower/envconfig"
-)
-
-type brokerSpecification struct {
-	APIServer       string
-	APIServerToken  string
-	RemoteNamespace string
-	Insecure        bool `default:"false"`
-	Ca              string
-}
-
-func getBrokerSpecification() (*brokerSpecification, error) {
-	brokerSpec := brokerSpecification{}
-
-	err := envconfig.Process("broker_k8s", &brokerSpec)
-	if err != nil {
-		return nil, err
-	}
-
-	return &brokerSpec, nil
-}
+// Package util provides various utility functions for Kubernetes resources.
+package util

--- a/pkg/util/helpers.go
+++ b/pkg/util/helpers.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package util
 
 import (

--- a/pkg/watcher/resource_watcher.go
+++ b/pkg/watcher/resource_watcher.go
@@ -15,6 +15,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+// Package watcher provides an interface that allows clients to watch for
+// change events on Kubernetes resources.
 package watcher
 
 import (

--- a/pkg/workqueue/queue.go
+++ b/pkg/workqueue/queue.go
@@ -15,6 +15,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+// Package workqueue provides a simplified wrapper interface for Kubernetes workqueues.
 package workqueue
 
 import (

--- a/test/apis/admiral.submariner.io/v1/doc.go
+++ b/test/apis/admiral.submariner.io/v1/doc.go
@@ -18,4 +18,5 @@ limitations under the License.
 // +k8s:deepcopy-gen=package,register
 
 // +groupName=admiral.submariner.io
+
 package v1

--- a/test/apis/admiral.submariner.io/v1/register.go
+++ b/test/apis/admiral.submariner.io/v1/register.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package v1
 
 import (

--- a/test/apis/admiral.submariner.io/v1/types.go
+++ b/test/apis/admiral.submariner.io/v1/types.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package v1
 
 import (

--- a/test/e2e/syncer/broker.go
+++ b/test/e2e/syncer/broker.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package syncer
 
 import (

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package util
 
 import (

--- a/test/e2e/watcher/watcher.go
+++ b/test/e2e/watcher/watcher.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package syncer
 
 import (


### PR DESCRIPTION
Currently, our package descriptions are our license headers, because
the header blocks aren’t separated from the package declarations.
This patch separates them, and adds short package descriptions.

Depends on https://github.com/submariner-io/shipyard/pull/598
Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
