### PR TITLE
Change ForDynamic to proper generic type *Unstructured

### DIFF
--- a/pkg/federate/create_or_update_federator.go
+++ b/pkg/federate/create_or_update_federator.go
@@ -58,9 +58,9 @@ func (f *createOrUpdateFederator) Distribute(ctx context.Context, obj runtime.Ob
 
 	f.prepareResourceForSync(toDistribute)
 
-	result, err := util.CreateOrUpdate[runtime.Object](ctx, resource.ForDynamic(resourceClient), toDistribute,
-		func(obj runtime.Object) (runtime.Object, error) {
-			return util.CopyImmutableMetadata(obj.(*unstructured.Unstructured), toDistribute), nil
+	result, err := util.CreateOrUpdate[*unstructured.Unstructured](ctx, resource.ForDynamic(resourceClient), toDistribute,
+		func(obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+			return util.CopyImmutableMetadata(obj, toDistribute), nil
 		})
 
 	if f.eventLogName != "" {

--- a/pkg/federate/update_federator.go
+++ b/pkg/federate/update_federator.go
@@ -62,8 +62,8 @@ func (f *updateFederator) Distribute(ctx context.Context, obj runtime.Object) er
 
 	f.prepareResourceForSync(toUpdate)
 
-	return util.Update[runtime.Object](ctx, resource.ForDynamic(resourceClient), toUpdate,
-		func(obj runtime.Object) (runtime.Object, error) {
-			return f.update(obj.(*unstructured.Unstructured), toUpdate), nil
+	return util.Update[*unstructured.Unstructured](ctx, resource.ForDynamic(resourceClient), toUpdate,
+		func(obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+			return f.update(obj, toUpdate), nil
 		})
 }

--- a/pkg/resource/interface_test.go
+++ b/pkg/resource/interface_test.go
@@ -30,6 +30,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -191,14 +192,14 @@ var _ = Describe("Interface", func() {
 	})
 
 	Context("ForDynamic", func() {
-		testInterfaceFuncs(func() resource.Interface[runtime.Object] {
+		testInterfaceFuncs(func() resource.Interface[*unstructured.Unstructured] {
 			return resource.ForDynamic(dynamicfake.NewSimpleDynamicClient(scheme.Scheme).Resource(
 				schema.GroupVersionResource{
 					Group:    corev1.SchemeGroupVersion.Group,
 					Version:  corev1.SchemeGroupVersion.Version,
 					Resource: "pods",
 				}).Namespace(test.LocalNamespace))
-		}, runtime.Object(resource.MustToUnstructured(&corev1.Pod{
+		}, resource.MustToUnstructured(&corev1.Pod{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "Pod",
 				APIVersion: "v1",
@@ -210,7 +211,7 @@ var _ = Describe("Interface", func() {
 			Spec: corev1.PodSpec{
 				Hostname: "my-host",
 			},
-		})))
+		}))
 	})
 })
 

--- a/pkg/syncer/test/util.go
+++ b/pkg/syncer/test/util.go
@@ -46,10 +46,7 @@ const (
 )
 
 func GetResourceAndError(resourceInterface dynamic.ResourceInterface, obj runtime.Object) (*unstructured.Unstructured, error) {
-	meta, err := metaapi.Accessor(obj)
-	Expect(err).To(Succeed())
-
-	return resourceInterface.Get(context.TODO(), meta.GetName(), metav1.GetOptions{})
+	return resourceInterface.Get(context.TODO(), resource.MustToMeta(obj).GetName(), metav1.GetOptions{})
 }
 
 func GetResource(resourceInterface dynamic.ResourceInterface, obj runtime.Object) *unstructured.Unstructured {
@@ -70,8 +67,9 @@ func CreateResource(resourceInterface dynamic.ResourceInterface, obj runtime.Obj
 }
 
 func UpdateResource(resourceInterface dynamic.ResourceInterface, obj runtime.Object) *unstructured.Unstructured {
-	err := util.Update[runtime.Object](context.Background(), resource.ForDynamic(resourceInterface), obj,
-		util.Replace(obj))
+	u := resource.MustToUnstructured(obj)
+	err := util.Update[*unstructured.Unstructured](context.Background(), resource.ForDynamic(resourceInterface), u,
+		util.Replace(u))
 	Expect(err).To(Succeed())
 
 	return GetResource(resourceInterface, obj)


### PR DESCRIPTION
...instead of `runtime.Object`, which I think was used originally to preserve the behavior of allowing any `runtime.Object` and internally converting to `*Unstructured` but we can easily adjust users accordingly.

Some resource syncer unit tests failed b/c previously `ForDynamic` had the side effect of actually modifying the resource on `Update` and the tests did not explicitly retrieve the updated resource after `test.UpdateResource`. The fake `Federator` was also modified to internally convert to `*Unstructured` to simplify users.
