### PR TITLE
Only ignore Dockerfile.* in the root directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ output
 *.out
 junit*.xml
 .shflags
-Dockerfile.*
+/Dockerfile.*


### PR DESCRIPTION
We don't want to ignore container descriptions elsewhere; the rule was
only intended for Dockerfile.dapper in the root directory (but we
don't want any Dockerfile.* there).

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
