### PR TITLE
CreateOrUpdate should only update status if it is specified

### DIFF
--- a/pkg/resource/kubernetes.go
+++ b/pkg/resource/kubernetes.go
@@ -48,9 +48,6 @@ func ForDaemonSet(client kubernetes.Interface, namespace string) Interface {
 		UpdateFunc: func(ctx context.Context, obj runtime.Object, options metav1.UpdateOptions) (runtime.Object, error) {
 			return client.AppsV1().DaemonSets(namespace).Update(ctx, obj.(*appsv1.DaemonSet), options)
 		},
-		UpdateStatusFunc: func(ctx context.Context, obj runtime.Object, options metav1.UpdateOptions) (runtime.Object, error) {
-			return client.AppsV1().DaemonSets(namespace).UpdateStatus(ctx, obj.(*appsv1.DaemonSet), options)
-		},
 		DeleteFunc: func(ctx context.Context, name string, options metav1.DeleteOptions) error {
 			return client.AppsV1().DaemonSets(namespace).Delete(ctx, name, options)
 		},
@@ -69,9 +66,6 @@ func ForDeployment(client kubernetes.Interface, namespace string) Interface {
 		UpdateFunc: func(ctx context.Context, obj runtime.Object, options metav1.UpdateOptions) (runtime.Object, error) {
 			return client.AppsV1().Deployments(namespace).Update(ctx, obj.(*appsv1.Deployment), options)
 		},
-		UpdateStatusFunc: func(ctx context.Context, obj runtime.Object, options metav1.UpdateOptions) (runtime.Object, error) {
-			return client.AppsV1().Deployments(namespace).UpdateStatus(ctx, obj.(*appsv1.Deployment), options)
-		},
 		DeleteFunc: func(ctx context.Context, name string, options metav1.DeleteOptions) error {
 			return client.AppsV1().Deployments(namespace).Delete(ctx, name, options)
 		},
@@ -80,6 +74,7 @@ func ForDeployment(client kubernetes.Interface, namespace string) Interface {
 
 // Core
 
+//nolint:dupl //false positive - lines are similar but not duplicated
 func ForNamespace(client kubernetes.Interface) Interface {
 	return &InterfaceFuncs{
 		GetFunc: func(ctx context.Context, name string, options metav1.GetOptions) (runtime.Object, error) {
@@ -90,9 +85,6 @@ func ForNamespace(client kubernetes.Interface) Interface {
 		},
 		UpdateFunc: func(ctx context.Context, obj runtime.Object, options metav1.UpdateOptions) (runtime.Object, error) {
 			return client.CoreV1().Namespaces().Update(ctx, obj.(*corev1.Namespace), options)
-		},
-		UpdateStatusFunc: func(ctx context.Context, obj runtime.Object, options metav1.UpdateOptions) (runtime.Object, error) {
-			return client.CoreV1().Namespaces().UpdateStatus(ctx, obj.(*corev1.Namespace), options)
 		},
 		DeleteFunc: func(ctx context.Context, name string, options metav1.DeleteOptions) error {
 			return client.CoreV1().Namespaces().Delete(ctx, name, options)
@@ -112,9 +104,6 @@ func ForPod(client kubernetes.Interface, namespace string) Interface {
 		UpdateFunc: func(ctx context.Context, obj runtime.Object, options metav1.UpdateOptions) (runtime.Object, error) {
 			return client.CoreV1().Pods(namespace).Update(ctx, obj.(*corev1.Pod), options)
 		},
-		UpdateStatusFunc: func(ctx context.Context, obj runtime.Object, options metav1.UpdateOptions) (runtime.Object, error) {
-			return client.CoreV1().Pods(namespace).UpdateStatus(ctx, obj.(*corev1.Pod), options)
-		},
 		DeleteFunc: func(ctx context.Context, name string, options metav1.DeleteOptions) error {
 			return client.CoreV1().Pods(namespace).Delete(ctx, name, options)
 		},
@@ -132,9 +121,6 @@ func ForService(client kubernetes.Interface, namespace string) Interface {
 		},
 		UpdateFunc: func(ctx context.Context, obj runtime.Object, options metav1.UpdateOptions) (runtime.Object, error) {
 			return client.CoreV1().Services(namespace).Update(ctx, obj.(*corev1.Service), options)
-		},
-		UpdateStatusFunc: func(ctx context.Context, obj runtime.Object, options metav1.UpdateOptions) (runtime.Object, error) {
-			return client.CoreV1().Services(namespace).UpdateStatus(ctx, obj.(*corev1.Service), options)
 		},
 		DeleteFunc: func(ctx context.Context, name string, options metav1.DeleteOptions) error {
 			return client.CoreV1().Services(namespace).Delete(ctx, name, options)

--- a/pkg/resource/util.go
+++ b/pkg/resource/util.go
@@ -19,6 +19,7 @@ limitations under the License.
 package resource
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode"
 
@@ -74,4 +75,9 @@ func EnsureValidName(name string) string {
 
 		return c
 	}, name)
+}
+
+func ToJSON(o any) string {
+	out, _ := json.MarshalIndent(o, "", "  ")
+	return string(out)
 }

--- a/pkg/util/create_or_update_test.go
+++ b/pkg/util/create_or_update_test.go
@@ -376,6 +376,23 @@ func (t *createOrUpdateTestDriver) testUpdate(doUpdate func(util.OperationResult
 			})
 		})
 
+		Context("and the existing resource has a status but the status on update is empty", func() {
+			BeforeEach(func() {
+				t.pod.Status = corev1.PodStatus{Phase: corev1.PodPending}
+			})
+
+			JustBeforeEach(func() {
+				t.pod = test.GetPod(t.client, t.pod)
+				t.pod.Status = corev1.PodStatus{}
+			})
+
+			It("should not update the resource", func() {
+				Expect(doUpdate(util.OperationResultNone)).To(Succeed())
+				tests.EnsureNoActionsForResource(t.testingFake, "pods", "update")
+				tests.EnsureNoActionsForResource(t.testingFake, "pods/status", "update")
+			})
+		})
+
 		Context("and Update initially fails due to conflict", func() {
 			BeforeEach(func() {
 				t.client.FailOnUpdate = apierrors.NewConflict(schema.GroupResource{}, "", errors.New("conflict"))


### PR DESCRIPTION
We saw an issue with a K8s `Deployment` where the existing resource had a status field and the new resource had an empty status field but `CreateOrUpdate` still tried to update the status which led to an eventual conflict failure due to retries exhausted. The reason for this is that it merely compares the original and new statuses for equality. We should first check if the new status is even specified.

In addition:

- Removed the `UpdateStatusFunc` from the K8s resource.Interface implementations (`Deployment`, `DaemonSet` et al). The K8s controllers own the status for these resources and we should never be updating it.

- Added a `resource.ToJSON `function to provide a more user-frendly output then the default Go object stringer. Also JSON outputs pointer values rather than their addresses..
