### PR TITLE
Automated backport of #773: Add ctx parameter to Federator methods

### DIFF
--- a/pkg/federate/base_federator.go
+++ b/pkg/federate/base_federator.go
@@ -63,7 +63,7 @@ func newBaseFederator(dynClient dynamic.Interface, restMapper meta.RESTMapper, t
 	return b
 }
 
-func (f *baseFederator) Delete(obj runtime.Object) error {
+func (f *baseFederator) Delete(ctx context.Context, obj runtime.Object) error {
 	toDelete, resourceClient, err := f.toUnstructured(obj)
 	if err != nil {
 		return err
@@ -71,7 +71,7 @@ func (f *baseFederator) Delete(obj runtime.Object) error {
 
 	logger.V(log.LIBTRACE).Infof("Deleting resource: %#v", toDelete)
 
-	err = resourceClient.Delete(context.TODO(), toDelete.GetName(), metav1.DeleteOptions{})
+	err = resourceClient.Delete(ctx, toDelete.GetName(), metav1.DeleteOptions{})
 
 	if f.eventLogName != "" && err == nil {
 		logger.Infof("%s: Deleted %s \"%s/%s\" ", f.eventLogName, toDelete.GetKind(), toDelete.GetNamespace(), toDelete.GetName())

--- a/pkg/federate/create_federator.go
+++ b/pkg/federate/create_federator.go
@@ -40,7 +40,7 @@ func NewCreateFederator(dynClient dynamic.Interface, restMapper meta.RESTMapper,
 }
 
 //nolint:wrapcheck // This function is effectively a wrapper so no need to wrap errors.
-func (f *createFederator) Distribute(obj runtime.Object) error {
+func (f *createFederator) Distribute(ctx context.Context, obj runtime.Object) error {
 	logger.V(log.LIBTRACE).Infof("In Distribute for %#v", obj)
 
 	toDistribute, resourceClient, err := f.toUnstructured(obj)
@@ -50,7 +50,7 @@ func (f *createFederator) Distribute(obj runtime.Object) error {
 
 	f.prepareResourceForSync(toDistribute)
 
-	_, err = resourceClient.Create(context.TODO(), toDistribute, metav1.CreateOptions{})
+	_, err = resourceClient.Create(ctx, toDistribute, metav1.CreateOptions{})
 	if apierrors.IsAlreadyExists(err) {
 		return nil
 	}

--- a/pkg/federate/create_or_update_federator.go
+++ b/pkg/federate/create_or_update_federator.go
@@ -45,7 +45,7 @@ func NewCreateOrUpdateFederator(dynClient dynamic.Interface, restMapper meta.RES
 }
 
 //nolint:wrapcheck // This function is effectively a wrapper so no need to wrap errors.
-func (f *createOrUpdateFederator) Distribute(obj runtime.Object) error {
+func (f *createOrUpdateFederator) Distribute(ctx context.Context, obj runtime.Object) error {
 	logger.V(log.LIBTRACE).Infof("In Distribute for %#v", obj)
 
 	toDistribute, resourceClient, err := f.toUnstructured(obj)
@@ -59,7 +59,7 @@ func (f *createOrUpdateFederator) Distribute(obj runtime.Object) error {
 
 	f.prepareResourceForSync(toDistribute)
 
-	result, err := util.CreateOrUpdate(context.TODO(), resource.ForDynamic(resourceClient), toDistribute,
+	result, err := util.CreateOrUpdate(ctx, resource.ForDynamic(resourceClient), toDistribute,
 		func(obj runtime.Object) (runtime.Object, error) {
 			return util.CopyImmutableMetadata(obj.(*unstructured.Unstructured), toDistribute), nil
 		})

--- a/pkg/federate/fake/federator.go
+++ b/pkg/federate/fake/federator.go
@@ -20,6 +20,7 @@ limitations under the License.
 package fake
 
 import (
+	"context"
 	"time"
 
 	. "github.com/onsi/gomega"
@@ -42,7 +43,7 @@ func New() *Federator {
 	}
 }
 
-func (f *Federator) Distribute(resource runtime.Object) error {
+func (f *Federator) Distribute(_ context.Context, resource runtime.Object) error {
 	err := f.FailOnDistribute
 	if err != nil {
 		if f.ResetOnFailure {
@@ -57,7 +58,7 @@ func (f *Federator) Distribute(resource runtime.Object) error {
 	return nil
 }
 
-func (f *Federator) Delete(resource runtime.Object) error {
+func (f *Federator) Delete(_ context.Context, resource runtime.Object) error {
 	err := f.FailOnDelete
 	if err != nil {
 		if f.ResetOnFailure {

--- a/pkg/federate/federator.go
+++ b/pkg/federate/federator.go
@@ -19,6 +19,8 @@ limitations under the License.
 package federate
 
 import (
+	"context"
+
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -34,12 +36,12 @@ type Federator interface {
 	//
 	// If the resource was previously distributed and the given resource differs, each previous cluster will receive the
 	// updated resource.
-	Distribute(resource runtime.Object) error
+	Distribute(ctx context.Context, resource runtime.Object) error
 
 	// Delete stops distributing the given resource and deletes it from all clusters to which it was distributed.
 	// The actual deletion may occur asynchronously in which any returned error only indicates that the request
 	// failed.
-	Delete(resource runtime.Object) error
+	Delete(ctx context.Context, resource runtime.Object) error
 }
 
 type FederatorExt interface {
@@ -54,10 +56,10 @@ func NewNoopFederator() Federator {
 	return &noopFederator{}
 }
 
-func (n noopFederator) Distribute(_ runtime.Object) error {
+func (n noopFederator) Distribute(_ context.Context, _ runtime.Object) error {
 	return nil
 }
 
-func (n noopFederator) Delete(_ runtime.Object) error {
+func (n noopFederator) Delete(_ context.Context, _ runtime.Object) error {
 	return nil
 }

--- a/pkg/federate/federator_test.go
+++ b/pkg/federate/federator_test.go
@@ -18,6 +18,7 @@ limitations under the License.
 package federate_test
 
 import (
+	"context"
 	"errors"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -36,6 +37,8 @@ import (
 )
 
 var (
+	ctx = context.Background()
+
 	_ = Describe("CreateOrUpdate Federator", testCreateOrUpdateFederator)
 	_ = Describe("Create Federator", testCreateFederator)
 	_ = Describe("Update Federator", testUpdateFederator)
@@ -61,7 +64,7 @@ func testCreateOrUpdateFederator() {
 	When("the resource does not already exist in the datastore", func() {
 		Context("and a local cluster ID is specified", func() {
 			It("should create the resource with the cluster ID label", func() {
-				Expect(f.Distribute(t.resource)).To(Succeed())
+				Expect(f.Distribute(ctx, t.resource)).To(Succeed())
 				t.verifyResource()
 			})
 		})
@@ -72,7 +75,7 @@ func testCreateOrUpdateFederator() {
 			})
 
 			It("should create the resource without the cluster ID label", func() {
-				Expect(f.Distribute(t.resource)).To(Succeed())
+				Expect(f.Distribute(ctx, t.resource)).To(Succeed())
 				t.verifyResource()
 			})
 		})
@@ -86,7 +89,7 @@ func testCreateOrUpdateFederator() {
 			})
 
 			It("should create the resource with the Status data", func() {
-				Expect(f.Distribute(t.resource)).To(Succeed())
+				Expect(f.Distribute(ctx, t.resource)).To(Succeed())
 				t.verifyResource()
 			})
 		})
@@ -103,7 +106,7 @@ func testCreateOrUpdateFederator() {
 			})
 
 			It("should create the resource with the OwnerReferences", func() {
-				Expect(f.Distribute(t.resource)).To(Succeed())
+				Expect(f.Distribute(ctx, t.resource)).To(Succeed())
 				t.verifyResource()
 			})
 		})
@@ -114,7 +117,7 @@ func testCreateOrUpdateFederator() {
 			})
 
 			It("should return an error", func() {
-				Expect(f.Distribute(t.resource)).ToNot(Succeed())
+				Expect(f.Distribute(ctx, t.resource)).ToNot(Succeed())
 			})
 		})
 
@@ -129,7 +132,7 @@ func testCreateOrUpdateFederator() {
 			})
 
 			It("should update the resource", func() {
-				Expect(f.Distribute(t.resource)).To(Succeed())
+				Expect(f.Distribute(ctx, t.resource)).To(Succeed())
 				t.verifyResource()
 			})
 		})
@@ -143,7 +146,7 @@ func testCreateOrUpdateFederator() {
 		})
 
 		It("should update the resource", func() {
-			Expect(f.Distribute(t.resource)).To(Succeed())
+			Expect(f.Distribute(ctx, t.resource)).To(Succeed())
 			t.verifyResource()
 		})
 
@@ -153,7 +156,7 @@ func testCreateOrUpdateFederator() {
 			})
 
 			It("should retry until it succeeds", func() {
-				Expect(f.Distribute(t.resource)).To(Succeed())
+				Expect(f.Distribute(ctx, t.resource)).To(Succeed())
 				t.verifyResource()
 			})
 		})
@@ -164,7 +167,7 @@ func testCreateOrUpdateFederator() {
 			})
 
 			It("should return an error", func() {
-				Expect(f.Distribute(t.resource)).ToNot(Succeed())
+				Expect(f.Distribute(ctx, t.resource)).ToNot(Succeed())
 			})
 		})
 	})
@@ -175,7 +178,7 @@ func testCreateOrUpdateFederator() {
 		})
 
 		It("should return an error", func() {
-			Expect(f.Distribute(t.resource)).ToNot(Succeed())
+			Expect(f.Distribute(ctx, t.resource)).ToNot(Succeed())
 		})
 	})
 
@@ -186,7 +189,7 @@ func testCreateOrUpdateFederator() {
 		})
 
 		It("should create the resource in the source namespace", func() {
-			Expect(f.Distribute(t.resource)).To(Succeed())
+			Expect(f.Distribute(ctx, t.resource)).To(Succeed())
 			t.verifyResource()
 		})
 	})
@@ -210,7 +213,7 @@ func testCreateFederator() {
 
 	When("the resource does not already exist in the datastore", func() {
 		It("create the resource", func() {
-			Expect(f.Distribute(t.resource)).To(Succeed())
+			Expect(f.Distribute(ctx, t.resource)).To(Succeed())
 			t.verifyResource()
 		})
 
@@ -220,7 +223,7 @@ func testCreateFederator() {
 			})
 
 			It("should return an error", func() {
-				Expect(f.Distribute(t.resource)).ToNot(Succeed())
+				Expect(f.Distribute(ctx, t.resource)).ToNot(Succeed())
 			})
 		})
 	})
@@ -232,7 +235,7 @@ func testCreateFederator() {
 		})
 
 		It("should succeed and not update the resource", func() {
-			Expect(f.Distribute(test.NewPodWithImage(test.LocalNamespace, "apache"))).To(Succeed())
+			Expect(f.Distribute(ctx, test.NewPodWithImage(test.LocalNamespace, "apache"))).To(Succeed())
 			t.verifyResource()
 		})
 	})
@@ -263,7 +266,7 @@ func testUpdateFederator() {
 		})
 
 		It("should update the resource", func() {
-			Expect(f.Distribute(t.resource)).To(Succeed())
+			Expect(f.Distribute(ctx, t.resource)).To(Succeed())
 			t.verifyResource()
 		})
 
@@ -273,7 +276,7 @@ func testUpdateFederator() {
 			})
 
 			It("should retry until it succeeds", func() {
-				Expect(f.Distribute(t.resource)).To(Succeed())
+				Expect(f.Distribute(ctx, t.resource)).To(Succeed())
 				t.verifyResource()
 			})
 
@@ -283,7 +286,7 @@ func testUpdateFederator() {
 				})
 
 				It("should return an error", func() {
-					Expect(f.Distribute(t.resource)).ToNot(Succeed())
+					Expect(f.Distribute(ctx, t.resource)).ToNot(Succeed())
 				})
 			})
 		})
@@ -294,14 +297,14 @@ func testUpdateFederator() {
 			})
 
 			It("should return an error", func() {
-				Expect(f.Distribute(t.resource)).ToNot(Succeed())
+				Expect(f.Distribute(ctx, t.resource)).ToNot(Succeed())
 			})
 		})
 	})
 
 	When("the resource does not exist in the datastore", func() {
 		It("should succeed", func() {
-			Expect(f.Distribute(t.resource)).To(Succeed())
+			Expect(f.Distribute(ctx, t.resource)).To(Succeed())
 		})
 	})
 }
@@ -337,7 +340,7 @@ func testUpdateStatusFederator() {
 				},
 			}
 
-			Expect(f.Distribute(t.resource)).To(Succeed())
+			Expect(f.Distribute(ctx, t.resource)).To(Succeed())
 			t.verifyResource()
 		})
 	})
@@ -355,7 +358,7 @@ func testUpdateStatusFederator() {
 				PodIP: "1.2.3.4",
 			}
 
-			Expect(f.Distribute(t.resource)).To(Succeed())
+			Expect(f.Distribute(ctx, t.resource)).To(Succeed())
 			t.verifyResource()
 		})
 	})
@@ -376,7 +379,7 @@ func testUpdateStatusFederator() {
 			t.resource.Annotations = map[string]string{"key1": "abc"}
 			t.resource.Labels = map[string]string{"key2": "def"}
 
-			Expect(f.Distribute(t.resource)).To(Succeed())
+			Expect(f.Distribute(ctx, t.resource)).To(Succeed())
 
 			t.resource = prev
 
@@ -408,7 +411,7 @@ func testDelete() {
 		})
 
 		It("should delete the resource", func() {
-			Expect(f.Delete(t.resource)).To(Succeed())
+			Expect(f.Delete(ctx, t.resource)).To(Succeed())
 
 			_, err := test.GetResourceAndError(t.resourceClient, t.resource)
 			Expect(apierrors.IsNotFound(err)).To(BeTrue())
@@ -420,7 +423,7 @@ func testDelete() {
 			})
 
 			It("should return an error", func() {
-				Expect(f.Delete(t.resource)).ToNot(Succeed())
+				Expect(f.Delete(ctx, t.resource)).ToNot(Succeed())
 			})
 		})
 
@@ -431,7 +434,7 @@ func testDelete() {
 			})
 
 			It("should delete the resource from the source namespace", func() {
-				Expect(f.Delete(t.resource)).To(Succeed())
+				Expect(f.Delete(ctx, t.resource)).To(Succeed())
 
 				_, err := test.GetResourceAndError(t.resourceClient, t.resource)
 				Expect(apierrors.IsNotFound(err)).To(BeTrue())
@@ -441,7 +444,7 @@ func testDelete() {
 
 	When("the resource does not exist in the datastore", func() {
 		It("should return NotFound error", func() {
-			Expect(apierrors.IsNotFound(f.Delete(t.resource))).To(BeTrue())
+			Expect(apierrors.IsNotFound(f.Delete(ctx, t.resource))).To(BeTrue())
 		})
 	})
 }

--- a/pkg/federate/update_federator.go
+++ b/pkg/federate/update_federator.go
@@ -53,7 +53,7 @@ func NewUpdateStatusFederator(dynClient dynamic.Interface, restMapper meta.RESTM
 }
 
 //nolint:wrapcheck // This function is effectively a wrapper so no need to wrap errors.
-func (f *updateFederator) Distribute(obj runtime.Object) error {
+func (f *updateFederator) Distribute(ctx context.Context, obj runtime.Object) error {
 	logger.V(log.LIBTRACE).Infof("In Distribute for %#v", obj)
 
 	toUpdate, resourceClient, err := f.toUnstructured(obj)
@@ -63,7 +63,7 @@ func (f *updateFederator) Distribute(obj runtime.Object) error {
 
 	f.prepareResourceForSync(toUpdate)
 
-	return util.Update(context.TODO(), resource.ForDynamic(resourceClient), toUpdate, func(obj runtime.Object) (runtime.Object, error) {
+	return util.Update(ctx, resource.ForDynamic(resourceClient), toUpdate, func(obj runtime.Object) (runtime.Object, error) {
 		return f.update(obj.(*unstructured.Unstructured), toUpdate), nil
 	})
 }

--- a/pkg/syncer/broker/syncer_test.go
+++ b/pkg/syncer/broker/syncer_test.go
@@ -496,7 +496,7 @@ var _ = Describe("Broker Syncer", func() {
 		Expect(f).ToNot(BeNil())
 
 		name := string(uuid.NewUUID())
-		Expect(f.Distribute(&corev1.Pod{
+		Expect(f.Distribute(context.Background(), &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
 			},
@@ -518,7 +518,7 @@ var _ = Describe("Broker Syncer", func() {
 		Expect(f).ToNot(BeNil())
 
 		name := string(uuid.NewUUID())
-		Expect(f.Distribute(&corev1.Pod{
+		Expect(f.Distribute(context.Background(), &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
 			},

--- a/pkg/syncer/resource_syncer.go
+++ b/pkg/syncer/resource_syncer.go
@@ -458,7 +458,7 @@ func (r *resourceSyncer) processNextWorkItem(key, _, _ string) (bool, error) {
 
 		r.log.V(log.LIBDEBUG).Infof("Syncer %q syncing resource %q", r.config.Name, resource.GetName())
 
-		err = r.config.Federator.Distribute(resource)
+		err = r.config.Federator.Distribute(context.Background(), resource)
 		if err != nil || r.onSuccessfulSync(resource, transformed, op) {
 			return true, errors.Wrapf(err, "error distributing resource %q", key)
 		}
@@ -503,7 +503,7 @@ func (r *resourceSyncer) handleDeleted(key string) (bool, error) {
 
 		deleted := true
 
-		err := r.config.Federator.Delete(resource)
+		err := r.config.Federator.Delete(context.Background(), resource)
 		if apierrors.IsNotFound(err) {
 			r.log.V(log.LIBDEBUG).Infof("Syncer %q: resource %q not found", r.config.Name, resource.GetName())
 


### PR DESCRIPTION
Backport of #773 on release-0.16.

#773: Add ctx parameter to Federator methods

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.