### PR TITLE
Fix data race due to trimming ManagedFields in resource syncer

### DIFF
--- a/pkg/syncer/resource_syncer.go
+++ b/pkg/syncer/resource_syncer.go
@@ -257,7 +257,11 @@ func NewResourceSyncer(config *ResourceSyncerConfig) (Interface, error) {
 		UpdateFunc: syncer.onUpdate,
 		DeleteFunc: syncer.onDelete,
 	}, func(obj interface{}) (interface{}, error) {
-		resourceUtil.MustToMeta(obj).SetManagedFields(nil)
+		objMeta, err := meta.Accessor(obj)
+		if err == nil && len(objMeta.GetManagedFields()) > 0 {
+			objMeta.SetManagedFields(nil)
+		}
+
 		return obj, nil
 	})
 

--- a/pkg/syncer/resource_syncer_test.go
+++ b/pkg/syncer/resource_syncer_test.go
@@ -45,6 +45,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/dynamic"
 	fakeClient "k8s.io/client-go/dynamic/fake"
+	"k8s.io/utils/ptr"
 )
 
 var _ = Describe("Resource Syncer", func() {
@@ -69,6 +70,7 @@ var _ = Describe("Resource Syncer", func() {
 		Context(fmt.Sprintf("Direction: %s", syncer.RemoteToLocal), testReconcileRemoteToLocal)
 		Context(fmt.Sprintf("Direction: %s", syncer.None), testReconcileNoDirection)
 	})
+	Describe("Trim Resource Fields", testTrimResourceFields)
 })
 
 func testReconcileLocalToRemote() {
@@ -1183,6 +1185,37 @@ func testRequeueResource() {
 	})
 }
 
+func testTrimResourceFields() {
+	d := newTestDriver(test.LocalNamespace, "", syncer.LocalToRemote)
+
+	BeforeEach(func() {
+		d.config.ResyncPeriod = time.Millisecond * 100
+
+		d.resource.SetManagedFields([]metav1.ManagedFieldsEntry{
+			{
+				Manager:    "kubectl",
+				Operation:  metav1.ManagedFieldsOperationApply,
+				APIVersion: "v1",
+				Time:       ptr.To(metav1.Now()),
+				FieldsType: "FieldsV1",
+				FieldsV1:   ptr.To(metav1.FieldsV1{}),
+			},
+		})
+
+		d.addInitialResource(d.resource)
+	})
+
+	It("should remove ManagedFields from created resources", func() {
+		obj, exists, err := d.syncer.GetResource(d.resource.Name, d.resource.Namespace)
+		Expect(err).To(Succeed())
+		Expect(exists).To(BeTrue())
+		Expect(resourceutils.MustToMeta(obj).GetManagedFields()).Should(BeNil())
+
+		// Sleep a little so a re-sync occurs and doesn't cause a data race.
+		time.Sleep(200)
+	})
+}
+
 func assertResourceList(actual []runtime.Object, expected ...*corev1.Pod) {
 	expSpecs := map[string]*corev1.PodSpec{}
 	for i := range expected {
@@ -1236,6 +1269,7 @@ func newTestDriver(sourceNamespace, localClusterID string, syncDirection syncer.
 		d.config.Transform = nil
 		d.config.OnSuccessfulSync = nil
 		d.config.ResourcesEquivalent = nil
+		d.config.ResyncPeriod = 0
 
 		err := corev1.AddToScheme(d.config.Scheme)
 		Expect(err).To(Succeed())


### PR DESCRIPTION
This was observed in a unit test elsewhere that configures a resync period. On re-sync, the K8s `DeltaFIFO` retrieves every object from the cache store and re-queues them. It also invokes the transform function which results in a data race when the resource syncer tries to nil the `ManagedFields`. This is because the object instance is the same as that stored in the cache which was previously accessed by another thread. So mutating it without the protection of a lock is unsafe. This is really an issue with the `DeltaFIFO` - it is documented that the "_TransformFunc sees the object before any other actor, and it is now safe to mutate the object in place instead of making a copy_" however this is not the case on a re-sync. The `DeltaFIFO` should either elide the `TransformFunc` on re-sync or make a copy of the object retrieved from the cache store.

As a workaround, the resource syncer should only set `ManagedFields` to nil if it is non-nil, which will be the case a a re-sync. Added a unit test to cover this case.

Also the object passed to the `TransformFunc` could be a `DeletedFinalStateUnknown` so we need to handle that as well.
