### PR TITLE
Add optional event logging in the Federators

### DIFF
--- a/pkg/federate/create_federator.go
+++ b/pkg/federate/create_federator.go
@@ -33,7 +33,7 @@ type createFederator struct {
 	*baseFederator
 }
 
-func NewCreateFederator(dynClient dynamic.Interface, restMapper meta.RESTMapper, targetNamespace string) Federator {
+func NewCreateFederator(dynClient dynamic.Interface, restMapper meta.RESTMapper, targetNamespace string) FederatorExt {
 	return &createFederator{
 		baseFederator: newBaseFederator(dynClient, restMapper, targetNamespace),
 	}
@@ -53,6 +53,11 @@ func (f *createFederator) Distribute(obj runtime.Object) error {
 	_, err = resourceClient.Create(context.TODO(), toDistribute, metav1.CreateOptions{})
 	if apierrors.IsAlreadyExists(err) {
 		return nil
+	}
+
+	if f.eventLogName != "" && err == nil {
+		logger.Infof("%s: Created %s \"%s/%s\" ", f.eventLogName, toDistribute.GetKind(), toDistribute.GetNamespace(),
+			toDistribute.GetName())
 	}
 
 	return err

--- a/pkg/federate/federator.go
+++ b/pkg/federate/federator.go
@@ -42,6 +42,12 @@ type Federator interface {
 	Delete(resource runtime.Object) error
 }
 
+type FederatorExt interface {
+	Federator
+
+	LogEvents(withName string)
+}
+
 type noopFederator struct{}
 
 func NewNoopFederator() Federator {

--- a/pkg/federate/federator_test.go
+++ b/pkg/federate/federator_test.go
@@ -45,7 +45,7 @@ var (
 
 func testCreateOrUpdateFederator() {
 	var (
-		f federate.Federator
+		f federate.FederatorExt
 		t *testDriver
 	)
 
@@ -55,6 +55,7 @@ func testCreateOrUpdateFederator() {
 
 	JustBeforeEach(func() {
 		f = federate.NewCreateOrUpdateFederator(t.dynClient, t.restMapper, t.federatorNamespace, t.localClusterID, t.keepMetadataFields...)
+		f.LogEvents("test")
 	})
 
 	When("the resource does not already exist in the datastore", func() {
@@ -193,7 +194,7 @@ func testCreateOrUpdateFederator() {
 
 func testCreateFederator() {
 	var (
-		f federate.Federator
+		f federate.FederatorExt
 		t *testDriver
 	)
 
@@ -204,6 +205,7 @@ func testCreateFederator() {
 
 	JustBeforeEach(func() {
 		f = federate.NewCreateFederator(t.dynClient, t.restMapper, t.federatorNamespace)
+		f.LogEvents("test")
 	})
 
 	When("the resource does not already exist in the datastore", func() {
@@ -385,7 +387,7 @@ func testUpdateStatusFederator() {
 
 func testDelete() {
 	var (
-		f federate.Federator
+		f federate.FederatorExt
 		t *testDriver
 	)
 
@@ -395,6 +397,7 @@ func testDelete() {
 
 	JustBeforeEach(func() {
 		f = federate.NewCreateOrUpdateFederator(t.dynClient, t.restMapper, t.federatorNamespace, "")
+		f.LogEvents("test")
 	})
 
 	When("the resource exists in the datastore", func() {

--- a/pkg/syncer/broker/syncer.go
+++ b/pkg/syncer/broker/syncer.go
@@ -184,8 +184,13 @@ func NewSyncer(config SyncerConfig) (*Syncer, error) { //nolint:gocritic // Mini
 		localClient:     config.LocalClient,
 	}
 
-	brokerSyncer.remoteFederator = NewFederator(config.BrokerClient, config.RestMapper, config.BrokerNamespace, config.LocalClusterID)
-	brokerSyncer.localFederator = NewFederator(config.LocalClient, config.RestMapper, config.LocalNamespace, "")
+	f := federate.NewCreateOrUpdateFederator(config.BrokerClient, config.RestMapper, config.BrokerNamespace, config.LocalClusterID)
+	f.LogEvents("local -> broker")
+	brokerSyncer.remoteFederator = f
+
+	f = federate.NewCreateOrUpdateFederator(config.LocalClient, config.RestMapper, config.LocalNamespace, "")
+	f.LogEvents("broker -> local")
+	brokerSyncer.localFederator = f
 
 	for i := range config.ResourceConfigs {
 		rc := &config.ResourceConfigs[i]


### PR DESCRIPTION
While debugging an issue, it would've been useful to see logging of resources synced to and from the broker. This commit extends the `Federator` interface to add a `LogEvents` method that enables logging of resources created, updated and deleted. The broker syncer was modified to enable this logging.
