### PR TITLE
Refactor the ToUnstructured functions

### DIFF
--- a/pkg/fake/delete_colection_reactor.go
+++ b/pkg/fake/delete_colection_reactor.go
@@ -24,7 +24,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
-	"github.com/submariner-io/admiral/pkg/syncer/test"
+	"github.com/submariner-io/admiral/pkg/test"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"

--- a/pkg/resource/util.go
+++ b/pkg/resource/util.go
@@ -24,7 +24,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes/scheme"
 )
 
 func ToUnstructured(from runtime.Object) (*unstructured.Unstructured, error) {
@@ -32,13 +31,12 @@ func ToUnstructured(from runtime.Object) (*unstructured.Unstructured, error) {
 	case *unstructured.Unstructured:
 		return f.DeepCopy(), nil
 	default:
-		to := &unstructured.Unstructured{}
-		err := scheme.Scheme.Convert(from, to, nil)
+		m, err := runtime.DefaultUnstructuredConverter.ToUnstructured(from)
 		if err != nil {
 			return nil, errors.Wrapf(err, "error converting %#v to unstructured.Unstructured", from)
 		}
 
-		return to, nil
+		return &unstructured.Unstructured{Object: m}, nil
 	}
 }
 

--- a/pkg/syncer/resource_syncer_test.go
+++ b/pkg/syncer/resource_syncer_test.go
@@ -29,6 +29,7 @@ import (
 	. "github.com/submariner-io/admiral/pkg/gomega"
 	"github.com/submariner-io/admiral/pkg/syncer"
 	"github.com/submariner-io/admiral/pkg/syncer/test"
+	testutil "github.com/submariner-io/admiral/pkg/test"
 	"github.com/submariner-io/admiral/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -189,7 +190,7 @@ func testTransformFunction() {
 		})
 
 		It("should distribute the transformed resource", func() {
-			d.federator.VerifyDistribute(test.ToUnstructured(transformed))
+			d.federator.VerifyDistribute(testutil.ToUnstructured(transformed))
 			Eventually(expOperation).Should(Receive(Equal(syncer.Create)))
 			Consistently(func() int {
 				return int(atomic.LoadInt32(&invocationCount))
@@ -215,12 +216,12 @@ func testTransformFunction() {
 		})
 
 		It("should distribute the transformed resource", func() {
-			d.federator.VerifyDistribute(test.ToUnstructured(transformed))
+			d.federator.VerifyDistribute(testutil.ToUnstructured(transformed))
 			Eventually(expOperation).Should(Receive(Equal(syncer.Create)))
 
 			d.resource = test.NewPodWithImage(d.config.SourceNamespace, "updated")
 			test.UpdateResource(d.sourceClient, test.NewPodWithImage(d.config.SourceNamespace, "updated"))
-			d.federator.VerifyDistribute(test.ToUnstructured(transformed))
+			d.federator.VerifyDistribute(testutil.ToUnstructured(transformed))
 			Eventually(expOperation).Should(Receive(Equal(syncer.Update)))
 		})
 	})
@@ -231,14 +232,14 @@ func testTransformFunction() {
 		})
 
 		JustBeforeEach(func() {
-			d.federator.VerifyDistribute(test.ToUnstructured(transformed))
+			d.federator.VerifyDistribute(testutil.ToUnstructured(transformed))
 			Eventually(expOperation).Should(Receive(Equal(syncer.Create)))
 			atomic.StoreInt32(&invocationCount, 0)
 		})
 
 		It("should delete the transformed resource", func() {
 			Expect(d.sourceClient.Delete(ctx, d.resource.GetName(), metav1.DeleteOptions{})).To(Succeed())
-			d.federator.VerifyDelete(test.ToUnstructured(transformed))
+			d.federator.VerifyDelete(testutil.ToUnstructured(transformed))
 			Eventually(expOperation).Should(Receive(Equal(syncer.Delete)))
 			Consistently(func() int {
 				return int(atomic.LoadInt32(&invocationCount))
@@ -266,11 +267,11 @@ func testTransformFunction() {
 		})
 
 		It("should retry until it succeeds", func() {
-			d.federator.VerifyDistribute(test.ToUnstructured(transformed))
+			d.federator.VerifyDistribute(testutil.ToUnstructured(transformed))
 			Eventually(expOperation).Should(Receive(Equal(syncer.Create)))
 
 			Expect(d.sourceClient.Delete(ctx, d.resource.GetName(), metav1.DeleteOptions{})).To(Succeed())
-			d.federator.VerifyDelete(test.ToUnstructured(transformed))
+			d.federator.VerifyDelete(testutil.ToUnstructured(transformed))
 			Eventually(expOperation).Should(Receive(Equal(syncer.Delete)))
 			Eventually(expOperation).Should(Receive(Equal(syncer.Delete)))
 		})
@@ -283,7 +284,7 @@ func testTransformFunction() {
 
 		It("retry until it succeeds", func() {
 			test.CreateResource(d.sourceClient, d.resource)
-			d.federator.VerifyDistribute(test.ToUnstructured(transformed))
+			d.federator.VerifyDistribute(testutil.ToUnstructured(transformed))
 			Eventually(expOperation).Should(Receive(Equal(syncer.Create)))
 			Eventually(expOperation).Should(Receive(Equal(syncer.Create)))
 		})
@@ -348,7 +349,7 @@ func testTransformFunction() {
 		Context("and a resource is created in the datastore", func() {
 			It("should eventually distribute the transformed resource", func() {
 				test.CreateResource(d.sourceClient, d.resource)
-				d.federator.VerifyDistribute(test.ToUnstructured(transformed))
+				d.federator.VerifyDistribute(testutil.ToUnstructured(transformed))
 				Eventually(expOperation).Should(Receive(Equal(syncer.Create)))
 			})
 		})
@@ -359,12 +360,12 @@ func testTransformFunction() {
 			})
 
 			It("should eventually delete the resource", func() {
-				d.federator.VerifyDistribute(test.ToUnstructured(transformed))
+				d.federator.VerifyDistribute(testutil.ToUnstructured(transformed))
 				Eventually(expOperation).Should(Receive(Equal(syncer.Create)))
 				transformFuncRet.Store(nilResource)
 
 				Expect(d.sourceClient.Delete(ctx, d.resource.GetName(), metav1.DeleteOptions{})).To(Succeed())
-				d.federator.VerifyDelete(test.ToUnstructured(transformed))
+				d.federator.VerifyDelete(testutil.ToUnstructured(transformed))
 				Eventually(expOperation).Should(Receive(Equal(syncer.Delete)))
 			})
 		})
@@ -440,7 +441,7 @@ func testOnSuccessfulSyncFunction() {
 
 			It("should invoke the OnSuccessfulSync function with the transformed resource", func() {
 				test.CreateResource(d.sourceClient, d.resource)
-				d.federator.VerifyDistribute(test.ToUnstructured(expResource))
+				d.federator.VerifyDistribute(testutil.ToUnstructured(expResource))
 				Eventually(expOperation).Should(Receive(Equal(syncer.Create)))
 			})
 		})
@@ -659,7 +660,7 @@ func testUpdateSuppression() {
 			})
 
 			It("should distribute it", func() {
-				d.federator.VerifyDistribute(test.ToUnstructured(d.resource))
+				d.federator.VerifyDistribute(testutil.ToUnstructured(d.resource))
 			})
 		})
 
@@ -670,7 +671,7 @@ func testUpdateSuppression() {
 			})
 
 			It("should distribute it", func() {
-				d.federator.VerifyDistribute(test.ToUnstructured(d.resource))
+				d.federator.VerifyDistribute(testutil.ToUnstructured(d.resource))
 			})
 		})
 	})
@@ -707,7 +708,7 @@ func testUpdateSuppression() {
 			})
 
 			It("should distribute it", func() {
-				d.federator.VerifyDistribute(test.ToUnstructured(d.resource))
+				d.federator.VerifyDistribute(testutil.ToUnstructured(d.resource))
 			})
 		})
 
@@ -717,7 +718,7 @@ func testUpdateSuppression() {
 			})
 
 			It("should distribute it", func() {
-				d.federator.VerifyDistribute(test.ToUnstructured(d.resource))
+				d.federator.VerifyDistribute(testutil.ToUnstructured(d.resource))
 			})
 		})
 	})
@@ -736,7 +737,7 @@ func testUpdateSuppression() {
 			})
 
 			It("should distribute it", func() {
-				d.federator.VerifyDistribute(test.ToUnstructured(d.resource))
+				d.federator.VerifyDistribute(testutil.ToUnstructured(d.resource))
 			})
 		})
 	})
@@ -752,7 +753,7 @@ func testUpdateSuppression() {
 			})
 
 			It("should distribute it", func() {
-				d.federator.VerifyDistribute(test.ToUnstructured(d.resource))
+				d.federator.VerifyDistribute(testutil.ToUnstructured(d.resource))
 			})
 		})
 
@@ -911,7 +912,7 @@ func newTestDiver(sourceNamespace, localClusterID string, syncDirection syncer.S
 }
 
 func (t *testDriver) addInitialResource(obj runtime.Object) {
-	t.initialResources = append(t.initialResources, test.ToUnstructured(obj))
+	t.initialResources = append(t.initialResources, testutil.ToUnstructured(obj))
 }
 
 func (t *testDriver) verifyDistributeOnCreateTest(clusterID string) {

--- a/pkg/syncer/test/util.go
+++ b/pkg/syncer/test/util.go
@@ -25,7 +25,7 @@ import (
 
 	. "github.com/onsi/gomega"
 	"github.com/submariner-io/admiral/pkg/federate"
-	resourceUtil "github.com/submariner-io/admiral/pkg/resource"
+	"github.com/submariner-io/admiral/pkg/test"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metaapi "k8s.io/apimachinery/pkg/api/meta"
@@ -59,14 +59,14 @@ func GetResource(resourceInterface dynamic.ResourceInterface, obj runtime.Object
 }
 
 func CreateResource(resourceInterface dynamic.ResourceInterface, resource runtime.Object) *unstructured.Unstructured {
-	obj, err := resourceInterface.Create(context.TODO(), ToUnstructured(resource), metav1.CreateOptions{})
+	obj, err := resourceInterface.Create(context.TODO(), test.ToUnstructured(resource), metav1.CreateOptions{})
 	Expect(err).To(Succeed())
 
 	return obj
 }
 
 func UpdateResource(resourceInterface dynamic.ResourceInterface, resource runtime.Object) *unstructured.Unstructured {
-	obj, err := resourceInterface.Update(context.TODO(), ToUnstructured(resource), metav1.UpdateOptions{})
+	obj, err := resourceInterface.Update(context.TODO(), test.ToUnstructured(resource), metav1.UpdateOptions{})
 	Expect(err).To(Succeed())
 
 	return obj
@@ -176,7 +176,7 @@ func PrepInitialClientObjs(namespace, clusterID string, initObjs ...runtime.Obje
 	newObjs := make([]runtime.Object, 0, len(initObjs))
 
 	for _, obj := range initObjs {
-		raw := ToUnstructured(obj)
+		raw := test.ToUnstructured(obj)
 		raw.SetUID(uuid.NewUUID())
 		raw.SetResourceVersion("1")
 
@@ -198,13 +198,6 @@ func PrepInitialClientObjs(namespace, clusterID string, initObjs ...runtime.Obje
 	}
 
 	return newObjs
-}
-
-func ToUnstructured(obj runtime.Object) *unstructured.Unstructured {
-	raw, err := resourceUtil.ToUnstructured(obj)
-	Expect(err).To(Succeed())
-
-	return raw
 }
 
 func SetClusterIDLabel(obj runtime.Object, clusterID string) runtime.Object {

--- a/pkg/test/utils.go
+++ b/pkg/test/utils.go
@@ -25,6 +25,8 @@ import (
 	"github.com/submariner-io/admiral/pkg/resource"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 func SetDeleting(client resource.Interface, name string) {
@@ -49,4 +51,11 @@ func GetFinalizers(client resource.Interface, name string) []string {
 	Expect(err).To(Succeed())
 
 	return metaObj.GetFinalizers()
+}
+
+func ToUnstructured(obj runtime.Object) *unstructured.Unstructured {
+	raw, err := resource.ToUnstructured(obj)
+	Expect(err).To(Succeed())
+
+	return raw
 }

--- a/pkg/util/create_or_update_test.go
+++ b/pkg/util/create_or_update_test.go
@@ -28,6 +28,7 @@ import (
 	. "github.com/submariner-io/admiral/pkg/gomega"
 	"github.com/submariner-io/admiral/pkg/resource"
 	"github.com/submariner-io/admiral/pkg/syncer/test"
+	testutil "github.com/submariner-io/admiral/pkg/test"
 	"github.com/submariner-io/admiral/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -158,14 +159,14 @@ var _ = Describe("", func() {
 
 		BeforeEach(func() {
 			mutateFn = func(existing runtime.Object) (runtime.Object, error) {
-				obj := test.ToUnstructured(pod)
+				obj := testutil.ToUnstructured(pod)
 				obj.SetUID(resource.ToMeta(existing).GetUID())
 				return util.Replace(obj)(nil)
 			}
 		})
 
 		createOrUpdate := func() (util.OperationResult, error) {
-			return util.CreateOrUpdate(context.TODO(), resource.ForDynamic(client), test.ToUnstructured(pod), mutateFn)
+			return util.CreateOrUpdate(context.TODO(), resource.ForDynamic(client), testutil.ToUnstructured(pod), mutateFn)
 		}
 
 		testCreateOrUpdateErr := func() {

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -24,7 +24,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/submariner-io/admiral/pkg/syncer/test"
+	"github.com/submariner-io/admiral/pkg/test"
 	testV1 "github.com/submariner-io/admiral/test/apis/admiral.submariner.io/v1"
 	"github.com/submariner-io/shipyard/test/e2e/framework"
 	metaapi "k8s.io/apimachinery/pkg/api/meta"


### PR DESCRIPTION
Change `resource.ToUnstructured` to use the `runtime.DefaultUnstructuredConverter` instead of `scheme.Scheme.Convert` as the latter requires the type to be registered with the global scheme.

Also move the test `ToUnstructured` function from the _syncer/test_ package to the general _test_ package.

**Note**: this is specifically to fix test failures in https://github.com/open-cluster-management/submariner-addon/pull/226.