### PR TITLE
Enable performance linting, fix issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,7 +4,7 @@ linters-settings:
     enabled-tags:
       - diagnostic
       - opinionated
-      # - performance
+      - performance
       - style
     disabled-checks:
       - unlambda

--- a/pkg/fake/dynamic_client.go
+++ b/pkg/fake/dynamic_client.go
@@ -184,7 +184,9 @@ func (f *DynamicResourceClient) Update(ctx context.Context, obj *unstructured.Un
 	return f.ResourceInterface.Update(ctx, obj, options, subresources...)
 }
 
-func (f *DynamicResourceClient) Delete(ctx context.Context, name string, options v1.DeleteOptions, subresources ...string) error {
+func (f *DynamicResourceClient) Delete(ctx context.Context, name string,
+	options v1.DeleteOptions, // nolint:gocritic // Match K8s API
+	subresources ...string) error {
 	f.deleted <- name
 
 	fail := f.FailOnDelete

--- a/pkg/resource/dynamic.go
+++ b/pkg/resource/dynamic.go
@@ -52,7 +52,8 @@ func (d *dynamicType) Update(ctx context.Context, obj runtime.Object, options me
 	return d.client.Update(ctx, raw, options)
 }
 
-func (d *dynamicType) Delete(ctx context.Context, name string, options metav1.DeleteOptions) error {
+func (d *dynamicType) Delete(ctx context.Context, name string,
+	options metav1.DeleteOptions) error { // nolint:gocritic // Match K8s API
 	return d.client.Delete(ctx, name, options)
 }
 

--- a/pkg/resource/interface.go
+++ b/pkg/resource/interface.go
@@ -51,6 +51,7 @@ func (i *InterfaceFuncs) Update(ctx context.Context, obj runtime.Object, options
 	return i.UpdateFunc(ctx, obj, options)
 }
 
-func (i *InterfaceFuncs) Delete(ctx context.Context, name string, options metav1.DeleteOptions) error {
+func (i *InterfaceFuncs) Delete(ctx context.Context, name string,
+	options metav1.DeleteOptions) error { // nolint:gocritic // Match K8s API
 	return i.DeleteFunc(ctx, name, options)
 }

--- a/pkg/resource/rest.go
+++ b/pkg/resource/rest.go
@@ -33,7 +33,7 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-func GetAuthorizedRestConfig(apiServer, apiServerToken, caData string, tls rest.TLSClientConfig,
+func GetAuthorizedRestConfig(apiServer, apiServerToken, caData string, tls *rest.TLSClientConfig,
 	gvr schema.GroupVersionResource, namespace string) (restConfig *rest.Config, authorized bool, err error) {
 	// First try a REST config without the CA trust chain
 	restConfig, err = BuildRestConfig(apiServer, apiServerToken, "", tls)
@@ -55,7 +55,11 @@ func GetAuthorizedRestConfig(apiServer, apiServerToken, caData string, tls rest.
 	return
 }
 
-func BuildRestConfig(apiServer, apiServerToken, caData string, tls rest.TLSClientConfig) (*rest.Config, error) {
+func BuildRestConfig(apiServer, apiServerToken, caData string, tls *rest.TLSClientConfig) (*rest.Config, error) {
+	if tls == nil {
+		tls = &rest.TLSClientConfig{}
+	}
+
 	if !tls.Insecure && caData != "" {
 		caDecoded, err := base64.StdEncoding.DecodeString(caData)
 		if err != nil {
@@ -67,7 +71,7 @@ func BuildRestConfig(apiServer, apiServerToken, caData string, tls rest.TLSClien
 
 	return &rest.Config{
 		Host:            fmt.Sprintf("https://%s", apiServer),
-		TLSClientConfig: tls,
+		TLSClientConfig: *tls,
 		BearerToken:     apiServerToken,
 	}, nil
 }

--- a/pkg/syncer/broker/syncer.go
+++ b/pkg/syncer/broker/syncer.go
@@ -136,7 +136,7 @@ type Syncer struct {
 }
 
 // NewSyncer creates a Syncer that performs bi-directional syncing of resources between a local source and a central broker.
-func NewSyncer(config SyncerConfig) (*Syncer, error) {
+func NewSyncer(config SyncerConfig) (*Syncer, error) { // nolint:gocritic // Minimal performance hit, we modify our copy
 	if len(config.ResourceConfigs) == 0 {
 		return nil, fmt.Errorf("no resources to sync")
 	}
@@ -171,7 +171,8 @@ func NewSyncer(config SyncerConfig) (*Syncer, error) {
 	brokerSyncer.remoteFederator = NewFederator(config.BrokerClient, config.RestMapper, config.BrokerNamespace, config.LocalClusterID)
 	brokerSyncer.localFederator = NewFederator(config.LocalClient, config.RestMapper, config.LocalNamespace, "")
 
-	for _, rc := range config.ResourceConfigs {
+	for i := range config.ResourceConfigs {
+		rc := &config.ResourceConfigs[i]
 		var syncCounter *prometheus.GaugeVec
 		if rc.SyncCounterOpts != nil {
 			syncCounter = prometheus.NewGaugeVec(
@@ -269,7 +270,7 @@ func createBrokerClient(config *SyncerConfig) error {
 		config.BrokerNamespace = spec.RemoteNamespace
 
 		config.BrokerRestConfig, authorized, err = resource.GetAuthorizedRestConfig(spec.APIServer, spec.APIServerToken, spec.Ca,
-			rest.TLSClientConfig{Insecure: spec.Insecure}, *gvr, spec.RemoteNamespace)
+			&rest.TLSClientConfig{Insecure: spec.Insecure}, *gvr, spec.RemoteNamespace)
 	}
 
 	if !authorized {

--- a/pkg/util/condition.go
+++ b/pkg/util/condition.go
@@ -22,18 +22,24 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog"
 )
 
 // TryAppendCondition appends the given Condition if it's not equal to the last Condition.
-func TryAppendCondition(conditions []metav1.Condition, newCondition metav1.Condition) []metav1.Condition {
-	newCondition.LastTransitionTime = metav1.Now()
-
-	numCond := len(conditions)
-	if numCond > 0 && conditionsEqual(&(conditions)[numCond-1], &newCondition) {
+func TryAppendCondition(conditions []metav1.Condition, newCondition *metav1.Condition) []metav1.Condition {
+	if newCondition == nil {
+		klog.Warning("TryAppendCondition call with nil newCondition")
 		return conditions
 	}
 
-	return append(conditions, newCondition)
+	newCondition.LastTransitionTime = metav1.Now()
+
+	numCond := len(conditions)
+	if numCond > 0 && conditionsEqual(&(conditions)[numCond-1], newCondition) {
+		return conditions
+	}
+
+	return append(conditions, *newCondition)
 }
 
 func conditionsEqual(c1, c2 *metav1.Condition) bool {

--- a/pkg/util/condition_test.go
+++ b/pkg/util/condition_test.go
@@ -44,7 +44,7 @@ var _ = Describe("TryAppendCondition", func() {
 	})
 
 	JustBeforeEach(func() {
-		outConditions = util.TryAppendCondition(inConditions, newCondition)
+		outConditions = util.TryAppendCondition(inConditions, &newCondition)
 	})
 
 	compareLast := func(expLen int) {

--- a/pkg/util/create_or_update.go
+++ b/pkg/util/create_or_update.go
@@ -130,7 +130,8 @@ func maybeCreateOrUpdate(ctx context.Context, client resource.Interface, obj run
 // with foreground propagation, Get will continue to return the object being deleted
 // and Create will fail with “already exists” until deletion is complete.
 func CreateAnew(ctx context.Context, client resource.Interface, obj runtime.Object,
-	createOptions metav1.CreateOptions, deleteOptions metav1.DeleteOptions) (runtime.Object, error) {
+	createOptions metav1.CreateOptions,
+	deleteOptions metav1.DeleteOptions) (runtime.Object, error) { // nolint:gocritic // Match K8s API
 	name := resource.ToMeta(obj).GetName()
 
 	var created runtime.Object


### PR DESCRIPTION
This mostly concerns hugeParam, with fixes to avoid copying large data structures.

In many cases, we still pass by copy instead of by reference, in particular to match K8s API practice (e.g. for DeleteOptions). In such cases, the linter is disabled with // nolint:gocritic; to limit the scope of the nolint comment, it is placed inline, and where possible the affected parameter is isolated. (It doesn't seem to be possible to only disable hugeParam, and we still want hugeParam to process any additional parameter in future anyway.)

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
