### PR TITLE
Backport: Add resource.ForNamespace, enabling CreateOrUpdate

### DIFF
--- a/pkg/resource/kubernetes.go
+++ b/pkg/resource/kubernetes.go
@@ -73,6 +73,24 @@ func ForDeployment(client kubernetes.Interface, namespace string) Interface {
 // Core
 
 //nolint:dupl //false positive - lines are similar but not duplicated
+func ForNamespace(client kubernetes.Interface) Interface {
+	return &InterfaceFuncs{
+		GetFunc: func(ctx context.Context, name string, options metav1.GetOptions) (runtime.Object, error) {
+			return client.CoreV1().Namespaces().Get(ctx, name, options)
+		},
+		CreateFunc: func(ctx context.Context, obj runtime.Object, options metav1.CreateOptions) (runtime.Object, error) {
+			return client.CoreV1().Namespaces().Create(ctx, obj.(*corev1.Namespace), options)
+		},
+		UpdateFunc: func(ctx context.Context, obj runtime.Object, options metav1.UpdateOptions) (runtime.Object, error) {
+			return client.CoreV1().Namespaces().Update(ctx, obj.(*corev1.Namespace), options)
+		},
+		DeleteFunc: func(ctx context.Context, name string, options metav1.DeleteOptions) error {
+			return client.CoreV1().Namespaces().Delete(ctx, name, options)
+		},
+	}
+}
+
+//nolint:dupl //false positive - lines are similar but not duplicated
 func ForPod(client kubernetes.Interface, namespace string) Interface {
 	return &InterfaceFuncs{
 		GetFunc: func(ctx context.Context, name string, options metav1.GetOptions) (runtime.Object, error) {


### PR DESCRIPTION
Add a resource.ForNamespace interface so we can use Admrial's
CreateOrUpdate helper for namespaces.

Relates-to: submariner-io/subctl#27
Signed-off-by: Daniel Farrell <dfarrell@redhat.com>
(cherry picked from commit c054a15f1c601394ca8e5a4145d7df37d53430b2)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
