### PR TITLE
Don't return error if WaitForCacheSync returns false

### DIFF
--- a/pkg/syncer/resource_syncer.go
+++ b/pkg/syncer/resource_syncer.go
@@ -284,9 +284,7 @@ func (r *resourceSyncer) Start(stopCh <-chan struct{}) error {
 	if *r.config.WaitForCacheSync {
 		r.log.V(log.LIBDEBUG).Infof("Syncer %q waiting for informer cache to sync", r.config.Name)
 
-		if ok := cache.WaitForCacheSync(stopCh, r.informer.HasSynced); !ok {
-			return fmt.Errorf("failed to wait for informer cache to sync")
-		}
+		_ = cache.WaitForCacheSync(stopCh, r.informer.HasSynced)
 	}
 
 	r.workQueue.Run(stopCh, r.processNextWorkItem)


### PR DESCRIPTION
... in` resourceSyncer.Start`. This means the stop channel was closed and we shouldn't treat this as an error.
