### PR TITLE
dependabot: don't ignore parent indirect dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,13 +33,10 @@ updates:
       # Our own dependencies are handled during releases
       - dependency-name: github.com/submariner-io/*
       # Managed in shipyard
-      - dependency-name: github.com/go-logr/logr
       - dependency-name: github.com/onsi/ginkgo/v2
       - dependency-name: github.com/onsi/gomega
       - dependency-name: github.com/pkg/errors
-      - dependency-name: golang.org/x/time
       - dependency-name: k8s.io/api
       - dependency-name: k8s.io/apimachinery
       - dependency-name: k8s.io/client-go
       - dependency-name: k8s.io/klog
-      - dependency-name: sigs.k8s.io/yaml


### PR DESCRIPTION
Some of the ignored dependencies, delegated to Shipyard, are indirect dependencies in Shipyard, and therefore won't get dependabot PRs. This unignores these dependencies.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
