### PR TITLE
Check GHA updates weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,17 +4,17 @@ updates:
   - package-ecosystem: github-actions
     directory: '/'
     schedule:
-      interval: daily
+      interval: weekly
   - package-ecosystem: github-actions
     directory: '/'
     target-branch: "release-0.12"
     schedule:
-      interval: daily
+      interval: weekly
   - package-ecosystem: github-actions
     directory: '/'
     target-branch: "release-0.13"
     schedule:
-      interval: daily
+      interval: weekly
   - package-ecosystem: gomod
     directory: "/"
     schedule:


### PR DESCRIPTION
The release frequency of some GHAs means we end up with daily
dependabot PRs, which results in lots of not-particularly-useful
review work. Reducing the update cadence to weekly shouldn't expose us
to much risk and will reduce PR churn.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
