### PR TITLE
Fix implicit memory aliasing in for loop

### DIFF
--- a/pkg/syncer/resource_syncer_test.go
+++ b/pkg/syncer/resource_syncer_test.go
@@ -1170,8 +1170,8 @@ func testRequeueResource() {
 
 func assertResourceList(actual []runtime.Object, expected ...*corev1.Pod) {
 	expSpecs := map[string]*corev1.PodSpec{}
-	for _, p := range expected {
-		expSpecs[p.Name] = &p.Spec
+	for i := range expected {
+		expSpecs[expected[i].Name] = &expected[i].Spec
 	}
 
 	Expect(actual).To(HaveLen(len(expSpecs)))


### PR DESCRIPTION
This is reported with **golangci-lint** _1.54.2_:

```
pkg/syncer/resource_syncer_test.go:1174:22: G601: Implicit memory aliasing in for loop. (gosec)
		expSpecs[p.Name] = &p.Spec
```

