### PR TITLE
Log the function failing to process a queue item

### DIFF
--- a/pkg/workqueue/queue.go
+++ b/pkg/workqueue/queue.go
@@ -103,7 +103,7 @@ func (q *queueType) processNextWorkItem(process ProcessFunc) bool {
 		return process(key, name, ns)
 	}()
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("%s: Failed to process object with key %q: %w", q.name, key, err))
+		utilruntime.HandleError(fmt.Errorf("%s: Failed to process object with key %q using function %#v: %w", q.name, key, process, err))
 	}
 
 	if requeue {


### PR DESCRIPTION
When a processing function fails to handle a queue item, log its name as well as the description of the object being processed.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
