### PR TITLE
Retain status fields when UpdateStatus returns NotFound

### DIFF
--- a/pkg/util/create_or_update.go
+++ b/pkg/util/create_or_update.go
@@ -129,13 +129,12 @@ func maybeCreateOrUpdate(ctx context.Context, client resource.Interface, obj run
 
 			result = OperationResultUpdated
 
-			unstructured.RemoveNestedField(origObj.Object, StatusField)
-			unstructured.RemoveNestedField(newObj.Object, StatusField)
-
 			// UpdateStatus for generic clients (eg dynamic client) will return NotFound error if the resource CRD
 			// doesn't have the status subresource so we'll ignore it.
 			updated, err := client.UpdateStatus(ctx, toUpdate, metav1.UpdateOptions{})
 			if err == nil {
+				unstructured.RemoveNestedField(origObj.Object, StatusField)
+				unstructured.RemoveNestedField(newObj.Object, StatusField)
 				resource.MustToMeta(toUpdate).SetResourceVersion(resource.MustToMeta(updated).GetResourceVersion())
 			} else if !apierrors.IsNotFound(err) {
 				return errors.Wrapf(err, "error updating status %s", resource.ToJSON(toUpdate))

--- a/pkg/util/create_or_update_test.go
+++ b/pkg/util/create_or_update_test.go
@@ -374,6 +374,17 @@ func (t *createOrUpdateTestDriver) testUpdate(doUpdate func(util.OperationResult
 				Expect(test.GetPod(t.client, t.pod).Status).To(Equal(t.pod.Status))
 				tests.EnsureNoActionsForResource(t.testingFake, "pods", "update")
 			})
+
+			Context("and UpdateStatus returns NotFound", func() {
+				JustBeforeEach(func() {
+					fake.FailOnAction(t.testingFake, "pods/status", "update", apierrors.NewNotFound(schema.GroupResource{}, ""), false)
+				})
+
+				It("should update the status", func() {
+					Expect(doUpdate(util.OperationResultUpdated)).To(Succeed())
+					Expect(test.GetPod(t.client, t.pod).Status).To(Equal(t.pod.Status))
+				})
+			})
 		})
 
 		Context("and the existing resource has a status but the status on update is empty", func() {


### PR DESCRIPTION
...in `maybeCreateOrUpdate` so it will observe the resource as having changed and proceed with the normal Update.