### PR TITLE
Rename ToMeta to MustToMeta since it panics

### DIFF
--- a/pkg/fake/watch_reactor.go
+++ b/pkg/fake/watch_reactor.go
@@ -45,7 +45,7 @@ func NewWatchReactor(f *testing.Fake) *WatchReactor {
 }
 
 func filterEvent(event watch.Event, restrictions *testing.WatchRestrictions) (watch.Event, bool) {
-	if restrictions.Labels != nil && !restrictions.Labels.Matches(labels.Set(resource.ToMeta(event.Object).GetLabels())) {
+	if restrictions.Labels != nil && !restrictions.Labels.Matches(labels.Set(resource.MustToMeta(event.Object).GetLabels())) {
 		return event, false
 	}
 

--- a/pkg/finalizer/finalizer.go
+++ b/pkg/finalizer/finalizer.go
@@ -29,7 +29,7 @@ import (
 )
 
 func Add(ctx context.Context, client resource.Interface, obj runtime.Object, finalizerName string) (bool, error) {
-	objMeta := resource.ToMeta(obj)
+	objMeta := resource.MustToMeta(obj)
 	if !objMeta.GetDeletionTimestamp().IsZero() {
 		return false, nil
 	}
@@ -39,7 +39,7 @@ func Add(ctx context.Context, client resource.Interface, obj runtime.Object, fin
 	}
 
 	err := util.Update(ctx, client, obj, func(existing runtime.Object) (runtime.Object, error) {
-		objMeta := resource.ToMeta(existing)
+		objMeta := resource.MustToMeta(existing)
 		objMeta.SetFinalizers(append(objMeta.GetFinalizers(), finalizerName))
 
 		return existing, nil
@@ -49,13 +49,13 @@ func Add(ctx context.Context, client resource.Interface, obj runtime.Object, fin
 }
 
 func Remove(ctx context.Context, client resource.Interface, obj runtime.Object, finalizerName string) error {
-	objMeta := resource.ToMeta(obj)
+	objMeta := resource.MustToMeta(obj)
 	if !IsPresent(objMeta, finalizerName) {
 		return nil
 	}
 
 	err := util.Update(ctx, client, obj, func(existing runtime.Object) (runtime.Object, error) {
-		objMeta := resource.ToMeta(existing)
+		objMeta := resource.MustToMeta(existing)
 
 		newFinalizers := []string{}
 		for _, f := range objMeta.GetFinalizers() {

--- a/pkg/resource/util.go
+++ b/pkg/resource/util.go
@@ -54,7 +54,7 @@ func MustToUnstructured(from runtime.Object) *unstructured.Unstructured {
 	return u
 }
 
-func ToMeta(obj runtime.Object) metav1.Object {
+func MustToMeta(obj runtime.Object) metav1.Object {
 	objMeta, err := meta.Accessor(obj)
 	if err != nil {
 		panic(err)

--- a/pkg/syncer/resource_syncer.go
+++ b/pkg/syncer/resource_syncer.go
@@ -345,7 +345,7 @@ func (r *resourceSyncer) Reconcile(resourceLister func() []runtime.Object) {
 				return
 			}
 
-			metaObj := resourceUtil.ToMeta(resource)
+			metaObj := resourceUtil.MustToMeta(resource)
 			clusterID, found := getClusterIDLabel(resource)
 			ns := r.config.SourceNamespace
 
@@ -671,6 +671,6 @@ func (r *resourceSyncer) assertUnstructured(obj interface{}) *unstructured.Unstr
 }
 
 func getClusterIDLabel(resource runtime.Object) (string, bool) {
-	clusterID, found := resourceUtil.ToMeta(resource).GetLabels()[federate.ClusterIDLabelKey]
+	clusterID, found := resourceUtil.MustToMeta(resource).GetLabels()[federate.ClusterIDLabelKey]
 	return clusterID, found
 }

--- a/pkg/util/create_or_update_test.go
+++ b/pkg/util/create_or_update_test.go
@@ -300,7 +300,7 @@ func newCreateOrUpdateTestDiver() *createOrUpdateTestDriver {
 
 		t.mutateFn = func(existing runtime.Object) (runtime.Object, error) {
 			obj := test.ToUnstructured(t.pod)
-			obj.SetUID(resource.ToMeta(existing).GetUID())
+			obj.SetUID(resource.MustToMeta(existing).GetUID())
 			return util.Replace(obj)(nil)
 		}
 	})


### PR DESCRIPTION
ToMeta panics on errors; to make that externally visible, use the Must... idiom.

ToMeta isn't used anywhere outside Admiral, so this won't require any change in other projects.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
