### PR TITLE
Create a test Secret explicitly

### DIFF
--- a/scripts/e2e
+++ b/scripts/e2e
@@ -8,9 +8,9 @@ function export_broker_env {
 
     export BROKER_K8S_APISERVER=$(kubectl  -n default get endpoints kubernetes -o jsonpath="{.subsets[0].addresses[0].ip}:{.subsets[0].ports[?(@.name=='https')].port}")
 
-    export BROKER_K8S_CA=$(kubectl -n ${BROKER_K8S_REMOTENAMESPACE} get secrets -o jsonpath="{.items[?(@.metadata.annotations['kubernetes\.io/service-account\.name']=='${BROKER_K8S_REMOTENAMESPACE}-client')].data['ca\.crt']}")
+    export BROKER_K8S_CA=$(kubectl -n ${BROKER_K8S_REMOTENAMESPACE} get secrets -o jsonpath="{.items[?(@.metadata.name=='broker-client-token')].data['ca\.crt']}")
 
-    export BROKER_K8S_APISERVERTOKEN=$(kubectl -n ${BROKER_K8S_REMOTENAMESPACE} get secrets -o jsonpath="{.items[?(@.metadata.annotations['kubernetes\.io/service-account\.name']=='${BROKER_K8S_REMOTENAMESPACE}-client')].data.token}"|base64 --decode)
+    export BROKER_K8S_APISERVERTOKEN=$(kubectl -n ${BROKER_K8S_REMOTENAMESPACE} get secrets -o jsonpath="{.items[?(@.metadata.name=='broker-client-token')].data.token}"|base64 --decode)
 }
 
 load_settings

--- a/test/e2e/deploy/broker.yaml
+++ b/test/e2e/deploy/broker.yaml
@@ -14,6 +14,16 @@ metadata:
     app: broker
 
 ---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: broker-client-token
+  namespace: broker
+  annotations:
+    kubernetes.io/service-account.name: broker-client
+type: kubernetes.io/service-account-token
+
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:


### PR DESCRIPTION
Kubernetes 1.24 no longer automatically creates Secrets for
ServiceAccounts, create one ourselves for the broker account.

Fixes: #388
Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
