### PR TITLE
Extend logr.Logger interface

### DIFF
--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -1,0 +1,60 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package log
+
+import (
+	"fmt"
+
+	"github.com/go-logr/logr"
+)
+
+const WarningKey = "WARNING"
+
+type Logger struct {
+	logr.Logger
+}
+
+func (l Logger) Info(msg string, keysAndValues ...interface{}) {
+	l.Logger.Info(msg, keysAndValues...)
+}
+
+func (l Logger) Infof(format string, args ...interface{}) {
+	l.Logger.Info(fmt.Sprintf(format, args...))
+}
+
+func (l Logger) Error(err error, msg string, keysAndValues ...interface{}) {
+	l.Logger.Error(err, msg, keysAndValues...)
+}
+
+func (l Logger) Errorf(err error, format string, args ...interface{}) {
+	l.Logger.Error(err, fmt.Sprintf(format, args...))
+}
+
+func (l Logger) Warning(msg string, keysAndValues ...interface{}) {
+	l.Logger.Info(msg, append(keysAndValues, WarningKey, "true")...)
+}
+
+func (l Logger) Warningf(format string, args ...interface{}) {
+	l.Logger.Info(fmt.Sprintf(format, args...), WarningKey, "true")
+}
+
+func (l Logger) V(level int) Logger {
+	l.Logger = l.Logger.V(level)
+	return l
+}


### PR DESCRIPTION
The `logr` interface allows for variable information to be passed as key/value pairs. It's also useful to format variable information in line ala `klog.Infof`, as has been used throughout the code base. Rather than having callers use `fmt.Sprintf,` create a new Logger interface that extends `logr` to add the `klog` style.

Also added `Warning`/`Warningf` methods. These pass a special "WARNNG" key that the `kzerolog` implementation uses to create a zerolog warning event.
