### PR TITLE
Remove settings flag from E2E arguments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ TARGETS := $(shell ls -p scripts | grep -v -e /)
 
 CLUSTER_SETTINGS_FLAG = --settings $(DAPPER_SOURCE)/.shipyard.e2e.yml
 override CLUSTERS_ARGS = $(CLUSTER_SETTINGS_FLAG)
-override E2E_ARGS += $(CLUSTER_SETTINGS_FLAG) --nolazy_deploy cluster1 cluster2
+override E2E_ARGS += --nolazy_deploy cluster1 cluster2
 override UNIT_TEST_ARGS += test/e2e
 
 deploy: clusters


### PR DESCRIPTION
The E2E script is not using anything from the settings, so there's no
need to load them.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
