### PR TITLE
Handle resource status update in util.CreateOrUpdate

### DIFF
--- a/pkg/resource/dynamic.go
+++ b/pkg/resource/dynamic.go
@@ -55,12 +55,30 @@ func (d *dynamicType) Update(ctx context.Context, obj runtime.Object, options me
 	return d.client.Update(ctx, raw, options)
 }
 
+//nolint:gocritic // hugeParam - we're matching K8s API
+func (d *dynamicType) UpdateStatus(ctx context.Context, obj runtime.Object, options metav1.UpdateOptions) (runtime.Object, error) {
+	raw, err := ToUnstructured(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	return d.client.UpdateStatus(ctx, raw, options)
+}
+
 func (d *dynamicType) Delete(ctx context.Context, name string,
 	options metav1.DeleteOptions, //nolint:gocritic // hugeParam - we're matching K8s API
 ) error {
 	return d.client.Delete(ctx, name, options)
 }
 
-func ForDynamic(client dynamic.ResourceInterface) Interface {
-	return &dynamicType{client: client}
+func ForDynamic(client dynamic.ResourceInterface) *InterfaceFuncs {
+	t := &dynamicType{client: client}
+
+	return &InterfaceFuncs{
+		GetFunc:          t.Get,
+		CreateFunc:       t.Create,
+		UpdateFunc:       t.Update,
+		UpdateStatusFunc: t.UpdateStatus,
+		DeleteFunc:       t.Delete,
+	}
 }

--- a/pkg/resource/interface.go
+++ b/pkg/resource/interface.go
@@ -21,22 +21,26 @@ package resource
 import (
 	"context"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 type Interface interface {
 	Get(ctx context.Context, name string, options metav1.GetOptions) (runtime.Object, error)
 	Create(ctx context.Context, obj runtime.Object, options metav1.CreateOptions) (runtime.Object, error)
 	Update(ctx context.Context, obj runtime.Object, options metav1.UpdateOptions) (runtime.Object, error)
+	UpdateStatus(ctx context.Context, obj runtime.Object, options metav1.UpdateOptions) (runtime.Object, error)
 	Delete(ctx context.Context, name string, options metav1.DeleteOptions) error
 }
 
 type InterfaceFuncs struct {
-	GetFunc    func(ctx context.Context, name string, options metav1.GetOptions) (runtime.Object, error)
-	CreateFunc func(ctx context.Context, obj runtime.Object, options metav1.CreateOptions) (runtime.Object, error)
-	UpdateFunc func(ctx context.Context, obj runtime.Object, options metav1.UpdateOptions) (runtime.Object, error)
-	DeleteFunc func(ctx context.Context, name string, options metav1.DeleteOptions) error
+	GetFunc          func(ctx context.Context, name string, options metav1.GetOptions) (runtime.Object, error)
+	CreateFunc       func(ctx context.Context, obj runtime.Object, options metav1.CreateOptions) (runtime.Object, error)
+	UpdateFunc       func(ctx context.Context, obj runtime.Object, options metav1.UpdateOptions) (runtime.Object, error)
+	UpdateStatusFunc func(ctx context.Context, obj runtime.Object, options metav1.UpdateOptions) (runtime.Object, error)
+	DeleteFunc       func(ctx context.Context, name string, options metav1.DeleteOptions) error
 }
 
 func (i *InterfaceFuncs) Get(ctx context.Context, name string, options metav1.GetOptions) (runtime.Object, error) {
@@ -53,8 +57,25 @@ func (i *InterfaceFuncs) Update(ctx context.Context, obj runtime.Object, options
 	return i.UpdateFunc(ctx, obj, options)
 }
 
+//nolint:gocritic // hugeParam - we're matching K8s API
+func (i *InterfaceFuncs) UpdateStatus(ctx context.Context, obj runtime.Object, options metav1.UpdateOptions) (runtime.Object, error) {
+	if i.UpdateStatusFunc == nil {
+		// The function isn't defined so assume the status subresource isn't supported.
+		return DefaultUpdateStatus(ctx, obj, options)
+	}
+
+	return i.UpdateStatusFunc(ctx, obj, options)
+}
+
 func (i *InterfaceFuncs) Delete(ctx context.Context, name string,
 	options metav1.DeleteOptions, //nolint:gocritic // hugeParam - we're matching K8s API
 ) error {
 	return i.DeleteFunc(ctx, name, options)
+}
+
+// DefaultUpdateStatus returns NotFound error indicating the status subresource isn't supported.
+//
+//nolint:gocritic // hugeParam - we're matching K8s API
+func DefaultUpdateStatus(_ context.Context, _ runtime.Object, _ metav1.UpdateOptions) (runtime.Object, error) {
+	return nil, apierrors.NewNotFound(schema.GroupResource{}, "")
 }

--- a/pkg/resource/kubernetes.go
+++ b/pkg/resource/kubernetes.go
@@ -48,6 +48,9 @@ func ForDaemonSet(client kubernetes.Interface, namespace string) Interface {
 		UpdateFunc: func(ctx context.Context, obj runtime.Object, options metav1.UpdateOptions) (runtime.Object, error) {
 			return client.AppsV1().DaemonSets(namespace).Update(ctx, obj.(*appsv1.DaemonSet), options)
 		},
+		UpdateStatusFunc: func(ctx context.Context, obj runtime.Object, options metav1.UpdateOptions) (runtime.Object, error) {
+			return client.AppsV1().DaemonSets(namespace).UpdateStatus(ctx, obj.(*appsv1.DaemonSet), options)
+		},
 		DeleteFunc: func(ctx context.Context, name string, options metav1.DeleteOptions) error {
 			return client.AppsV1().DaemonSets(namespace).Delete(ctx, name, options)
 		},
@@ -66,6 +69,9 @@ func ForDeployment(client kubernetes.Interface, namespace string) Interface {
 		UpdateFunc: func(ctx context.Context, obj runtime.Object, options metav1.UpdateOptions) (runtime.Object, error) {
 			return client.AppsV1().Deployments(namespace).Update(ctx, obj.(*appsv1.Deployment), options)
 		},
+		UpdateStatusFunc: func(ctx context.Context, obj runtime.Object, options metav1.UpdateOptions) (runtime.Object, error) {
+			return client.AppsV1().Deployments(namespace).UpdateStatus(ctx, obj.(*appsv1.Deployment), options)
+		},
 		DeleteFunc: func(ctx context.Context, name string, options metav1.DeleteOptions) error {
 			return client.AppsV1().Deployments(namespace).Delete(ctx, name, options)
 		},
@@ -74,7 +80,6 @@ func ForDeployment(client kubernetes.Interface, namespace string) Interface {
 
 // Core
 
-//nolint:dupl //false positive - lines are similar but not duplicated
 func ForNamespace(client kubernetes.Interface) Interface {
 	return &InterfaceFuncs{
 		GetFunc: func(ctx context.Context, name string, options metav1.GetOptions) (runtime.Object, error) {
@@ -85,6 +90,9 @@ func ForNamespace(client kubernetes.Interface) Interface {
 		},
 		UpdateFunc: func(ctx context.Context, obj runtime.Object, options metav1.UpdateOptions) (runtime.Object, error) {
 			return client.CoreV1().Namespaces().Update(ctx, obj.(*corev1.Namespace), options)
+		},
+		UpdateStatusFunc: func(ctx context.Context, obj runtime.Object, options metav1.UpdateOptions) (runtime.Object, error) {
+			return client.CoreV1().Namespaces().UpdateStatus(ctx, obj.(*corev1.Namespace), options)
 		},
 		DeleteFunc: func(ctx context.Context, name string, options metav1.DeleteOptions) error {
 			return client.CoreV1().Namespaces().Delete(ctx, name, options)
@@ -104,6 +112,9 @@ func ForPod(client kubernetes.Interface, namespace string) Interface {
 		UpdateFunc: func(ctx context.Context, obj runtime.Object, options metav1.UpdateOptions) (runtime.Object, error) {
 			return client.CoreV1().Pods(namespace).Update(ctx, obj.(*corev1.Pod), options)
 		},
+		UpdateStatusFunc: func(ctx context.Context, obj runtime.Object, options metav1.UpdateOptions) (runtime.Object, error) {
+			return client.CoreV1().Pods(namespace).UpdateStatus(ctx, obj.(*corev1.Pod), options)
+		},
 		DeleteFunc: func(ctx context.Context, name string, options metav1.DeleteOptions) error {
 			return client.CoreV1().Pods(namespace).Delete(ctx, name, options)
 		},
@@ -121,6 +132,9 @@ func ForService(client kubernetes.Interface, namespace string) Interface {
 		},
 		UpdateFunc: func(ctx context.Context, obj runtime.Object, options metav1.UpdateOptions) (runtime.Object, error) {
 			return client.CoreV1().Services(namespace).Update(ctx, obj.(*corev1.Service), options)
+		},
+		UpdateStatusFunc: func(ctx context.Context, obj runtime.Object, options metav1.UpdateOptions) (runtime.Object, error) {
+			return client.CoreV1().Services(namespace).UpdateStatus(ctx, obj.(*corev1.Service), options)
 		},
 		DeleteFunc: func(ctx context.Context, name string, options metav1.DeleteOptions) error {
 			return client.CoreV1().Services(namespace).Delete(ctx, name, options)
@@ -238,7 +252,7 @@ func ForConfigMap(client kubernetes.Interface, namespace string) Interface {
 	}
 }
 
-func ForControllerClient(client controllerClient.Client, namespace string, objType controllerClient.Object) Interface {
+func ForControllerClient(client controllerClient.Client, namespace string, objType controllerClient.Object) *InterfaceFuncs {
 	return &InterfaceFuncs{
 		GetFunc: func(ctx context.Context, name string, options metav1.GetOptions) (runtime.Object, error) {
 			obj := objType.DeepCopyObject()
@@ -246,11 +260,18 @@ func ForControllerClient(client controllerClient.Client, namespace string, objTy
 			return obj, err
 		},
 		CreateFunc: func(ctx context.Context, obj runtime.Object, options metav1.CreateOptions) (runtime.Object, error) {
+			obj = obj.DeepCopyObject()
 			err := client.Create(ctx, obj.(controllerClient.Object))
 			return obj, err
 		},
 		UpdateFunc: func(ctx context.Context, obj runtime.Object, options metav1.UpdateOptions) (runtime.Object, error) {
+			obj = obj.DeepCopyObject()
 			err := client.Update(ctx, obj.(controllerClient.Object))
+			return obj, err
+		},
+		UpdateStatusFunc: func(ctx context.Context, obj runtime.Object, options metav1.UpdateOptions) (runtime.Object, error) {
+			obj = obj.DeepCopyObject()
+			err := client.Status().Update(ctx, obj.(controllerClient.Object))
 			return obj, err
 		},
 		DeleteFunc: func(ctx context.Context, name string, options metav1.DeleteOptions) error {

--- a/pkg/resource/util.go
+++ b/pkg/resource/util.go
@@ -45,6 +45,15 @@ func ToUnstructured(from runtime.Object) (*unstructured.Unstructured, error) {
 	}
 }
 
+func MustToUnstructured(from runtime.Object) *unstructured.Unstructured {
+	u, err := ToUnstructured(from)
+	if err != nil {
+		panic(err)
+	}
+
+	return u
+}
+
 func ToMeta(obj runtime.Object) metav1.Object {
 	objMeta, err := meta.Accessor(obj)
 	if err != nil {

--- a/pkg/util/util_suite_test.go
+++ b/pkg/util/util_suite_test.go
@@ -18,6 +18,7 @@ limitations under the License.
 package util_test
 
 import (
+	"flag"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -26,12 +27,13 @@ import (
 )
 
 func init() {
-	kzerolog.AddFlags(nil)
-}
+	flags := flag.NewFlagSet("kzerolog", flag.ExitOnError)
+	kzerolog.AddFlags(flags)
 
-var _ = Describe("", func() {
+	_ = flags.Parse([]string{"-v=6"})
+
 	kzerolog.InitK8sLogging()
-})
+}
 
 func TestUtil(t *testing.T) {
 	RegisterFailHandler(Fail)


### PR DESCRIPTION
The `Status` field is a subresource and K8s only allows updating it via the `UpdateStatus` method - the `Update` and `Create` methods silently ignore it. Modify `util.CreateOrUpdate` to handle updates to `Status` by detecting that the `Status` field has been specified/modified and use `UpdateStatus`.
    
This requires adding the `UpdateStatus` method to the `resource.Interface`. This new method is optional in `InterfaceFuncs` as not all CRDs define a status subresource. By default, the `InterfaceFuncs` implementation returns `NotFound` error to match the K8s API behavior when the status subresource doesn't exist.
