### PR TITLE
AwaitStopped should do just that

### DIFF
--- a/pkg/syncer/resource_syncer.go
+++ b/pkg/syncer/resource_syncer.go
@@ -266,7 +266,7 @@ func (r *resourceSyncer) Start(stopCh <-chan struct{}) error {
 			r.stopped <- struct{}{}
 			r.log.V(log.LIBDEBUG).Infof("Syncer %q stopped", r.config.Name)
 		}()
-		defer r.workQueue.ShutDown()
+		defer r.workQueue.ShutDownWithDrain()
 
 		r.informer.Run(stopCh)
 	}()

--- a/pkg/workqueue/queue.go
+++ b/pkg/workqueue/queue.go
@@ -39,6 +39,7 @@ type Interface interface {
 	NumRequeues(key string) int
 	Run(stopCh <-chan struct{}, process ProcessFunc)
 	ShutDown()
+	ShutDownWithDrain()
 }
 
 type queueType struct {
@@ -117,4 +118,20 @@ func (q *queueType) processNextWorkItem(process ProcessFunc) bool {
 
 func (q *queueType) NumRequeues(key string) int {
 	return q.RateLimitingInterface.NumRequeues(key)
+}
+
+func (q *queueType) ShutDownWithDrain() {
+	done := make(chan struct{})
+
+	// ShutDownWithDrain waits for all in-flight work to complete and thus could block indefinitely so put a deadline on it.
+	go func() {
+		q.RateLimitingInterface.ShutDownWithDrain()
+		done <- struct{}{}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		logger.Warningf("%s: timed out draining the queue on shut down", q.name)
+	}
 }


### PR DESCRIPTION
When the `stopCh` is closed, the resource syncer shuts down the `workQueue` via `ShutDown` but this only ignores new items added to it. Use `ShutDownWithDrain` instead which waits for processing to complete on all existing items in the queue.

One caveat is that `ShutDownWithDrain` blocks indefinitely so put a deadline on it.

**Note**: This is needed to fix an intermittent unit test failure in **lighthouse**.
