### PR TITLE
Trim ManagedFields in the resource syncer to

### DIFF
--- a/test/e2e/watcher/watcher.go
+++ b/test/e2e/watcher/watcher.go
@@ -36,6 +36,7 @@ var _ = Describe("[watcher] Resource watcher tests", func() {
 		It("should notify the handler of each event", func() {
 			clusterName := framework.TestContext.ClusterIDs[framework.ClusterA]
 			toaster := util.CreateToaster(t.client, util.NewToaster("test-toaster", t.framework.Namespace), clusterName)
+			toaster.SetManagedFields(nil)
 			Eventually(t.created).Should(Receive(Equal(toaster)))
 
 			util.DeleteToaster(t.client, toaster, clusterName)


### PR DESCRIPTION
...reduce the informer cache memory usage.

Fixes https://github.com/submariner-io/admiral/issues/859
