### PR TITLE
Automated backport of #765: Don't return error if WaitForCacheSync returns false

### DIFF
--- a/pkg/syncer/resource_syncer.go
+++ b/pkg/syncer/resource_syncer.go
@@ -284,9 +284,7 @@ func (r *resourceSyncer) Start(stopCh <-chan struct{}) error {
 	if *r.config.WaitForCacheSync {
 		r.log.V(log.LIBDEBUG).Infof("Syncer %q waiting for informer cache to sync", r.config.Name)
 
-		if ok := cache.WaitForCacheSync(stopCh, r.informer.HasSynced); !ok {
-			return fmt.Errorf("failed to wait for informer cache to sync")
-		}
+		_ = cache.WaitForCacheSync(stopCh, r.informer.HasSynced)
 	}
 
 	r.workQueue.Run(stopCh, r.processNextWorkItem)


### PR DESCRIPTION
Backport of #765 on release-0.16.

#765: Don't return error if WaitForCacheSync returns false

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.