### PR TITLE
Automated backport of #867: Only fail builds for high+ vulns

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -106,7 +106,7 @@ jobs:
         with:
           path: "."
           fail-build: true
-          severity-cutoff: negligible
+          severity-cutoff: high
       - name: Show Anchore scan SARIF report
         if: always()
         run: cat ${{ steps.scan.outputs.sarif }}


### PR DESCRIPTION
Backport of #867 on release-0.16.

#867: Only fail builds for high+ vulns

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.