### PR TITLE
Add fake client reactors to mimic real K8s behavior

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	k8s.io/apimachinery v0.27.3
 	k8s.io/client-go v0.27.3
 	k8s.io/klog v1.0.0
-	k8s.io/utils v0.0.0-20230711102312-30195339c3c7
+	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
 	sigs.k8s.io/controller-runtime v0.15.0
 	sigs.k8s.io/yaml v1.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -645,8 +645,8 @@ k8s.io/kube-openapi v0.0.0-20230501164219-8b0f38b5fd1f h1:2kWPakN3i/k81b0gvD5C5F
 k8s.io/kube-openapi v0.0.0-20230501164219-8b0f38b5fd1f/go.mod h1:byini6yhqGC14c3ebc/QwanvYwhuMWF6yz2F8uwW8eg=
 k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 k8s.io/utils v0.0.0-20200603063816-c1c6865ac451/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
-k8s.io/utils v0.0.0-20230711102312-30195339c3c7 h1:ZgnF1KZsYxWIifwSNZFZgNtWE89WI5yiP5WwlfDoIyc=
-k8s.io/utils v0.0.0-20230711102312-30195339c3c7/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
+k8s.io/utils v0.0.0-20230726121419-3b25d923346b h1:sgn3ZU783SCgtaSJjpcVVlRqd6GSnlTLKgpAAttJvpI=
+k8s.io/utils v0.0.0-20230726121419-3b25d923346b/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.7/go.mod h1:PHgbrJT7lCHcxMU+mDHEm+nx46H4zuuHZkDP6icnhu0=
 sigs.k8s.io/controller-runtime v0.6.1/go.mod h1:XRYBPdbf5XJu9kpS84VJiZ7h/u1hF3gEORz0efEja7A=
 sigs.k8s.io/controller-runtime v0.15.0 h1:ML+5Adt3qZnMSYxZ7gAverBLNPSMQEibtzAgp0UPojU=

--- a/pkg/fake/basic_reactors.go
+++ b/pkg/fake/basic_reactors.go
@@ -1,0 +1,33 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"k8s.io/client-go/testing"
+)
+
+// AddBasicReactors adds reactors to mimic real K8s behavior for create, update, delete, list, watchs.
+func AddBasicReactors(f *testing.Fake) {
+	AddCreateReactor(f)
+	AddUpdateReactor(f)
+	AddDeleteReactor(f)
+	AddFilteringListReactor(f)
+	AddFilteringWatchReactor(f)
+	AddDeleteCollectionReactor(f)
+}

--- a/pkg/fake/basic_reactors_test.go
+++ b/pkg/fake/basic_reactors_test.go
@@ -1,0 +1,343 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/fake"
+	"github.com/submariner-io/admiral/pkg/resource"
+	"github.com/submariner-io/admiral/pkg/syncer/test"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	k8slabels "k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/watch"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/utils/ptr"
+)
+
+var _ = Describe("Create", func() {
+	t := newBasicReactorsTestDriver()
+
+	When("the GenerateName field is set", func() {
+		It("should set Name field", func() {
+			actual := t.assertCreateSuccess(t.pod)
+			Expect(actual.Name).To(HavePrefix(t.pod.GenerateName))
+		})
+	})
+
+	It("should set the ResourceVersion field", func() {
+		actual := t.assertCreateSuccess(t.pod)
+		Expect(actual.ResourceVersion).To(Equal("1"))
+	})
+
+	It("should set the UID field", func() {
+		actual := t.assertCreateSuccess(t.pod)
+		Expect(actual.UID).ToNot(BeEmpty())
+	})
+
+	When("the Name and GenerateName fields are empty", func() {
+		It("should return an error", func() {
+			t.pod.GenerateName = ""
+			_, err := t.doCreate(t.pod)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	When("the ResourceVersion field is set", func() {
+		It("should return an error", func() {
+			t.pod.ResourceVersion = "2"
+			_, err := t.doCreate(t.pod)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})
+
+var _ = Describe("Update", func() {
+	t := newBasicReactorsTestDriver()
+
+	JustBeforeEach(func() {
+		t.pod = t.assertCreateSuccess(t.pod)
+		t.pod.Namespace = ""
+		t.pod.Spec = corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Image: "image2",
+					Name:  "server2",
+				},
+			},
+		}
+	})
+
+	It("should update the resource", func() {
+		actual := t.doUpdateSuccess()
+		Expect(actual.Spec).To(Equal(t.pod.Spec))
+		Expect(actual.ResourceVersion > t.pod.ResourceVersion).To(BeTrue())
+	})
+
+	When("the Name field is empty", func() {
+		It("should return an Invalid error", func() {
+			t.pod.Name = ""
+			_, err := t.doUpdate()
+			Expect(apierrors.IsInvalid(err)).To(BeTrue())
+		})
+	})
+
+	When("the ResourceVersion field doesn't match", func() {
+		It("should return a Conflict error", func() {
+			t.pod.ResourceVersion = "111"
+			_, err := t.doUpdate()
+			Expect(apierrors.IsConflict(err)).To(BeTrue())
+		})
+	})
+})
+
+var _ = Describe("Delete", func() {
+	t := newBasicReactorsTestDriver()
+
+	JustBeforeEach(func() {
+		t.pod = t.assertCreateSuccess(t.pod)
+	})
+
+	It("should delete the resource", func() {
+		Expect(t.doDelete(metav1.DeleteOptions{})).To(Succeed())
+		_, err := t.doGet(t.pod.Name)
+		Expect(apierrors.IsNotFound(err)).To(BeTrue())
+	})
+
+	When("a specific ResourceVersion is requested", func() {
+		Context("and it matches", func() {
+			It("should delete the resource", func() {
+				Expect(t.doDelete(metav1.DeleteOptions{
+					Preconditions: &metav1.Preconditions{
+						ResourceVersion: &t.pod.ResourceVersion,
+					},
+				})).To(Succeed())
+				_, err := t.doGet(t.pod.Name)
+				Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			})
+		})
+
+		Context("and it doesn't match", func() {
+			It("should return a Conflict error", func() {
+				err := t.doDelete(metav1.DeleteOptions{
+					Preconditions: &metav1.Preconditions{
+						ResourceVersion: ptr.To("111"),
+					},
+				})
+				Expect(apierrors.IsConflict(err)).To(BeTrue())
+			})
+		})
+	})
+
+	When("there's remaining finalizers", func() {
+		BeforeEach(func() {
+			t.pod.Finalizers = []string{"some-finalizer"}
+		})
+
+		It("should set the DeletionTimestamp field", func() {
+			Expect(t.doDelete(metav1.DeleteOptions{})).To(Succeed())
+			actual, err := t.doGet(t.pod.Name)
+			Expect(err).To(Succeed())
+			Expect(actual.GetDeletionTimestamp()).ToNot(BeNil())
+		})
+	})
+})
+
+var _ = Describe("List", func() {
+	t := newBasicReactorsTestDriver()
+
+	JustBeforeEach(func() {
+		t.pod = t.assertCreateSuccess(t.pod)
+		t.assertCreateSuccess(&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "other-pod",
+			},
+		})
+	})
+
+	When("a field selector is specified", func() {
+		It("should return the correct resources", func() {
+			list, err := t.client.CoreV1().Pods(test.LocalNamespace).List(context.Background(), metav1.ListOptions{
+				FieldSelector: fields.OneTermEqualSelector("metadata.name", t.pod.Name).String(),
+			})
+
+			Expect(err).To(Succeed())
+			Expect(list.Items).To(HaveLen(1))
+			Expect(list.Items[0].Name).To(Equal(t.pod.Name))
+		})
+	})
+})
+
+var _ = Describe("Watch", func() {
+	t := newBasicReactorsTestDriver()
+
+	var watcher watch.Interface
+
+	JustBeforeEach(func() {
+		var err error
+
+		watcher, err = t.client.CoreV1().Pods(test.LocalNamespace).Watch(context.Background(), metav1.ListOptions{
+			LabelSelector: k8slabels.SelectorFromSet(t.pod.Labels).String(),
+		})
+		Expect(err).To(Succeed())
+	})
+
+	AfterEach(func() {
+		watcher.Stop()
+	})
+
+	When("a label selector is specified", func() {
+		It("should correctly filter the resources", func() {
+			t.pod = t.assertCreateSuccess(t.pod)
+
+			select {
+			case event, ok := <-watcher.ResultChan():
+				Expect(ok).To(BeTrue())
+
+				//nolint:exhaustive // Other types handled in default case.
+				switch event.Type {
+				case watch.Added:
+					Expect(resource.MustToMeta(event.Object).GetName()).To(Equal(t.pod.Name))
+				default:
+					Fail(fmt.Sprintf("Received unexpected watch event: %s", resource.ToJSON(event)))
+				}
+			case <-time.After(1 * time.Second):
+				Fail("Did not receive expected watch event")
+			}
+
+			t.assertCreateSuccess(&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "other-pod",
+				},
+			})
+
+			select {
+			case event := <-watcher.ResultChan():
+				Fail(fmt.Sprintf("Received unexpected watch event: %s", resource.ToJSON(event)))
+			case <-time.After(300 * time.Millisecond):
+			}
+		})
+	})
+})
+
+var _ = Describe("DeleteCollection", func() {
+	t := newBasicReactorsTestDriver()
+
+	JustBeforeEach(func() {
+		t.pod = t.assertCreateSuccess(t.pod)
+	})
+
+	It("should delete the correct resources", func() {
+		otherPod := t.assertCreateSuccess(&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "other-pod",
+			},
+		})
+
+		err := t.client.CoreV1().Pods(test.LocalNamespace).DeleteCollection(context.Background(), metav1.DeleteOptions{},
+			metav1.ListOptions{
+				LabelSelector: k8slabels.SelectorFromSet(t.pod.Labels).String(),
+			})
+
+		Expect(err).To(Succeed())
+
+		_, err = t.doGet(t.pod.Name)
+		Expect(apierrors.IsNotFound(err)).To(BeTrue())
+
+		t.assertGetSuccess(otherPod)
+	})
+})
+
+type basicReactorsTestDriver struct {
+	client *k8sfake.Clientset
+	pod    *corev1.Pod
+}
+
+func newBasicReactorsTestDriver() *basicReactorsTestDriver {
+	t := &basicReactorsTestDriver{}
+
+	BeforeEach(func() {
+		t.client = k8sfake.NewSimpleClientset()
+		fake.AddBasicReactors(&t.client.Fake)
+
+		t.pod = &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "pod-",
+				Labels:       map[string]string{"app": "test"},
+				Annotations:  map[string]string{"foo": "bar"},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Image: "image1",
+						Name:  "server1",
+					},
+				},
+			},
+		}
+	})
+
+	return t
+}
+
+func (t *basicReactorsTestDriver) doGet(name string) (*corev1.Pod, error) {
+	return t.client.CoreV1().Pods(test.LocalNamespace).Get(context.Background(), name, metav1.GetOptions{})
+}
+
+func (t *basicReactorsTestDriver) assertGetSuccess(p *corev1.Pod) *corev1.Pod {
+	actual, err := t.doGet(p.Name)
+	Expect(err).To(Succeed())
+	Expect(actual).To(Equal(p))
+
+	return actual
+}
+
+func (t *basicReactorsTestDriver) doCreate(pod *corev1.Pod) (*corev1.Pod, error) {
+	return t.client.CoreV1().Pods(test.LocalNamespace).Create(context.Background(), pod, metav1.CreateOptions{})
+}
+
+func (t *basicReactorsTestDriver) assertCreateSuccess(pod *corev1.Pod) *corev1.Pod {
+	created, err := t.doCreate(pod)
+	Expect(err).To(Succeed())
+
+	return t.assertGetSuccess(created)
+}
+
+func (t *basicReactorsTestDriver) doUpdate() (*corev1.Pod, error) {
+	return t.client.CoreV1().Pods(test.LocalNamespace).Update(context.Background(), t.pod, metav1.UpdateOptions{})
+}
+
+func (t *basicReactorsTestDriver) doUpdateSuccess() *corev1.Pod {
+	updated, err := t.doUpdate()
+	Expect(err).To(Succeed())
+
+	return t.assertGetSuccess(updated)
+}
+
+//nolint:gocritic // Ignore hugeParam
+func (t *basicReactorsTestDriver) doDelete(opts metav1.DeleteOptions) error {
+	return t.client.CoreV1().Pods(test.LocalNamespace).Delete(context.Background(), t.pod.Name, opts)
+}

--- a/pkg/fake/create_reactor.go
+++ b/pkg/fake/create_reactor.go
@@ -1,0 +1,73 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"fmt"
+
+	"github.com/submariner-io/admiral/pkg/resource"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/client-go/testing"
+)
+
+type createReactor struct {
+	reactors []testing.Reactor
+}
+
+// AddCreateReactor adds a reactor to mimic real K8s create behavior to handle GenerateName, validation et al.
+func AddCreateReactor(f *testing.Fake) {
+	r := &createReactor{reactors: f.ReactionChain[0:]}
+	f.PrependReactor("create", "*", r.react)
+}
+
+func (r *createReactor) react(a testing.Action) (bool, runtime.Object, error) {
+	action := a.(testing.CreateAction)
+
+	target := resource.MustToMeta(action.GetObject())
+
+	if target.GetName() == "" && target.GetGenerateName() != "" {
+		target.SetName(fmt.Sprintf("%s%s", target.GetGenerateName(), utilrand.String(5)))
+	}
+
+	if target.GetName() == "" {
+		return true, nil, apierrors.NewInvalid(
+			action.GetObject().GetObjectKind().GroupVersionKind().GroupKind(), "",
+			field.ErrorList{field.Required(field.NewPath("metadata.name"), "name is required")})
+	}
+
+	if target.GetResourceVersion() != "" {
+		return true, nil, apierrors.NewBadRequest("resourceVersion can not be set for Create requests")
+	}
+
+	target.SetResourceVersion("1")
+
+	if !target.GetDeletionTimestamp().IsZero() {
+		target.SetDeletionTimestamp(nil)
+	}
+
+	target.SetUID(uuid.NewUUID())
+
+	obj, err := invokeReactors(action, r.reactors)
+
+	return true, obj, err
+}

--- a/pkg/fake/delete_reactor.go
+++ b/pkg/fake/delete_reactor.go
@@ -1,0 +1,74 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"fmt"
+
+	"github.com/submariner-io/admiral/pkg/resource"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/testing"
+)
+
+type deleteReactor struct {
+	reactors []testing.Reactor
+}
+
+// AddDeleteReactor adds a reactor to mimic real K8s delete behavior to handle ResourceVersion, DeletionTimestamp et al.
+func AddDeleteReactor(f *testing.Fake) {
+	r := &deleteReactor{reactors: f.ReactionChain[0:]}
+	f.PrependReactor("delete", "*", r.react)
+}
+
+func (r *deleteReactor) react(a testing.Action) (bool, runtime.Object, error) {
+	action := a.(testing.DeleteAction)
+
+	existingObj, err := invokeReactors(testing.NewGetAction(action.GetResource(), action.GetNamespace(),
+		action.GetName()), r.reactors)
+	if err != nil {
+		return true, nil, err
+	}
+
+	existing := resource.MustToMeta(existingObj)
+
+	if action.GetDeleteOptions().Preconditions != nil && action.GetDeleteOptions().Preconditions.ResourceVersion != nil {
+		if existing.GetResourceVersion() != *action.GetDeleteOptions().Preconditions.ResourceVersion {
+			return true, nil, apierrors.NewConflict(action.GetResource().GroupResource(), action.GetName(),
+				fmt.Errorf("the ResourceVersion in the precondition (%s) does not match the ResourceVersion in record (%s). "+
+					"The object might have been modified",
+					*action.GetDeleteOptions().Preconditions.ResourceVersion, existing.GetResourceVersion()))
+		}
+	}
+
+	if len(existing.GetFinalizers()) > 0 {
+		now := metav1.Now()
+		existing.SetDeletionTimestamp(&now)
+
+		obj, err := invokeReactors(testing.NewUpdateAction(action.GetResource(), action.GetNamespace(),
+			existingObj), r.reactors)
+
+		return true, obj, err
+	}
+
+	obj, err := invokeReactors(action, r.reactors)
+
+	return true, obj, err
+}

--- a/pkg/fake/dynamic_client.go
+++ b/pkg/fake/dynamic_client.go
@@ -68,7 +68,7 @@ type DynamicResourceClient struct {
 func NewDynamicClient(scheme *runtime.Scheme, objects ...runtime.Object) *DynamicClient {
 	f := fake.NewSimpleDynamicClient(scheme, objects...)
 
-	AddDeleteCollectionReactor(&f.Fake, schema.GroupVersionKind{Group: "fake-dynamic-client-group", Version: "v1", Kind: ""})
+	AddDeleteCollectionReactor(&f.Fake)
 	AddFilteringListReactor(&f.Fake)
 
 	return &DynamicClient{

--- a/pkg/fake/fake_suite_test.go
+++ b/pkg/fake/fake_suite_test.go
@@ -1,0 +1,31 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestFake(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Fake Suite")
+}

--- a/pkg/fake/update_reactor.go
+++ b/pkg/fake/update_reactor.go
@@ -1,0 +1,75 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/submariner-io/admiral/pkg/resource"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/client-go/testing"
+)
+
+type updateReactor struct {
+	reactors []testing.Reactor
+}
+
+// AddUpdateReactor adds a reactor to mimic real K8s update behavior to handle ResourceVersion et al.
+func AddUpdateReactor(f *testing.Fake) {
+	r := &updateReactor{reactors: f.ReactionChain[0:]}
+	f.PrependReactor("update", "*", r.react)
+}
+
+func (r *updateReactor) react(a testing.Action) (bool, runtime.Object, error) {
+	action := a.(testing.UpdateAction)
+
+	target := resource.MustToMeta(action.GetObject())
+
+	if target.GetName() == "" {
+		return true, nil, apierrors.NewInvalid(
+			action.GetObject().GetObjectKind().GroupVersionKind().GroupKind(), "",
+			field.ErrorList{field.Required(field.NewPath("metadata.name"), "name is required")})
+	}
+
+	o, err := invokeReactors(testing.NewGetAction(action.GetResource(), action.GetNamespace(),
+		target.GetName()), r.reactors)
+	if err != nil {
+		return true, nil, err
+	}
+
+	existing := resource.MustToMeta(o)
+	if existing.GetResourceVersion() != target.GetResourceVersion() {
+		return true, nil, apierrors.NewConflict(schema.GroupResource{}, target.GetName(),
+			fmt.Errorf("resource version %q does not match expected %q", target.GetResourceVersion(),
+				existing.GetResourceVersion()))
+	}
+
+	v, err := strconv.Atoi(existing.GetResourceVersion())
+	utilruntime.Must(err)
+	target.SetResourceVersion(strconv.Itoa(v + 1))
+
+	obj, err := invokeReactors(action, r.reactors)
+
+	return true, obj, err
+}


### PR DESCRIPTION
...for Create, Update and Delete operations to handle `GenerateName`, `ResourceVersion`, `DeletionTimestamp` et al behaviors. Also added a convenience function, `AddBasicReactors`, that adds the new reactors and the existing List, Watch and DeleteCollection reactors.
