### PR TITLE
Hide mutexes

### DIFF
--- a/pkg/fake/dynamic_client.go
+++ b/pkg/fake/dynamic_client.go
@@ -40,13 +40,12 @@ import (
 
 type DynamicClient struct {
 	*fake.FakeDynamicClient
-	sync.Mutex
 	namespaceableResources map[schema.GroupVersionResource]dynamic.NamespaceableResourceInterface
 }
 
 type namespaceableResource struct {
 	dynamic.NamespaceableResourceInterface
-	sync.Mutex
+	mutex           sync.Mutex
 	resourceClients map[string]dynamic.ResourceInterface
 }
 
@@ -95,8 +94,8 @@ func (f *DynamicClient) Resource(gvr schema.GroupVersionResource) dynamic.Namesp
 }
 
 func (f *namespaceableResource) Namespace(namespace string) dynamic.ResourceInterface {
-	f.Lock()
-	defer f.Unlock()
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
 
 	i := f.resourceClients[namespace]
 	if i != nil {

--- a/pkg/fake/failing_reactor.go
+++ b/pkg/fake/failing_reactor.go
@@ -26,7 +26,7 @@ import (
 )
 
 type FailingReactor struct {
-	sync.Mutex
+	mutex          sync.Mutex
 	failOnCreate   error
 	failOnUpdate   error
 	failOnDelete   error
@@ -48,8 +48,8 @@ func NewFailingReactorForResource(f *testing.Fake, resource string) *FailingReac
 }
 
 func (f *FailingReactor) react(action testing.Action) (bool, runtime.Object, error) {
-	f.Lock()
-	defer f.Unlock()
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
 
 	switch action.GetVerb() {
 	case "get":
@@ -133,37 +133,37 @@ func (f *FailingReactor) list() (bool, runtime.Object, error) {
 }
 
 func (f *FailingReactor) SetResetOnFailure(v bool) {
-	f.Lock()
-	defer f.Unlock()
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
 	f.resetOnFailure = v
 }
 
 func (f *FailingReactor) SetFailOnCreate(err error) {
-	f.Lock()
-	defer f.Unlock()
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
 	f.failOnCreate = err
 }
 
 func (f *FailingReactor) SetFailOnUpdate(err error) {
-	f.Lock()
-	defer f.Unlock()
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
 	f.failOnUpdate = err
 }
 
 func (f *FailingReactor) SetFailOnDelete(err error) {
-	f.Lock()
-	defer f.Unlock()
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
 	f.failOnDelete = err
 }
 
 func (f *FailingReactor) SetFailOnGet(err error) {
-	f.Lock()
-	defer f.Unlock()
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
 	f.failOnGet = err
 }
 
 func (f *FailingReactor) SetFailOnList(err error) {
-	f.Lock()
-	defer f.Unlock()
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
 	f.failOnList = err
 }

--- a/pkg/fake/watch_reactor.go
+++ b/pkg/fake/watch_reactor.go
@@ -31,7 +31,7 @@ import (
 )
 
 type WatchReactor struct {
-	sync.Mutex
+	mutex    sync.Mutex
 	watches  map[string]*watchDelegator
 	reactors []testing.WatchReactor
 }
@@ -55,8 +55,8 @@ func filterEvent(event watch.Event, restrictions *testing.WatchRestrictions) (wa
 func (r *WatchReactor) react(action testing.Action) (bool, watch.Interface, error) {
 	switch w := action.(type) {
 	case testing.WatchActionImpl:
-		r.Lock()
-		defer r.Unlock()
+		r.mutex.Lock()
+		defer r.mutex.Unlock()
 
 		if r.watches[w.Resource.Resource] != nil {
 			return true, nil, fmt.Errorf("watch for %q was already started", w.Resource.Resource)
@@ -90,8 +90,8 @@ func (r *WatchReactor) react(action testing.Action) (bool, watch.Interface, erro
 }
 
 func (r *WatchReactor) getDelegator(forResource string) *watchDelegator {
-	r.Lock()
-	defer r.Unlock()
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
 
 	return r.watches[forResource]
 }


### PR DESCRIPTION
This is flagged by the latest gocritic:
https://go-critic.com/overview.html#exposedSyncMutex-ref

This patch avoids exposing the mutex functions on the containing
struct.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
