### PR TITLE
Generify resource handling

### DIFF
--- a/pkg/federate/create_or_update_federator.go
+++ b/pkg/federate/create_or_update_federator.go
@@ -44,7 +44,6 @@ func NewCreateOrUpdateFederator(dynClient dynamic.Interface, restMapper meta.RES
 	}
 }
 
-//nolint:wrapcheck // This function is effectively a wrapper so no need to wrap errors.
 func (f *createOrUpdateFederator) Distribute(obj runtime.Object) error {
 	logger.V(log.LIBTRACE).Infof("In Distribute for %#v", obj)
 
@@ -59,7 +58,7 @@ func (f *createOrUpdateFederator) Distribute(obj runtime.Object) error {
 
 	f.prepareResourceForSync(toDistribute)
 
-	result, err := util.CreateOrUpdate(context.TODO(), resource.ForDynamic(resourceClient), toDistribute,
+	result, err := util.CreateOrUpdate[runtime.Object](context.TODO(), resource.ForDynamic(resourceClient), toDistribute,
 		func(obj runtime.Object) (runtime.Object, error) {
 			return util.CopyImmutableMetadata(obj.(*unstructured.Unstructured), toDistribute), nil
 		})

--- a/pkg/federate/update_federator.go
+++ b/pkg/federate/update_federator.go
@@ -52,7 +52,6 @@ func NewUpdateStatusFederator(dynClient dynamic.Interface, restMapper meta.RESTM
 		})
 }
 
-//nolint:wrapcheck // This function is effectively a wrapper so no need to wrap errors.
 func (f *updateFederator) Distribute(obj runtime.Object) error {
 	logger.V(log.LIBTRACE).Infof("In Distribute for %#v", obj)
 
@@ -63,7 +62,8 @@ func (f *updateFederator) Distribute(obj runtime.Object) error {
 
 	f.prepareResourceForSync(toUpdate)
 
-	return util.Update(context.TODO(), resource.ForDynamic(resourceClient), toUpdate, func(obj runtime.Object) (runtime.Object, error) {
-		return f.update(obj.(*unstructured.Unstructured), toUpdate), nil
-	})
+	return util.Update[runtime.Object](context.TODO(), resource.ForDynamic(resourceClient), toUpdate,
+		func(obj runtime.Object) (runtime.Object, error) {
+			return f.update(obj.(*unstructured.Unstructured), toUpdate), nil
+		})
 }

--- a/pkg/finalizer/finalizer.go
+++ b/pkg/finalizer/finalizer.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-func Add(ctx context.Context, client resource.Interface, obj runtime.Object, finalizerName string) (bool, error) {
+func Add[T runtime.Object](ctx context.Context, client resource.Interface[T], obj T, finalizerName string) (bool, error) {
 	objMeta := resource.MustToMeta(obj)
 	if !objMeta.GetDeletionTimestamp().IsZero() {
 		return false, nil
@@ -38,7 +38,7 @@ func Add(ctx context.Context, client resource.Interface, obj runtime.Object, fin
 		return false, nil
 	}
 
-	err := util.Update(ctx, client, obj, func(existing runtime.Object) (runtime.Object, error) {
+	err := util.Update(ctx, client, obj, func(existing T) (T, error) {
 		objMeta := resource.MustToMeta(existing)
 		objMeta.SetFinalizers(append(objMeta.GetFinalizers(), finalizerName))
 
@@ -48,13 +48,13 @@ func Add(ctx context.Context, client resource.Interface, obj runtime.Object, fin
 	return err == nil, errors.Wrapf(err, "error adding finalizer %q to %q", finalizerName, objMeta.GetName())
 }
 
-func Remove(ctx context.Context, client resource.Interface, obj runtime.Object, finalizerName string) error {
+func Remove[T runtime.Object](ctx context.Context, client resource.Interface[T], obj T, finalizerName string) error {
 	objMeta := resource.MustToMeta(obj)
 	if !IsPresent(objMeta, finalizerName) {
 		return nil
 	}
 
-	err := util.Update(ctx, client, obj, func(existing runtime.Object) (runtime.Object, error) {
+	err := util.Update(ctx, client, obj, func(existing T) (T, error) {
 		objMeta := resource.MustToMeta(existing)
 
 		newFinalizers := []string{}

--- a/pkg/finalizer/finalizer_test.go
+++ b/pkg/finalizer/finalizer_test.go
@@ -197,7 +197,7 @@ var _ = Describe("Remove", func() {
 type testDriver struct {
 	pod        *corev1.Pod
 	kubeClient *kubeFake.Clientset
-	client     resource.Interface
+	client     resource.Interface[*corev1.Pod]
 }
 
 func newTestDriver() *testDriver {

--- a/pkg/resource/dynamic.go
+++ b/pkg/resource/dynamic.go
@@ -75,13 +75,13 @@ func (d *dynamicType) List(ctx context.Context,
 	options metav1.ListOptions, //nolint:gocritic // hugeParam - we're matching K8s API
 ) ([]runtime.Object, error) {
 	l, err := d.client.List(ctx, options)
-	return MustExtractList(l), err
+	return MustExtractList[runtime.Object](l), err
 }
 
-func ForDynamic(client dynamic.ResourceInterface) *InterfaceFuncs {
+func ForDynamic(client dynamic.ResourceInterface) *InterfaceFuncs[runtime.Object] {
 	t := &dynamicType{client: client}
 
-	return &InterfaceFuncs{
+	return &InterfaceFuncs[runtime.Object]{
 		GetFunc:          t.Get,
 		CreateFunc:       t.Create,
 		UpdateFunc:       t.Update,

--- a/pkg/resource/interface_test.go
+++ b/pkg/resource/interface_test.go
@@ -41,7 +41,7 @@ import (
 
 var _ = Describe("Interface", func() {
 	Context("ForDaemonSet", func() {
-		testInterfaceFuncs(func() resource.Interface {
+		testInterfaceFuncs(func() resource.Interface[*appsv1.DaemonSet] {
 			return resource.ForDaemonSet(k8sfake.NewSimpleClientset(), test.LocalNamespace)
 		}, &appsv1.DaemonSet{
 			ObjectMeta: metav1.ObjectMeta{
@@ -55,7 +55,7 @@ var _ = Describe("Interface", func() {
 	})
 
 	Context("ForDeployment", func() {
-		testInterfaceFuncs(func() resource.Interface {
+		testInterfaceFuncs(func() resource.Interface[*appsv1.Deployment] {
 			return resource.ForDeployment(k8sfake.NewSimpleClientset(), test.LocalNamespace)
 		}, &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
@@ -69,7 +69,7 @@ var _ = Describe("Interface", func() {
 	})
 
 	Context("ForNamespace", func() {
-		testInterfaceFuncs(func() resource.Interface {
+		testInterfaceFuncs(func() resource.Interface[*corev1.Namespace] {
 			return resource.ForNamespace(k8sfake.NewSimpleClientset())
 		}, &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
@@ -79,7 +79,7 @@ var _ = Describe("Interface", func() {
 	})
 
 	Context("ForPod", func() {
-		testInterfaceFuncs(func() resource.Interface {
+		testInterfaceFuncs(func() resource.Interface[*corev1.Pod] {
 			return resource.ForPod(k8sfake.NewSimpleClientset(), test.LocalNamespace)
 		}, &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
@@ -93,7 +93,7 @@ var _ = Describe("Interface", func() {
 	})
 
 	Context("ForService", func() {
-		testInterfaceFuncs(func() resource.Interface {
+		testInterfaceFuncs(func() resource.Interface[*corev1.Service] {
 			return resource.ForService(k8sfake.NewSimpleClientset(), test.LocalNamespace)
 		}, &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
@@ -107,7 +107,7 @@ var _ = Describe("Interface", func() {
 	})
 
 	Context("ForServiceAccount", func() {
-		testInterfaceFuncs(func() resource.Interface {
+		testInterfaceFuncs(func() resource.Interface[*corev1.ServiceAccount] {
 			return resource.ForServiceAccount(k8sfake.NewSimpleClientset(), test.LocalNamespace)
 		}, &corev1.ServiceAccount{
 			ObjectMeta: metav1.ObjectMeta{
@@ -118,7 +118,7 @@ var _ = Describe("Interface", func() {
 	})
 
 	Context("ForClusterRole", func() {
-		testInterfaceFuncs(func() resource.Interface {
+		testInterfaceFuncs(func() resource.Interface[*rbacv1.ClusterRole] {
 			return resource.ForClusterRole(k8sfake.NewSimpleClientset())
 		}, &rbacv1.ClusterRole{
 			ObjectMeta: metav1.ObjectMeta{
@@ -128,7 +128,7 @@ var _ = Describe("Interface", func() {
 	})
 
 	Context("ForClusterRoleBinding", func() {
-		testInterfaceFuncs(func() resource.Interface {
+		testInterfaceFuncs(func() resource.Interface[*rbacv1.ClusterRoleBinding] {
 			return resource.ForClusterRoleBinding(k8sfake.NewSimpleClientset())
 		}, &rbacv1.ClusterRoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
@@ -138,7 +138,7 @@ var _ = Describe("Interface", func() {
 	})
 
 	Context("ForRole", func() {
-		testInterfaceFuncs(func() resource.Interface {
+		testInterfaceFuncs(func() resource.Interface[*rbacv1.Role] {
 			return resource.ForRole(k8sfake.NewSimpleClientset(), test.LocalNamespace)
 		}, &rbacv1.Role{
 			ObjectMeta: metav1.ObjectMeta{
@@ -149,7 +149,7 @@ var _ = Describe("Interface", func() {
 	})
 
 	Context("ForRoleBinding", func() {
-		testInterfaceFuncs(func() resource.Interface {
+		testInterfaceFuncs(func() resource.Interface[*rbacv1.RoleBinding] {
 			return resource.ForRoleBinding(k8sfake.NewSimpleClientset(), test.LocalNamespace)
 		}, &rbacv1.RoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
@@ -160,7 +160,7 @@ var _ = Describe("Interface", func() {
 	})
 
 	Context("ForConfigMap", func() {
-		testInterfaceFuncs(func() resource.Interface {
+		testInterfaceFuncs(func() resource.Interface[*corev1.ConfigMap] {
 			return resource.ForConfigMap(k8sfake.NewSimpleClientset(), test.LocalNamespace)
 		}, &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -172,7 +172,7 @@ var _ = Describe("Interface", func() {
 	})
 
 	Context("ForListableControllerClient", func() {
-		testInterfaceFuncs(func() resource.Interface {
+		testInterfaceFuncs(func() resource.Interface[*corev1.Pod] {
 			return resource.ForListableControllerClient(clientfake.NewClientBuilder().WithScheme(scheme.Scheme).Build(),
 				test.LocalNamespace, &corev1.Pod{}, &corev1.PodList{})
 		}, &corev1.Pod{
@@ -191,14 +191,14 @@ var _ = Describe("Interface", func() {
 	})
 
 	Context("ForDynamic", func() {
-		testInterfaceFuncs(func() resource.Interface {
+		testInterfaceFuncs(func() resource.Interface[runtime.Object] {
 			return resource.ForDynamic(dynamicfake.NewSimpleDynamicClient(scheme.Scheme).Resource(
 				schema.GroupVersionResource{
 					Group:    corev1.SchemeGroupVersion.Group,
 					Version:  corev1.SchemeGroupVersion.Version,
 					Resource: "pods",
 				}).Namespace(test.LocalNamespace))
-		}, resource.MustToUnstructured(&corev1.Pod{
+		}, runtime.Object(resource.MustToUnstructured(&corev1.Pod{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "Pod",
 				APIVersion: "v1",
@@ -210,13 +210,13 @@ var _ = Describe("Interface", func() {
 			Spec: corev1.PodSpec{
 				Hostname: "my-host",
 			},
-		}))
+		})))
 	})
 })
 
-func testInterfaceFuncs(newInterface func() resource.Interface, initialObj runtime.Object) {
+func testInterfaceFuncs[T runtime.Object](newInterface func() resource.Interface[T], initialObj T) {
 	Specify("verify functions", func() {
-		sanitize := func(o runtime.Object) runtime.Object {
+		sanitize := func(o T) T {
 			m := resource.MustToMeta(o)
 			m.SetResourceVersion("")
 			m.SetCreationTimestamp(metav1.Time{})
@@ -227,7 +227,7 @@ func testInterfaceFuncs(newInterface func() resource.Interface, initialObj runti
 		i := newInterface()
 		initialObj = sanitize(initialObj)
 
-		another := initialObj.DeepCopyObject()
+		another := initialObj.DeepCopyObject().(T)
 		resource.MustToMeta(another).SetName(resource.MustToMeta(initialObj).GetName() + "-2")
 
 		// Create

--- a/pkg/syncer/test/util.go
+++ b/pkg/syncer/test/util.go
@@ -70,7 +70,7 @@ func CreateResource(resourceInterface dynamic.ResourceInterface, obj runtime.Obj
 }
 
 func UpdateResource(resourceInterface dynamic.ResourceInterface, obj runtime.Object) *unstructured.Unstructured {
-	err := util.Update(context.Background(), resource.ForDynamic(resourceInterface), obj,
+	err := util.Update[runtime.Object](context.Background(), resource.ForDynamic(resourceInterface), obj,
 		util.Replace(obj))
 	Expect(err).To(Succeed())
 

--- a/pkg/test/assert.go
+++ b/pkg/test/assert.go
@@ -66,19 +66,19 @@ func GetOccurredActionVerbs(f *testing.Fake, resourceType string, expectedVerbs 
 	return verbs
 }
 
-func AwaitFinalizer(client resource.Interface, name, finalizer string) {
+func AwaitFinalizer[T runtime.Object](client resource.Interface[T], name, finalizer string) {
 	Eventually(func() []string {
 		return GetFinalizers(client, name)
 	}).Should(ContainElement(finalizer))
 }
 
-func AwaitNoFinalizer(client resource.Interface, name, finalizer string) {
+func AwaitNoFinalizer[T runtime.Object](client resource.Interface[T], name, finalizer string) {
 	Eventually(func() []string {
 		return GetFinalizers(client, name)
 	}).ShouldNot(ContainElement(finalizer))
 }
 
-func AssertFinalizers(client resource.Interface, name string, finalizers ...string) {
+func AssertFinalizers[T runtime.Object](client resource.Interface[T], name string, finalizers ...string) {
 	if finalizers == nil {
 		finalizers = []string{}
 	}
@@ -104,7 +104,7 @@ func AwaitStatusCondition(expCond *metav1.Condition, get func() ([]metav1.Condit
 	Expect(found.LastTransitionTime).To(Not(BeNil()))
 }
 
-func AwaitResource(client resource.Interface, name string) runtime.Object {
+func AwaitResource[T runtime.Object](client resource.Interface[T], name string) runtime.Object {
 	var obj runtime.Object
 
 	Eventually(func() error {
@@ -117,14 +117,14 @@ func AwaitResource(client resource.Interface, name string) runtime.Object {
 	return obj
 }
 
-func AwaitNoResource(client resource.Interface, name string) {
+func AwaitNoResource[T runtime.Object](client resource.Interface[T], name string) {
 	Eventually(func() bool {
 		_, err := client.Get(context.TODO(), name, metav1.GetOptions{})
 		return apierrors.IsNotFound(err)
 	}, 3).Should(BeTrue(), "Found unexpected resource %q", name)
 }
 
-func EnsureNoResource(client resource.Interface, name string) {
+func EnsureNoResource[T runtime.Object](client resource.Interface[T], name string) {
 	Consistently(func() bool {
 		_, err := client.Get(context.TODO(), name, metav1.GetOptions{})
 		return apierrors.IsNotFound(err)

--- a/pkg/test/utils.go
+++ b/pkg/test/utils.go
@@ -25,9 +25,10 @@ import (
 	"github.com/submariner-io/admiral/pkg/resource"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
-func SetDeleting(client resource.Interface, name string) {
+func SetDeleting[T runtime.Object](client resource.Interface[T], name string) {
 	obj, err := client.Get(context.TODO(), name, metav1.GetOptions{})
 	Expect(err).To(Succeed())
 
@@ -41,7 +42,7 @@ func SetDeleting(client resource.Interface, name string) {
 	Expect(err).To(Succeed())
 }
 
-func GetFinalizers(client resource.Interface, name string) []string {
+func GetFinalizers[T runtime.Object](client resource.Interface[T], name string) []string {
 	obj, err := client.Get(context.TODO(), name, metav1.GetOptions{})
 	Expect(err).To(Succeed())
 

--- a/pkg/util/create_or_update_test.go
+++ b/pkg/util/create_or_update_test.go
@@ -44,7 +44,8 @@ var _ = Describe("CreateAnew function", func() {
 	t := newCreateOrUpdateTestDiver()
 
 	createAnew := func() (runtime.Object, error) {
-		return util.CreateAnew(context.TODO(), resource.ForDynamic(t.client), t.pod, metav1.CreateOptions{}, metav1.DeleteOptions{})
+		return util.CreateAnew[runtime.Object](context.TODO(), resource.ForDynamic(t.client), t.pod, metav1.CreateOptions{},
+			metav1.DeleteOptions{})
 	}
 
 	createAnewSuccess := func() *corev1.Pod {
@@ -143,7 +144,7 @@ var _ = Describe("CreateOrUpdate function", func() {
 	t := newCreateOrUpdateTestDiver()
 
 	createOrUpdate := func(expResult util.OperationResult) error {
-		result, err := util.CreateOrUpdate(context.TODO(), resource.ForDynamic(t.client), test.ToUnstructured(t.pod), t.mutateFn)
+		result, err := util.CreateOrUpdate[runtime.Object](context.TODO(), resource.ForDynamic(t.client), test.ToUnstructured(t.pod), t.mutateFn)
 		if err != nil && expResult != util.OperationResultNone {
 			return err
 		}
@@ -245,7 +246,7 @@ var _ = Describe("Update function", func() {
 	t := newCreateOrUpdateTestDiver()
 
 	update := func() error {
-		return util.Update(context.TODO(), resource.ForDynamic(t.client), test.ToUnstructured(t.pod), t.mutateFn)
+		return util.Update[runtime.Object](context.TODO(), resource.ForDynamic(t.client), test.ToUnstructured(t.pod), t.mutateFn)
 	}
 
 	When("the resource doesn't exist", func() {
@@ -267,7 +268,7 @@ var _ = Describe("MustUpdate function", func() {
 	t := newCreateOrUpdateTestDiver()
 
 	mustUpdate := func() error {
-		return util.MustUpdate(context.TODO(), resource.ForDynamic(t.client), test.ToUnstructured(t.pod), t.mutateFn)
+		return util.MustUpdate[runtime.Object](context.TODO(), resource.ForDynamic(t.client), test.ToUnstructured(t.pod), t.mutateFn)
 	}
 
 	When("the resource doesn't exist", func() {
@@ -291,7 +292,7 @@ type createOrUpdateTestDriver struct {
 	client      *fake.DynamicResourceClient
 	origBackoff wait.Backoff
 	expectedErr error
-	mutateFn    util.MutateFn
+	mutateFn    util.MutateFn[runtime.Object]
 }
 
 func newCreateOrUpdateTestDiver() *createOrUpdateTestDriver {


### PR DESCRIPTION
This simplifies various wrappers and allows the compiler to check types for us.

For now, this only addresses non-dynamic resource handlers; making the dynamic handlers generic runs into a couple of issues. The first is that the handlers are asymmetric (they take runtime.Objects as input but produce unstructured.Unstructured values as output); this can be fixed, rather nicely, by typing them and making them convert unstructured values back to their input type, but that then requires that *all* users fully specify the type. This causes problems with the federator, which makes extensive use of dynamic handlers but also expects to manage slices of syncers, which also need to be typed, but generics in Go don’t allow that.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
