### PR TITLE
Add IsNotFoundErr function

### DIFF
--- a/pkg/resource/errors.go
+++ b/pkg/resource/errors.go
@@ -1,0 +1,44 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"errors"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/client-go/discovery"
+)
+
+func IsNotFoundErr(err error) bool {
+	if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
+		return true
+	}
+
+	var errGDF *discovery.ErrGroupDiscoveryFailed
+	if !errors.As(err, &errGDF) {
+		return false
+	}
+
+	for _, err := range errGDF.Groups {
+		return IsNotFoundErr(err)
+	}
+
+	return false
+}

--- a/pkg/resource/errors_test.go
+++ b/pkg/resource/errors_test.go
@@ -1,0 +1,69 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource_test
+
+import (
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/resource"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+)
+
+var _ = Describe("IsNotFoundErr", func() {
+	When("the error is NotFound", func() {
+		It("should return true", func() {
+			Expect(resource.IsNotFoundErr(apierrors.NewNotFound(schema.GroupResource{}, "foo"))).To(BeTrue())
+		})
+	})
+
+	When("the error is NoMatchError", func() {
+		It("should return true", func() {
+			Expect(resource.IsNotFoundErr(&meta.NoKindMatchError{})).To(BeTrue())
+		})
+	})
+
+	When("the error is ErrGroupDiscoveryFailed", func() {
+		Context("and the underlying error is NotFound", func() {
+			It("should return true", func() {
+				Expect(resource.IsNotFoundErr(&discovery.ErrGroupDiscoveryFailed{
+					Groups: map[schema.GroupVersion]error{{}: apierrors.NewNotFound(schema.GroupResource{}, "foo")},
+				})).To(BeTrue())
+			})
+		})
+
+		Context("and the underlying error does not indicate not found", func() {
+			It("should return false", func() {
+				Expect(resource.IsNotFoundErr(&discovery.ErrGroupDiscoveryFailed{
+					Groups: map[schema.GroupVersion]error{{}: apierrors.NewServiceUnavailable("")},
+				})).To(BeFalse())
+			})
+		})
+	})
+
+	When("the error does not indicate not found", func() {
+		It("should return false", func() {
+			Expect(resource.IsNotFoundErr(apierrors.NewForbidden(schema.GroupResource{}, "foo", errors.New("")))).To(BeFalse())
+		})
+	})
+})


### PR DESCRIPTION
When retrieving a resource, the following errors can occur:

- `apierrors.IsNotFound` : if the resource doesn't exist
- `meta.IsNoMatchError` : if the resource's Kind doesn't exist
- `discovery.ErrGroupDiscoveryFailed` (new in **controller-runtime** 0.15) : if the resource's group doesn't exist.

There are various places where we try to retrieve a resource where the CRD may not exist. Add a function to consolidate the above checks.