### PR TITLE
Lock testing.Fake object when modifying its ReactionChain

### DIFF
--- a/pkg/fake/conflict_reactor.go
+++ b/pkg/fake/conflict_reactor.go
@@ -30,6 +30,9 @@ import (
 )
 
 func ConflictOnUpdateReactor(f *testing.Fake, resource string) {
+	f.Lock()
+	defer f.Unlock()
+
 	reactors := f.ReactionChain[0:]
 	resourceVersion := "100"
 	state := sync.Map{}

--- a/pkg/fake/create_reactor.go
+++ b/pkg/fake/create_reactor.go
@@ -36,6 +36,9 @@ type createReactor struct {
 
 // AddCreateReactor adds a reactor to mimic real K8s create behavior to handle GenerateName, validation et al.
 func AddCreateReactor(f *testing.Fake) {
+	f.Lock()
+	defer f.Unlock()
+
 	r := &createReactor{reactors: f.ReactionChain[0:]}
 	f.PrependReactor("create", "*", r.react)
 }

--- a/pkg/fake/delete_colection_reactor.go
+++ b/pkg/fake/delete_colection_reactor.go
@@ -43,8 +43,10 @@ type DeleteCollectionReactor struct {
 }
 
 func AddDeleteCollectionReactor(f *testing.Fake) {
+	f.Lock()
 	r := &DeleteCollectionReactor{gvrToGVK: map[schema.GroupVersionResource]schema.GroupVersionKind{}, reactors: f.ReactionChain[0:]}
 	f.PrependReactor("delete-collection", "*", r.react)
+	f.Unlock()
 
 	for gvk := range scheme.Scheme.AllKnownTypes() {
 		if !strings.HasSuffix(gvk.Kind, "List") {

--- a/pkg/fake/delete_reactor.go
+++ b/pkg/fake/delete_reactor.go
@@ -34,6 +34,9 @@ type deleteReactor struct {
 
 // AddDeleteReactor adds a reactor to mimic real K8s delete behavior to handle ResourceVersion, DeletionTimestamp et al.
 func AddDeleteReactor(f *testing.Fake) {
+	f.Lock()
+	defer f.Unlock()
+
 	r := &deleteReactor{reactors: f.ReactionChain[0:]}
 	f.PrependReactor("delete", "*", r.react)
 }

--- a/pkg/fake/failing_reactor.go
+++ b/pkg/fake/failing_reactor.go
@@ -41,8 +41,11 @@ func NewFailingReactor(f *testing.Fake) *FailingReactor {
 
 func NewFailingReactorForResource(f *testing.Fake, resource string) *FailingReactor {
 	r := &FailingReactor{}
-	chain := []testing.Reactor{&testing.SimpleReactor{Verb: "*", Resource: resource, Reaction: r.react}}
-	f.ReactionChain = append(chain, f.ReactionChain...)
+
+	f.Lock()
+	defer f.Unlock()
+
+	f.PrependReactor("*", resource, r.react)
 
 	return r
 }

--- a/pkg/fake/list_reactor.go
+++ b/pkg/fake/list_reactor.go
@@ -33,6 +33,9 @@ type filteringListReactor struct {
 }
 
 func AddFilteringListReactor(f *testing.Fake) {
+	f.Lock()
+	defer f.Unlock()
+
 	r := &filteringListReactor{reactors: f.ReactionChain[0:]}
 	f.PrependReactor("list", "*", r.react)
 }

--- a/pkg/fake/update_reactor.go
+++ b/pkg/fake/update_reactor.go
@@ -37,6 +37,9 @@ type updateReactor struct {
 
 // AddUpdateReactor adds a reactor to mimic real K8s update behavior to handle ResourceVersion et al.
 func AddUpdateReactor(f *testing.Fake) {
+	f.Lock()
+	defer f.Unlock()
+
 	r := &updateReactor{reactors: f.ReactionChain[0:]}
 	f.PrependReactor("update", "*", r.react)
 }


### PR DESCRIPTION
The lock is acquired when it accesses the `ReactionChain` on invocation but not in `PrependReactor` and `AppendReactor`. It probably assumes that the `ReactionChain` is only modified on startup but there are cases in our code base where we setup a reactor after startup and occasionally encounter a race failure. So explicitly lock the testing.Fake when setting up a reactor.
