### PR TITLE
Handle GenerateName in util.CreateOrUpdate

### DIFF
--- a/pkg/fake/dynamic_client.go
+++ b/pkg/fake/dynamic_client.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/fake"
@@ -146,6 +147,14 @@ func (f *DynamicResourceClient) Create(ctx context.Context, obj *unstructured.Un
 	fail = getError(f.PersistentFailOnCreate)
 	if fail != nil {
 		return nil, fail
+	}
+
+	if obj.GetName() == "" && obj.GetGenerateName() != "" {
+		obj.SetName(fmt.Sprintf("%s%s", obj.GetGenerateName(), utilrand.String(5)))
+	}
+
+	if obj.GetName() == "" {
+		return nil, fmt.Errorf("resource name may not be empty")
 	}
 
 	obj.SetUID(uuid.NewUUID())

--- a/pkg/federate/base_federator.go
+++ b/pkg/federate/base_federator.go
@@ -46,10 +46,13 @@ func newBaseFederator(dynClient dynamic.Interface, restMapper meta.RESTMapper, t
 	keepMetadataField ...string,
 ) *baseFederator {
 	b := &baseFederator{
-		dynClient:          dynClient,
-		restMapper:         restMapper,
-		targetNamespace:    targetNamespace,
-		keepMetadataFields: map[string]bool{"name": true, "namespace": true, util.LabelsField: true, util.AnnotationsField: true},
+		dynClient:       dynClient,
+		restMapper:      restMapper,
+		targetNamespace: targetNamespace,
+		keepMetadataFields: map[string]bool{
+			"name": true, "namespace": true, "generateName": true,
+			util.LabelsField: true, util.AnnotationsField: true,
+		},
 	}
 
 	for _, field := range keepMetadataField {

--- a/pkg/resource/dynamic.go
+++ b/pkg/resource/dynamic.go
@@ -71,6 +71,13 @@ func (d *dynamicType) Delete(ctx context.Context, name string,
 	return d.client.Delete(ctx, name, options)
 }
 
+func (d *dynamicType) List(ctx context.Context,
+	options metav1.ListOptions, //nolint:gocritic // hugeParam - we're matching K8s API
+) ([]runtime.Object, error) {
+	l, err := d.client.List(ctx, options)
+	return MustExtractList(l), err
+}
+
 func ForDynamic(client dynamic.ResourceInterface) *InterfaceFuncs {
 	t := &dynamicType{client: client}
 
@@ -80,5 +87,6 @@ func ForDynamic(client dynamic.ResourceInterface) *InterfaceFuncs {
 		UpdateFunc:       t.Update,
 		UpdateStatusFunc: t.UpdateStatus,
 		DeleteFunc:       t.Delete,
+		ListFunc:         t.List,
 	}
 }

--- a/pkg/resource/interface_test.go
+++ b/pkg/resource/interface_test.go
@@ -1,0 +1,275 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/resource"
+	"github.com/submariner-io/admiral/pkg/syncer/test"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/kubernetes/scheme"
+	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("Interface", func() {
+	Context("ForDaemonSet", func() {
+		testInterfaceFuncs(func() resource.Interface {
+			return resource.ForDaemonSet(k8sfake.NewSimpleClientset(), test.LocalNamespace)
+		}, &appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: test.LocalNamespace,
+			},
+			Spec: appsv1.DaemonSetSpec{
+				MinReadySeconds: 3,
+			},
+		})
+	})
+
+	Context("ForDeployment", func() {
+		testInterfaceFuncs(func() resource.Interface {
+			return resource.ForDeployment(k8sfake.NewSimpleClientset(), test.LocalNamespace)
+		}, &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: test.LocalNamespace,
+			},
+			Spec: appsv1.DeploymentSpec{
+				MinReadySeconds: 3,
+			},
+		})
+	})
+
+	Context("ForNamespace", func() {
+		testInterfaceFuncs(func() resource.Interface {
+			return resource.ForNamespace(k8sfake.NewSimpleClientset())
+		}, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+			},
+		})
+	})
+
+	Context("ForPod", func() {
+		testInterfaceFuncs(func() resource.Interface {
+			return resource.ForPod(k8sfake.NewSimpleClientset(), test.LocalNamespace)
+		}, &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: test.LocalNamespace,
+			},
+			Spec: corev1.PodSpec{
+				Hostname: "my-host",
+			},
+		})
+	})
+
+	Context("ForService", func() {
+		testInterfaceFuncs(func() resource.Interface {
+			return resource.ForService(k8sfake.NewSimpleClientset(), test.LocalNamespace)
+		}, &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: test.LocalNamespace,
+			},
+			Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeClusterIP,
+			},
+		})
+	})
+
+	Context("ForServiceAccount", func() {
+		testInterfaceFuncs(func() resource.Interface {
+			return resource.ForServiceAccount(k8sfake.NewSimpleClientset(), test.LocalNamespace)
+		}, &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: test.LocalNamespace,
+			},
+		})
+	})
+
+	Context("ForClusterRole", func() {
+		testInterfaceFuncs(func() resource.Interface {
+			return resource.ForClusterRole(k8sfake.NewSimpleClientset())
+		}, &rbacv1.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+			},
+		})
+	})
+
+	Context("ForClusterRoleBinding", func() {
+		testInterfaceFuncs(func() resource.Interface {
+			return resource.ForClusterRoleBinding(k8sfake.NewSimpleClientset())
+		}, &rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+			},
+		})
+	})
+
+	Context("ForRole", func() {
+		testInterfaceFuncs(func() resource.Interface {
+			return resource.ForRole(k8sfake.NewSimpleClientset(), test.LocalNamespace)
+		}, &rbacv1.Role{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: test.LocalNamespace,
+			},
+		})
+	})
+
+	Context("ForRoleBinding", func() {
+		testInterfaceFuncs(func() resource.Interface {
+			return resource.ForRoleBinding(k8sfake.NewSimpleClientset(), test.LocalNamespace)
+		}, &rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: test.LocalNamespace,
+			},
+		})
+	})
+
+	Context("ForConfigMap", func() {
+		testInterfaceFuncs(func() resource.Interface {
+			return resource.ForConfigMap(k8sfake.NewSimpleClientset(), test.LocalNamespace)
+		}, &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: test.LocalNamespace,
+			},
+			Data: map[string]string{"one": "two"},
+		})
+	})
+
+	Context("ForListableControllerClient", func() {
+		testInterfaceFuncs(func() resource.Interface {
+			return resource.ForListableControllerClient(clientfake.NewClientBuilder().WithScheme(scheme.Scheme).Build(),
+				test.LocalNamespace, &corev1.Pod{}, &corev1.PodList{})
+		}, &corev1.Pod{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Pod",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: test.LocalNamespace,
+			},
+			Spec: corev1.PodSpec{
+				Hostname: "my-host",
+			},
+		})
+	})
+
+	Context("ForDynamic", func() {
+		testInterfaceFuncs(func() resource.Interface {
+			return resource.ForDynamic(dynamicfake.NewSimpleDynamicClient(scheme.Scheme).Resource(
+				schema.GroupVersionResource{
+					Group:    corev1.SchemeGroupVersion.Group,
+					Version:  corev1.SchemeGroupVersion.Version,
+					Resource: "pods",
+				}).Namespace(test.LocalNamespace))
+		}, resource.MustToUnstructured(&corev1.Pod{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Pod",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: test.LocalNamespace,
+			},
+			Spec: corev1.PodSpec{
+				Hostname: "my-host",
+			},
+		}))
+	})
+})
+
+func testInterfaceFuncs(newInterface func() resource.Interface, initialObj runtime.Object) {
+	Specify("verify functions", func() {
+		sanitize := func(o runtime.Object) runtime.Object {
+			m := resource.MustToMeta(o)
+			m.SetResourceVersion("")
+			m.SetCreationTimestamp(metav1.Time{})
+
+			return o
+		}
+
+		i := newInterface()
+		initialObj = sanitize(initialObj)
+
+		another := initialObj.DeepCopyObject()
+		resource.MustToMeta(another).SetName(resource.MustToMeta(initialObj).GetName() + "-2")
+
+		// Create
+		actual, err := i.Create(context.Background(), initialObj, metav1.CreateOptions{})
+		Expect(err).To(Succeed())
+
+		objMeta := resource.MustToMeta(actual)
+		actual = sanitize(actual)
+		Expect(actual).To(Equal(initialObj))
+
+		// Get
+		obj, err := i.Get(context.Background(), objMeta.GetName(), metav1.GetOptions{})
+		Expect(err).To(Succeed())
+		Expect(sanitize(obj)).To(Equal(actual))
+
+		// Update
+		objMeta.SetLabels(map[string]string{"foo": "bar"})
+		obj, err = i.Update(context.Background(), actual, metav1.UpdateOptions{})
+		Expect(err).To(Succeed())
+		Expect(sanitize(obj)).To(Equal(actual))
+
+		// List
+		list, err := i.List(context.Background(), metav1.ListOptions{})
+		Expect(err).To(Succeed())
+		Expect(list).To(HaveLen(1))
+		Expect(sanitize(list[0])).To(Equal(actual))
+
+		// List with label selector
+		_, err = i.Create(context.Background(), another, metav1.CreateOptions{})
+		Expect(err).To(Succeed())
+
+		list, err = i.List(context.Background(), metav1.ListOptions{
+			LabelSelector: labels.SelectorFromSet(objMeta.GetLabels()).String(),
+		})
+		Expect(err).To(Succeed())
+		Expect(list).To(HaveLen(1))
+		Expect(sanitize(list[0])).To(Equal(actual))
+
+		// Delete
+		err = i.Delete(context.Background(), objMeta.GetName(), metav1.DeleteOptions{})
+		Expect(err).To(Succeed())
+		_, err = i.Get(context.Background(), objMeta.GetName(), metav1.GetOptions{})
+		Expect(apierrors.IsNotFound(err)).To(BeTrue())
+	})
+}

--- a/pkg/resource/kubernetes.go
+++ b/pkg/resource/kubernetes.go
@@ -26,8 +26,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes"
 	controllerClient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -51,6 +53,10 @@ func ForDaemonSet(client kubernetes.Interface, namespace string) Interface {
 		DeleteFunc: func(ctx context.Context, name string, options metav1.DeleteOptions) error {
 			return client.AppsV1().DaemonSets(namespace).Delete(ctx, name, options)
 		},
+		ListFunc: func(ctx context.Context, options metav1.ListOptions) ([]runtime.Object, error) {
+			l, err := client.AppsV1().DaemonSets(namespace).List(ctx, options)
+			return MustExtractList(l), err
+		},
 	}
 }
 
@@ -68,6 +74,10 @@ func ForDeployment(client kubernetes.Interface, namespace string) Interface {
 		},
 		DeleteFunc: func(ctx context.Context, name string, options metav1.DeleteOptions) error {
 			return client.AppsV1().Deployments(namespace).Delete(ctx, name, options)
+		},
+		ListFunc: func(ctx context.Context, options metav1.ListOptions) ([]runtime.Object, error) {
+			l, err := client.AppsV1().Deployments(namespace).List(ctx, options)
+			return MustExtractList(l), err
 		},
 	}
 }
@@ -89,6 +99,10 @@ func ForNamespace(client kubernetes.Interface) Interface {
 		DeleteFunc: func(ctx context.Context, name string, options metav1.DeleteOptions) error {
 			return client.CoreV1().Namespaces().Delete(ctx, name, options)
 		},
+		ListFunc: func(ctx context.Context, options metav1.ListOptions) ([]runtime.Object, error) {
+			l, err := client.CoreV1().Namespaces().List(ctx, options)
+			return MustExtractList(l), err
+		},
 	}
 }
 
@@ -106,6 +120,10 @@ func ForPod(client kubernetes.Interface, namespace string) Interface {
 		},
 		DeleteFunc: func(ctx context.Context, name string, options metav1.DeleteOptions) error {
 			return client.CoreV1().Pods(namespace).Delete(ctx, name, options)
+		},
+		ListFunc: func(ctx context.Context, options metav1.ListOptions) ([]runtime.Object, error) {
+			l, err := client.CoreV1().Pods(namespace).List(ctx, options)
+			return MustExtractList(l), err
 		},
 	}
 }
@@ -125,6 +143,10 @@ func ForService(client kubernetes.Interface, namespace string) Interface {
 		DeleteFunc: func(ctx context.Context, name string, options metav1.DeleteOptions) error {
 			return client.CoreV1().Services(namespace).Delete(ctx, name, options)
 		},
+		ListFunc: func(ctx context.Context, options metav1.ListOptions) ([]runtime.Object, error) {
+			l, err := client.CoreV1().Services(namespace).List(ctx, options)
+			return MustExtractList(l), err
+		},
 	}
 }
 
@@ -142,6 +164,10 @@ func ForServiceAccount(client kubernetes.Interface, namespace string) Interface 
 		},
 		DeleteFunc: func(ctx context.Context, name string, options metav1.DeleteOptions) error {
 			return client.CoreV1().ServiceAccounts(namespace).Delete(ctx, name, options)
+		},
+		ListFunc: func(ctx context.Context, options metav1.ListOptions) ([]runtime.Object, error) {
+			l, err := client.CoreV1().ServiceAccounts(namespace).List(ctx, options)
+			return MustExtractList(l), err
 		},
 	}
 }
@@ -163,6 +189,10 @@ func ForClusterRole(client kubernetes.Interface) Interface {
 		DeleteFunc: func(ctx context.Context, name string, options metav1.DeleteOptions) error {
 			return client.RbacV1().ClusterRoles().Delete(ctx, name, options)
 		},
+		ListFunc: func(ctx context.Context, options metav1.ListOptions) ([]runtime.Object, error) {
+			l, err := client.RbacV1().ClusterRoles().List(ctx, options)
+			return MustExtractList(l), err
+		},
 	}
 }
 
@@ -180,6 +210,10 @@ func ForClusterRoleBinding(client kubernetes.Interface) Interface {
 		},
 		DeleteFunc: func(ctx context.Context, name string, options metav1.DeleteOptions) error {
 			return client.RbacV1().ClusterRoleBindings().Delete(ctx, name, options)
+		},
+		ListFunc: func(ctx context.Context, options metav1.ListOptions) ([]runtime.Object, error) {
+			l, err := client.RbacV1().ClusterRoleBindings().List(ctx, options)
+			return MustExtractList(l), err
 		},
 	}
 }
@@ -199,6 +233,10 @@ func ForRole(client kubernetes.Interface, namespace string) Interface {
 		DeleteFunc: func(ctx context.Context, name string, options metav1.DeleteOptions) error {
 			return client.RbacV1().Roles(namespace).Delete(ctx, name, options)
 		},
+		ListFunc: func(ctx context.Context, options metav1.ListOptions) ([]runtime.Object, error) {
+			l, err := client.RbacV1().Roles(namespace).List(ctx, options)
+			return MustExtractList(l), err
+		},
 	}
 }
 
@@ -217,6 +255,10 @@ func ForRoleBinding(client kubernetes.Interface, namespace string) Interface {
 		DeleteFunc: func(ctx context.Context, name string, options metav1.DeleteOptions) error {
 			return client.RbacV1().RoleBindings(namespace).Delete(ctx, name, options)
 		},
+		ListFunc: func(ctx context.Context, options metav1.ListOptions) ([]runtime.Object, error) {
+			l, err := client.RbacV1().RoleBindings(namespace).List(ctx, options)
+			return MustExtractList(l), err
+		},
 	}
 }
 
@@ -234,6 +276,10 @@ func ForConfigMap(client kubernetes.Interface, namespace string) Interface {
 		},
 		DeleteFunc: func(ctx context.Context, name string, options metav1.DeleteOptions) error {
 			return client.CoreV1().ConfigMaps(namespace).Delete(ctx, name, options)
+		},
+		ListFunc: func(ctx context.Context, options metav1.ListOptions) ([]runtime.Object, error) {
+			l, err := client.CoreV1().ConfigMaps(namespace).List(ctx, options)
+			return MustExtractList(l), err
 		},
 	}
 }
@@ -268,4 +314,28 @@ func ForControllerClient(client controllerClient.Client, namespace string, objTy
 			return client.Delete(ctx, obj)
 		},
 	}
+}
+
+func ForListableControllerClient(client controllerClient.Client, namespace string, objType controllerClient.Object,
+	listType controllerClient.ObjectList,
+) *InterfaceFuncs {
+	i := ForControllerClient(client, namespace, objType)
+	i.ListFunc = func(ctx context.Context, options metav1.ListOptions) ([]runtime.Object, error) {
+		opts := []controllerClient.ListOption{controllerClient.InNamespace(namespace)}
+
+		if options.LabelSelector != "" {
+			s, err := labels.Parse(options.LabelSelector)
+			utilruntime.Must(err)
+
+			opts = append(opts, controllerClient.MatchingLabelsSelector{Selector: s})
+		}
+
+		list := listType.DeepCopyObject().(controllerClient.ObjectList)
+
+		err := client.List(ctx, list, opts...)
+
+		return MustExtractList(list), err
+	}
+
+	return i
 }


### PR DESCRIPTION
If `Name` is empty and `GenerateName` is set in the target resource, use the `List` method to obtain the existing resource by label selector. The motivating use case is for transforming `EndpointSlices` in **lighthouse** via a resource syncer. Instead of constructing a well-known name by concatenating various fields and risking exceeding the max length, we can use the `GenerateName` functionality. This means we need to find the target by some other means than its name. Using List by its labels makes sense although it assumes the labels uniquely identify the target resource. In order to use the `GenerateName` functionality, the caller has to ensure label uniqueness.

This requires adding a `List` method to the `resource.Interface` ([first commit](https://github.com/submariner-io/admiral/pull/687/commits/ab6549ec997088f21c7db5d8129fc226e68374a4)). In addition, add support for `GenerateName` in the fake dynamic client.