### PR TITLE
Bump to Go 1.19

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/submariner-io/admiral
 
-go 1.18
+go 1.19
 
 retract v0.10.0 // Tag was moved
 
@@ -13,7 +13,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0
 	github.com/rs/zerolog v1.28.0
-	github.com/submariner-io/shipyard v0.14.0-m2
+	github.com/submariner-io/shipyard v0.14.0-m2.0.20221201085151-213fcc93e081
 	golang.org/x/time v0.2.0
 	k8s.io/api v0.25.4
 	k8s.io/apimachinery v0.25.4

--- a/go.sum
+++ b/go.sum
@@ -515,8 +515,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
-github.com/submariner-io/shipyard v0.14.0-m2 h1:C5/Pi/fHPpFWcg7gpUWTaYL+x/ezBSWD5PDGsm0yauY=
-github.com/submariner-io/shipyard v0.14.0-m2/go.mod h1:W3Oufy60RlxZ6vEQK1obw/jM35a9kNZVj4ls5Pyi+K0=
+github.com/submariner-io/shipyard v0.14.0-m2.0.20221201085151-213fcc93e081 h1:kD3Z1DDhAblN5Gw760LorkiFj3FYDIR7jeP846l7HxE=
+github.com/submariner-io/shipyard v0.14.0-m2.0.20221201085151-213fcc93e081/go.mod h1:j2W635uQE2/ZsgcMCrE4pqvcFHYimREM7dCqpIl9IsQ=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=


### PR DESCRIPTION
Now that our build infrastructure has a Go 1.19 compiler, we can bump the required version to 1.19.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
