### PR TITLE
Add component names 

### DIFF
--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -1,0 +1,32 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package names
+
+/* Component names. */
+const (
+	NetworkPluginSyncerComponent = "submariner-networkplugin-syncer"
+	RouteAgentComponent          = "submariner-routeagent"
+	GatewayComponent             = "submariner-gateway"
+	GlobalnetComponent           = "submariner-globalnet"
+	ServiceDiscoveryComponent    = "submariner-lighthouse-agent"
+	LighthouseCoreDNSComponent   = "submariner-lighthouse-coredns"
+	OperatorComponent            = "submariner-operator"
+	MetricsProxyComponent        = "submariner-metrics-proxy"
+	NettestComponent             = "submariner-nettest"
+)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,28 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"fmt"
+	"os"
+)
+
+func Print(componentName, version string) {
+	fmt.Fprintf(os.Stderr, "%s version: %s\n", componentName, version)
+}


### PR DESCRIPTION
Adds names/names.go with submariner component names to provide consistency in component names across repos.