### PR TITLE
Add a function to build configuration settings

### DIFF
--- a/pkg/syncer/broker/config_test.go
+++ b/pkg/syncer/broker/config_test.go
@@ -1,0 +1,38 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package broker_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/syncer/broker"
+)
+
+var _ = Describe("Broker configuration", func() {
+	When("an environment variable is requested for a valid setting", func() {
+		It("should return the correct value", func() {
+			Expect(broker.EnvironmentVariable("Insecure")).To(Equal("BROKER_K8S_INSECURE"))
+		})
+	})
+
+	When("an environment variable is requested for an invalid setting", func() {
+		It("should panic", func() {
+			Expect(func() { broker.EnvironmentVariable("impossible setting") }).To(Panic())
+		})
+	})
+})


### PR DESCRIPTION
Admiral expects certain environment variables to configure the broker
syncer; this adds a function which allows callers to find out what the
correct variable is, without embedding knowledge about Admiral (beyond
the fact that it expects environment variables).

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
