### PR TITLE
Allow empty messages when adapting errors

### DIFF
--- a/pkg/reporter/adapter.go
+++ b/pkg/reporter/adapter.go
@@ -33,7 +33,9 @@ func (a *Adapter) Error(err error, message string, args ...interface{}) error {
 		return nil
 	}
 
-	err = errors.Wrapf(err, message, args...)
+	if message != "" {
+		err = errors.Wrapf(err, message, args...)
+	}
 
 	capitalizeFirst := func(str string) string {
 		for i, v := range str {


### PR DESCRIPTION
It can be useful to report an error without any accompanying message
(when the error is self-sufficient).

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
