### PR TITLE
Automated backport of #905: Add IsMissingNamespaceErr function

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,9 @@ linters-settings:
       - opinionated
       - performance
       - style
+    disabled-checks:
+      - ifElseChain
+      - unnamedResult
   gocyclo:
     min-complexity: 15
   goheader:

--- a/pkg/resource/errors.go
+++ b/pkg/resource/errors.go
@@ -42,3 +42,16 @@ func IsNotFoundErr(err error) bool {
 
 	return false
 }
+
+func IsMissingNamespaceErr(err error) (bool, string) {
+	if !apierrors.IsNotFound(err) {
+		return false, ""
+	}
+
+	var status apierrors.APIStatus
+	_ = errors.As(err, &status)
+
+	d := status.Status().Details
+
+	return d != nil && d.Kind == "namespaces" && d.Group == "", d.Name
+}

--- a/pkg/resource/errors_test.go
+++ b/pkg/resource/errors_test.go
@@ -67,3 +67,31 @@ var _ = Describe("IsNotFoundErr", func() {
 		})
 	})
 })
+
+var _ = Describe("IsMissingNamespaceErr", func() {
+	When("the error isn't NotFound", func() {
+		It("should return false", func() {
+			ok, _ := resource.IsMissingNamespaceErr(apierrors.NewBadRequest(""))
+			Expect(ok).To(BeFalse())
+		})
+	})
+
+	When("the error details specify a namespace", func() {
+		It("should return true and the name", func() {
+			ok, name := resource.IsMissingNamespaceErr(apierrors.NewNotFound(schema.GroupResource{
+				Resource: "namespaces",
+			}, "missing-ns"))
+			Expect(ok).To(BeTrue())
+			Expect(name).To(Equal("missing-ns"))
+		})
+	})
+
+	When("the error details does not specify a namespace", func() {
+		It("should return false", func() {
+			ok, _ := resource.IsMissingNamespaceErr(apierrors.NewNotFound(schema.GroupResource{
+				Resource: "pods",
+			}, "missing"))
+			Expect(ok).To(BeFalse())
+		})
+	})
+})


### PR DESCRIPTION
Backport of #905 on release-0.16.

#905: Add IsMissingNamespaceErr function

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.