### PR TITLE
Automated backport of #838: Add Makefile.shipyard to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /bin
 dist
 Makefile.dapper
+Makefile.shipyard
 output
 /vendor
 *.coverprofile


### PR DESCRIPTION
Backport of #838 on release-0.17.

#838: Add Makefile.shipyard to .gitignore

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.