### PR TITLE
Stop vendoring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,9 @@ override UNIT_TEST_ARGS += test/e2e
 deploy: clusters
 	./scripts/$@
 
-e2e: vendor/modules.txt deploy
+e2e: deploy
 	./scripts/$@ $(E2E_ARGS)
-	
+
 .PHONY: $(TARGETS) test
 
 else


### PR DESCRIPTION
go mod vendor is no longer necessary; see
https://go.dev/ref/mod#vendoring for details. Dependencies will be fulfilled using the module cache.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
