### PR TITLE
Add list resources by label selector method to syncer interfaces

### DIFF
--- a/pkg/resource/util.go
+++ b/pkg/resource/util.go
@@ -88,7 +88,7 @@ func MustToUnstructuredUsingDefaultConverter(from runtime.Object) *unstructured.
 	return u
 }
 
-func MustToMeta(obj runtime.Object) metav1.Object {
+func MustToMeta(obj interface{}) metav1.Object {
 	objMeta, err := meta.Accessor(obj)
 	if err != nil {
 		panic(err)

--- a/pkg/syncer/broker/syncer.go
+++ b/pkg/syncer/broker/syncer.go
@@ -32,6 +32,7 @@ import (
 	"github.com/submariner-io/admiral/pkg/syncer"
 	"github.com/submariner-io/admiral/pkg/util"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
@@ -370,6 +371,15 @@ func (s *Syncer) ListLocalResources(ofType runtime.Object) ([]runtime.Object, er
 	}
 
 	return ls.ListResources() //nolint:wrapcheck // OK to return the error as is.
+}
+
+func (s *Syncer) ListLocalResourcesBySelector(ofType runtime.Object, selector labels.Selector) []runtime.Object {
+	ls, found := s.localSyncers[reflect.TypeOf(ofType)]
+	if !found {
+		panic(fmt.Errorf("no Syncer found for %#v", ofType))
+	}
+
+	return ls.ListResourcesBySelector(selector)
 }
 
 func (s *Syncer) GetBrokerNamespace() string {

--- a/pkg/syncer/broker/syncer_test.go
+++ b/pkg/syncer/broker/syncer_test.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -441,6 +442,18 @@ var _ = Describe("Broker Syncer", func() {
 
 			list, err := syncer.ListLocalResources(resource)
 			Expect(err).To(Succeed())
+			Expect(list).To(HaveLen(1))
+			Expect(list[0]).To(BeAssignableToTypeOf(&corev1.Pod{}))
+			Expect(&list[0].(*corev1.Pod).Spec).To(Equal(&resource.Spec))
+		})
+	})
+
+	When("ListLocalResourcesBySelector is called", func() {
+		It("should return the correct resources", func() {
+			test.CreateResource(localClient, resource)
+			test.AwaitResource(brokerClient, resource.GetName())
+
+			list := syncer.ListLocalResourcesBySelector(resource, labels.Set(resource.Labels).AsSelector())
 			Expect(list).To(HaveLen(1))
 			Expect(list[0]).To(BeAssignableToTypeOf(&corev1.Pod{}))
 			Expect(&list[0].(*corev1.Pod).Spec).To(Equal(&resource.Spec))

--- a/pkg/syncer/broker/syncer_test.go
+++ b/pkg/syncer/broker/syncer_test.go
@@ -440,8 +440,7 @@ var _ = Describe("Broker Syncer", func() {
 			test.CreateResource(localClient, resource)
 			test.AwaitResource(brokerClient, resource.GetName())
 
-			list, err := syncer.ListLocalResources(resource)
-			Expect(err).To(Succeed())
+			list := syncer.ListLocalResources(resource)
 			Expect(list).To(HaveLen(1))
 			Expect(list[0]).To(BeAssignableToTypeOf(&corev1.Pod{}))
 			Expect(&list[0].(*corev1.Pod).Spec).To(Equal(&resource.Spec))

--- a/pkg/syncer/resource_syncer.go
+++ b/pkg/syncer/resource_syncer.go
@@ -38,7 +38,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -310,8 +309,8 @@ func (r *resourceSyncer) GetResource(name, namespace string) (runtime.Object, bo
 	return converted, true, nil
 }
 
-func (r *resourceSyncer) ListResources() ([]runtime.Object, error) {
-	return r.ListResourcesBySelector(k8slabels.Everything()), nil
+func (r *resourceSyncer) ListResources() []runtime.Object {
+	return r.ListResourcesBySelector(k8slabels.Everything())
 }
 
 func (r *resourceSyncer) ListResourcesBySelector(selector k8slabels.Selector) []runtime.Object {
@@ -330,10 +329,7 @@ func (r *resourceSyncer) ListResourcesBySelector(selector k8slabels.Selector) []
 			continue
 		}
 
-		converted, err := r.convert(obj.(*unstructured.Unstructured))
-		utilruntime.Must(err)
-
-		retObjects = append(retObjects, converted)
+		retObjects = append(retObjects, r.convertNoError(obj.(*unstructured.Unstructured)))
 	}
 
 	return retObjects

--- a/pkg/syncer/resource_syncer.go
+++ b/pkg/syncer/resource_syncer.go
@@ -36,7 +36,9 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -309,23 +311,32 @@ func (r *resourceSyncer) GetResource(name, namespace string) (runtime.Object, bo
 }
 
 func (r *resourceSyncer) ListResources() ([]runtime.Object, error) {
+	return r.ListResourcesBySelector(k8slabels.Everything()), nil
+}
+
+func (r *resourceSyncer) ListResourcesBySelector(selector k8slabels.Selector) []runtime.Object {
 	if ok := cache.WaitForCacheSync(r.stopCh, r.informer.HasSynced); !ok {
-		return nil, fmt.Errorf("failed to wait for informer cache to sync")
+		// This means the cache was stopped.
+		r.log.Warningf("Syncer %q failed to wait for informer cache to sync while listing resources", r.config.Name)
+
+		return []runtime.Object{}
 	}
 
 	list := r.store.List()
 	retObjects := make([]runtime.Object, 0, len(list))
 
 	for _, obj := range list {
-		converted, err := r.convert(obj.(*unstructured.Unstructured))
-		if err != nil {
-			return nil, err
+		if !selector.Matches(k8slabels.Set(resourceUtil.MustToMeta(obj).GetLabels())) {
+			continue
 		}
+
+		converted, err := r.convert(obj.(*unstructured.Unstructured))
+		utilruntime.Must(err)
 
 		retObjects = append(retObjects, converted)
 	}
 
-	return retObjects, nil
+	return retObjects
 }
 
 func (r *resourceSyncer) Reconcile(resourceLister func() []runtime.Object) {

--- a/pkg/syncer/resource_syncer_test.go
+++ b/pkg/syncer/resource_syncer_test.go
@@ -872,8 +872,7 @@ func testListResources() {
 	})
 
 	It("should return all the resources", func() {
-		list, err := d.syncer.ListResources()
-		Expect(err).To(Succeed())
+		list := d.syncer.ListResources()
 		assertResourceList(list, d.resource, resource2)
 	})
 }

--- a/pkg/syncer/resource_syncer_test.go
+++ b/pkg/syncer/resource_syncer_test.go
@@ -20,6 +20,7 @@ package syncer_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync/atomic"
 	"time"
 
@@ -36,6 +37,7 @@ import (
 	metaapi "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -58,6 +60,7 @@ var _ = Describe("Resource Syncer", func() {
 	Describe("Update Suppression", testUpdateSuppression)
 	Describe("GetResource", testGetResource)
 	Describe("ListResources", testListResources)
+	Describe("ListResourcesBySelector", testListResourcesBySelector)
 })
 
 func testLocalToRemote() {
@@ -852,6 +855,7 @@ func testListResources() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "apache-pod",
 				Namespace: d.resource.Namespace,
+				Labels:    map[string]string{"foo": "bar"},
 			},
 			Spec: corev1.PodSpec{
 				Containers: []corev1.Container{
@@ -870,18 +874,105 @@ func testListResources() {
 	It("should return all the resources", func() {
 		list, err := d.syncer.ListResources()
 		Expect(err).To(Succeed())
-
-		expected := map[string]*corev1.PodSpec{d.resource.Name: &d.resource.Spec, resource2.Name: &resource2.Spec}
-
-		Expect(list).To(HaveLen(len(expected)))
-		for _, actual := range list {
-			meta, err := metaapi.Accessor(actual)
-			Expect(err).To(Succeed())
-			Expect(actual).To(BeAssignableToTypeOf(&corev1.Pod{}))
-			Expect(&actual.(*corev1.Pod).Spec).To(Equal(expected[meta.GetName()]))
-			delete(expected, meta.GetName())
-		}
+		assertResourceList(list, d.resource, resource2)
 	})
+}
+
+func testListResourcesBySelector() {
+	d := newTestDiver(test.LocalNamespace, "", syncer.LocalToRemote)
+
+	newPod := func(i int, labels map[string]string) *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("pod%d", i),
+				Namespace: fmt.Sprintf("namespace%d", i),
+				Labels:    labels,
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Image: fmt.Sprintf("image%d", i),
+						Name:  fmt.Sprintf("container%d", i),
+					},
+				},
+			},
+		}
+	}
+
+	var (
+		pod1 = newPod(1, map[string]string{
+			"foo":    "bar",
+			"label1": "match",
+			"label2": "no-match",
+		})
+
+		pod2 = newPod(2, map[string]string{
+			"label1": "match",
+		})
+
+		pod3 = newPod(3, map[string]string{
+			"label1": "no-match",
+			"label2": "match",
+		})
+
+		pod4 = newPod(4, map[string]string{
+			"label1": "no-match",
+		})
+
+		pod5 = newPod(5, map[string]string{
+			"label1": "match",
+			"label2": "match",
+		})
+	)
+
+	BeforeEach(func() {
+		d.addInitialResource(d.resource)
+		d.addInitialResource(pod1)
+		d.addInitialResource(pod2)
+		d.addInitialResource(pod3)
+		d.addInitialResource(pod4)
+		d.addInitialResource(pod5)
+	})
+
+	It("should return correct resources for label1 selector", func() {
+		list := d.syncer.ListResourcesBySelector(labels.Set(map[string]string{"label1": "match"}).AsSelector())
+		assertResourceList(list, pod1, pod2, pod5)
+	})
+
+	It("should return correct resources for label2 selector", func() {
+		list := d.syncer.ListResourcesBySelector(labels.Set(map[string]string{"label2": "match"}).AsSelector())
+		assertResourceList(list, pod3, pod5)
+	})
+
+	It("should return correct resources for label1 and label2 selector", func() {
+		list := d.syncer.ListResourcesBySelector(labels.Set(map[string]string{
+			"label1": "match",
+			"label2": "match",
+		}).AsSelector())
+		assertResourceList(list, pod5)
+	})
+
+	It("should return no resources for label3 selector", func() {
+		list := d.syncer.ListResourcesBySelector(labels.Set(map[string]string{"label3": "match"}).AsSelector())
+		assertResourceList(list)
+	})
+}
+
+func assertResourceList(actual []runtime.Object, expected ...*corev1.Pod) {
+	expSpecs := map[string]*corev1.PodSpec{}
+	for _, p := range expected {
+		expSpecs[p.Name] = &p.Spec
+	}
+
+	Expect(actual).To(HaveLen(len(expSpecs)))
+
+	for _, obj := range actual {
+		meta, err := metaapi.Accessor(obj)
+		Expect(err).To(Succeed())
+		Expect(obj).To(BeAssignableToTypeOf(&corev1.Pod{}))
+		Expect(&obj.(*corev1.Pod).Spec).To(Equal(expSpecs[meta.GetName()]))
+		delete(expSpecs, meta.GetName())
+	}
 }
 
 type testDriver struct {

--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -18,12 +18,16 @@ limitations under the License.
 
 package syncer
 
-import "k8s.io/apimachinery/pkg/runtime"
+import (
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+)
 
 type Interface interface {
 	Start(stopCh <-chan struct{}) error
 	AwaitStopped()
 	GetResource(name, namespace string) (runtime.Object, bool, error)
 	ListResources() ([]runtime.Object, error)
+	ListResourcesBySelector(selector labels.Selector) []runtime.Object
 	Reconcile(resourceLister func() []runtime.Object)
 }

--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -27,7 +27,7 @@ type Interface interface {
 	Start(stopCh <-chan struct{}) error
 	AwaitStopped()
 	GetResource(name, namespace string) (runtime.Object, bool, error)
-	ListResources() ([]runtime.Object, error)
+	ListResources() []runtime.Object
 	ListResourcesBySelector(selector labels.Selector) []runtime.Object
 	Reconcile(resourceLister func() []runtime.Object)
 }


### PR DESCRIPTION
It's useful for users to query resources by selector filter rather than list all resources and filter afterwards.

The new method does not return an error, as `ListResources` does, to simplify usage. There are 2 error cases, neither of which is recoverable by the caller:
    
 - `cache.WaitForCacheSync` returns false. This means the informer was stopped so log a warning and return an empty list.
 - conversion from `Unstructured` to the resource type failed which is a programming error and shouldn't happen so use `r.convertNoError`. In fact, we really should just panic but that can be done in a separate PR.

The new method is called by `ListResources` which now can no longer return an error so error was removed from the return signature.

