### PR TITLE
Drop error return from BuildRestConfigFromFiles

### DIFF
--- a/pkg/resource/rest.go
+++ b/pkg/resource/rest.go
@@ -57,19 +57,12 @@ func GetAuthorizedRestConfigFromData(apiServer, apiServerToken, caData string, t
 func GetAuthorizedRestConfigFromFiles(apiServer, apiServerTokenFile, caFile string, tls *rest.TLSClientConfig,
 	gvr schema.GroupVersionResource, namespace string) (restConfig *rest.Config, authorized bool, err error) {
 	// First try a REST config without the CA trust chain
-	restConfig, err = BuildRestConfigFromFiles(apiServer, apiServerTokenFile, "", tls)
-	if err != nil {
-		return
-	}
-
+	restConfig = BuildRestConfigFromFiles(apiServer, apiServerTokenFile, "", tls)
 	authorized, err = IsAuthorizedFor(restConfig, gvr, namespace)
+
 	if !authorized {
 		// Now try with the trust chain
-		restConfig, err = BuildRestConfigFromFiles(apiServer, apiServerTokenFile, caFile, tls)
-		if err != nil {
-			return
-		}
-
+		restConfig = BuildRestConfigFromFiles(apiServer, apiServerTokenFile, caFile, tls)
 		authorized, err = IsAuthorizedFor(restConfig, gvr, namespace)
 	}
 
@@ -97,7 +90,7 @@ func BuildRestConfigFromData(apiServer, apiServerToken, caData string, tls *rest
 	}, nil
 }
 
-func BuildRestConfigFromFiles(apiServer, apiServerTokenFile, caFile string, tls *rest.TLSClientConfig) (*rest.Config, error) {
+func BuildRestConfigFromFiles(apiServer, apiServerTokenFile, caFile string, tls *rest.TLSClientConfig) *rest.Config {
 	if tls == nil {
 		tls = &rest.TLSClientConfig{}
 	}
@@ -110,7 +103,7 @@ func BuildRestConfigFromFiles(apiServer, apiServerTokenFile, caFile string, tls 
 		Host:            fmt.Sprintf("https://%s", apiServer),
 		TLSClientConfig: *tls,
 		BearerTokenFile: apiServerTokenFile,
-	}, nil
+	}
 }
 
 func IsAuthorizedFor(restConfig *rest.Config, gvr schema.GroupVersionResource, namespace string) (bool, error) {


### PR DESCRIPTION
BuildRestConfigFromFiles always returns a nil error, drop the return
value entirely.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
