### PR TITLE
Set GVK in Unstructured passed to informer

### DIFF
--- a/pkg/syncer/resource_syncer.go
+++ b/pkg/syncer/resource_syncer.go
@@ -211,7 +211,7 @@ func NewResourceSyncer(config *ResourceSyncerConfig) (Interface, error) {
 		syncer.config.WaitForCacheSync = &wait
 	}
 
-	_, gvr, err := util.ToUnstructuredResource(config.ResourceType, config.RestMapper)
+	rawType, gvr, err := util.ToUnstructuredResource(config.ResourceType, config.RestMapper)
 	if err != nil {
 		return nil, err //nolint:wrapcheck // OK to return the error as is.
 	}
@@ -246,7 +246,7 @@ func NewResourceSyncer(config *ResourceSyncerConfig) (Interface, error) {
 			options.FieldSelector = config.SourceFieldSelector
 			return resourceClient.Watch(context.TODO(), options)
 		},
-	}, &unstructured.Unstructured{}, config.ResyncPeriod, cache.ResourceEventHandlerFuncs{
+	}, rawType, config.ResyncPeriod, cache.ResourceEventHandlerFuncs{
 		AddFunc:    syncer.onCreate,
 		UpdateFunc: syncer.onUpdate,
 		DeleteFunc: syncer.onDelete,


### PR DESCRIPTION
...instead of passing an empty `Unstructured`. This allows the informer to have knowledge of the actual resource type. This is mainly used by the informer in log messages so it will print the GVK which is more useful than simply "_*Unstructured_".
