### PR TITLE
Add IsMissingNamespaceErr function

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,9 @@ linters-settings:
       - opinionated
       - performance
       - style
+    disabled-checks:
+      - ifElseChain
+      - unnamedResult
   gocyclo:
     min-complexity: 15
   goheader:

--- a/pkg/resource/errors.go
+++ b/pkg/resource/errors.go
@@ -42,3 +42,16 @@ func IsNotFoundErr(err error) bool {
 
 	return false
 }
+
+func IsMissingNamespaceErr(err error) (bool, string) {
+	if !apierrors.IsNotFound(err) {
+		return false, ""
+	}
+
+	var status apierrors.APIStatus
+	_ = errors.As(err, &status)
+
+	d := status.Status().Details
+
+	return d != nil && d.Kind == "namespaces" && d.Group == "", d.Name
+}

--- a/pkg/resource/errors_test.go
+++ b/pkg/resource/errors_test.go
@@ -67,3 +67,31 @@ var _ = Describe("IsNotFoundErr", func() {
 		})
 	})
 })
+
+var _ = Describe("IsMissingNamespaceErr", func() {
+	When("the error isn't NotFound", func() {
+		It("should return false", func() {
+			ok, _ := resource.IsMissingNamespaceErr(apierrors.NewBadRequest(""))
+			Expect(ok).To(BeFalse())
+		})
+	})
+
+	When("the error details specify a namespace", func() {
+		It("should return true and the name", func() {
+			ok, name := resource.IsMissingNamespaceErr(apierrors.NewNotFound(schema.GroupResource{
+				Resource: "namespaces",
+			}, "missing-ns"))
+			Expect(ok).To(BeTrue())
+			Expect(name).To(Equal("missing-ns"))
+		})
+	})
+
+	When("the error details does not specify a namespace", func() {
+		It("should return false", func() {
+			ok, _ := resource.IsMissingNamespaceErr(apierrors.NewNotFound(schema.GroupResource{
+				Resource: "pods",
+			}, "missing"))
+			Expect(ok).To(BeFalse())
+		})
+	})
+})


### PR DESCRIPTION
Checks if the error indicates the namespace for a resource is missing when trying to create it. In this case the error is NotFound and the status details reflects the "namespaces" Kind. For example:

```
{
  "ErrStatus": {
    "status": "Failure",
    "message": "namespaces \"foo\" not found",
    "reason": "NotFound",
    "details": {
      "name": "foo",
      "kind": "namespaces"
    },
    "code": 404
  }
}

```
