### PR TITLE
Delete resource when finalizers are empty in fake reactor

### DIFF
--- a/pkg/fake/update_reactor.go
+++ b/pkg/fake/update_reactor.go
@@ -74,5 +74,9 @@ func (r *updateReactor) react(a testing.Action) (bool, runtime.Object, error) {
 
 	obj, err := invokeReactors(action, r.reactors)
 
+	if err == nil && !target.GetDeletionTimestamp().IsZero() && len(target.GetFinalizers()) == 0 {
+		_, err = invokeReactors(testing.NewDeleteAction(action.GetResource(), action.GetNamespace(), target.GetName()), r.reactors)
+	}
+
 	return true, obj, err
 }


### PR DESCRIPTION
When a resource is deleting and the finalizers become empty on update, delete the resource. This mimics the real K8s behavior.

Also don't update the `DeletionTimestamp` on delete if already set.