### PR TITLE
Automated backport of #582: Add specific ToUnstructured functions

### DIFF
--- a/pkg/resource/util.go
+++ b/pkg/resource/util.go
@@ -32,12 +32,16 @@ import (
 )
 
 func ToUnstructured(from runtime.Object) (*unstructured.Unstructured, error) {
+	return ToUnstructuredUsingScheme(from, scheme.Scheme)
+}
+
+func ToUnstructuredUsingScheme(from runtime.Object, usingScheme *runtime.Scheme) (*unstructured.Unstructured, error) {
 	switch f := from.(type) {
 	case *unstructured.Unstructured:
 		return f.DeepCopy(), nil
 	default:
 		to := &unstructured.Unstructured{}
-		err := scheme.Scheme.Convert(from, to, nil)
+		err := usingScheme.Convert(from, to, nil)
 		if err != nil {
 			return nil, errors.Wrapf(err, "error converting %#v to unstructured.Unstructured", from)
 		}
@@ -47,10 +51,39 @@ func ToUnstructured(from runtime.Object) (*unstructured.Unstructured, error) {
 }
 
 func MustToUnstructured(from runtime.Object) *unstructured.Unstructured {
-	u, err := ToUnstructured(from)
+	return MustToUnstructuredUsingScheme(from, scheme.Scheme)
+}
+
+func MustToUnstructuredUsingScheme(from runtime.Object, usingScheme *runtime.Scheme) *unstructured.Unstructured {
+	u, err := ToUnstructuredUsingScheme(from, usingScheme)
 	if err != nil {
 		panic(err)
 	}
+
+	return u
+}
+
+// MustToUnstructuredUsingDefaultConverter uses runtime.DefaultUnstructuredConverter which doesn't use a runtime.Scheme
+// and thus the returned Unstructured will not have the type metadata field populated.
+func MustToUnstructuredUsingDefaultConverter(from runtime.Object) *unstructured.Unstructured {
+	var u *unstructured.Unstructured
+
+	switch f := from.(type) {
+	case *unstructured.Unstructured:
+		u = f.DeepCopy()
+	default:
+		m, err := runtime.DefaultUnstructuredConverter.ToUnstructured(from)
+		if err != nil {
+			panic(err)
+		}
+
+		u = &unstructured.Unstructured{Object: m}
+	}
+
+	// 'from' may have already contained the type metadata fields. To be consistent with this function's API contract,
+	// remove the fields just in case since we can't guarantee the fields will always be populated.
+	unstructured.RemoveNestedField(u.Object, "kind")
+	unstructured.RemoveNestedField(u.Object, "apiVersion")
 
 	return u
 }

--- a/pkg/util/create_or_update.go
+++ b/pkg/util/create_or_update.go
@@ -107,7 +107,7 @@ func maybeCreateOrUpdate(ctx context.Context, client resource.Interface, obj run
 			return errors.Wrapf(err, "error retrieving %q", objMeta.GetName())
 		}
 
-		origObj := resource.MustToUnstructured(existing)
+		origObj := resource.MustToUnstructuredUsingDefaultConverter(existing)
 
 		toUpdate, err := mutate(existing)
 		if err != nil {
@@ -116,7 +116,7 @@ func maybeCreateOrUpdate(ctx context.Context, client resource.Interface, obj run
 
 		resource.MustToMeta(toUpdate).SetResourceVersion(origObj.GetResourceVersion())
 
-		newObj := resource.MustToUnstructured(toUpdate)
+		newObj := resource.MustToUnstructuredUsingDefaultConverter(toUpdate)
 
 		origStatus := GetNestedField(origObj, StatusField)
 		newStatus, ok := GetNestedField(newObj, StatusField).(map[string]interface{})
@@ -173,7 +173,7 @@ func createResource(ctx context.Context, client resource.Interface, obj runtime.
 		return errors.Wrapf(err, "error creating %#v", obj)
 	}
 
-	status, ok := GetNestedField(resource.MustToUnstructured(obj), StatusField).(map[string]interface{})
+	status, ok := GetNestedField(resource.MustToUnstructuredUsingDefaultConverter(obj), StatusField).(map[string]interface{})
 	if ok && len(status) > 0 {
 		// If the resource CRD has the status subresource the Create won't set the status field so we need to
 		// do a separate UpdateStatus call.
@@ -233,8 +233,8 @@ func CreateAnew(ctx context.Context, client resource.Interface, obj runtime.Obje
 }
 
 func mutableFieldsEqual(existingObj, newObj runtime.Object) bool {
-	existingU := resource.MustToUnstructured(existingObj)
-	newU := resource.MustToUnstructured(newObj)
+	existingU := resource.MustToUnstructuredUsingDefaultConverter(existingObj)
+	newU := resource.MustToUnstructuredUsingDefaultConverter(newObj)
 
 	newU = CopyImmutableMetadata(existingU, newU)
 


### PR DESCRIPTION
Backport of #582 on release-0.15.

#582: Add specific ToUnstructured functions

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.