### PR TITLE
Rename local/broker transformers for clarity

### DIFF
--- a/pkg/syncer/broker/syncer.go
+++ b/pkg/syncer/broker/syncer.go
@@ -51,11 +51,11 @@ type ResourceConfig struct {
 	// LocalResourceType the type of the local resources to sync to the broker.
 	LocalResourceType runtime.Object
 
-	// LocalTransform function used to transform a local resource to the equivalent broker resource.
-	LocalTransform syncer.TransformFunc
+	// TransformLocalToBroker function used to transform a local resource to the equivalent broker resource.
+	TransformLocalToBroker syncer.TransformFunc
 
-	// OnSuccessfulSync function invoked after a successful sync operation to the broker.
-	LocalOnSuccessfulSync syncer.OnSuccessfulSyncFunc
+	// OnSuccessfulSyncToBroker function invoked after a successful sync operation to the broker.
+	OnSuccessfulSyncToBroker syncer.OnSuccessfulSyncFunc
 
 	// LocalResourcesEquivalent function to compare two local resources for equivalence. See ResourceSyncerConfig.ResourcesEquivalent
 	// for more details.
@@ -74,11 +74,11 @@ type ResourceConfig struct {
 	// BrokerResourceType the type of the broker resources to sync to the local source.
 	BrokerResourceType runtime.Object
 
-	// BrokerTransform function used to transform a broker resource to the equivalent local resource.
-	BrokerTransform syncer.TransformFunc
+	// TransformBrokerToLocal function used to transform a broker resource to the equivalent local resource.
+	TransformBrokerToLocal syncer.TransformFunc
 
-	// OnSuccessfulSync function invoked after a successful sync operation from the broker.
-	BrokerOnSuccessfulSync syncer.OnSuccessfulSyncFunc
+	// OnSuccessfulSyncFromBroker function invoked after a successful sync operation from the broker.
+	OnSuccessfulSyncFromBroker syncer.OnSuccessfulSyncFunc
 
 	// BrokerResourcesEquivalent function to compare two broker resources for equivalence. See ResourceSyncerConfig.ResourcesEquivalent
 	// for more details.
@@ -211,8 +211,8 @@ func NewSyncer(config SyncerConfig) (*Syncer, error) { //nolint:gocritic // Mini
 			RestMapper:          config.RestMapper,
 			Federator:           brokerSyncer.remoteFederator,
 			ResourceType:        rc.LocalResourceType,
-			Transform:           rc.LocalTransform,
-			OnSuccessfulSync:    rc.LocalOnSuccessfulSync,
+			Transform:           rc.TransformLocalToBroker,
+			OnSuccessfulSync:    rc.OnSuccessfulSyncToBroker,
 			ResourcesEquivalent: rc.LocalResourcesEquivalent,
 			ShouldProcess:       rc.LocalShouldProcess,
 			WaitForCacheSync:    rc.LocalWaitForCacheSync,
@@ -244,8 +244,8 @@ func NewSyncer(config SyncerConfig) (*Syncer, error) { //nolint:gocritic // Mini
 			RestMapper:          config.RestMapper,
 			Federator:           brokerSyncer.localFederator,
 			ResourceType:        rc.BrokerResourceType,
-			Transform:           rc.BrokerTransform,
-			OnSuccessfulSync:    rc.BrokerOnSuccessfulSync,
+			Transform:           rc.TransformBrokerToLocal,
+			OnSuccessfulSync:    rc.OnSuccessfulSyncFromBroker,
 			ResourcesEquivalent: rc.BrokerResourcesEquivalent,
 			WaitForCacheSync:    waitForCacheSync,
 			Scheme:              config.Scheme,

--- a/pkg/syncer/broker/syncer_test.go
+++ b/pkg/syncer/broker/syncer_test.go
@@ -218,7 +218,7 @@ var _ = Describe("Broker Syncer", func() {
 	When("a local transform function is specified", func() {
 		BeforeEach(func() {
 			transformed = test.NewPodWithImage(config.LocalNamespace, "transformed")
-			config.ResourceConfigs[0].LocalTransform = func(from runtime.Object, numRequeues int,
+			config.ResourceConfigs[0].TransformLocalToBroker = func(from runtime.Object, numRequeues int,
 				op sync.Operation,
 			) (runtime.Object, bool) {
 				return transformed, false
@@ -238,7 +238,7 @@ var _ = Describe("Broker Syncer", func() {
 	When("a broker transform function is specified", func() {
 		BeforeEach(func() {
 			transformed = test.NewPodWithImage(config.LocalNamespace, "transformed")
-			config.ResourceConfigs[0].BrokerTransform = func(from runtime.Object, numRequeues int,
+			config.ResourceConfigs[0].TransformBrokerToLocal = func(from runtime.Object, numRequeues int,
 				op sync.Operation,
 			) (runtime.Object, bool) {
 				return transformed, false


### PR DESCRIPTION
This makes the direction of transformers and syncers explicit. The documentation is updated to match.

This will require matching changes in Submariner and Lighthouse.

Depends on https://github.com/submariner-io/releases/issues/644

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
