### PR TITLE
Automated backport of #905: Add IsMissingNamespaceErr function

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,9 @@ linters-settings:
       - opinionated
       - performance
       - style
+    disabled-checks:
+      - ifElseChain
+      - unnamedResult
   gocyclo:
     min-complexity: 15
   goheader:

--- a/pkg/resource/errors.go
+++ b/pkg/resource/errors.go
@@ -1,0 +1,38 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"errors"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+func IsMissingNamespaceErr(err error) (bool, string) {
+	if !apierrors.IsNotFound(err) {
+		return false, ""
+	}
+
+	var status apierrors.APIStatus
+	_ = errors.As(err, &status)
+
+	d := status.Status().Details
+
+	return d != nil && d.Kind == "namespaces" && d.Group == "", d.Name
+}

--- a/pkg/resource/errors_test.go
+++ b/pkg/resource/errors_test.go
@@ -1,0 +1,55 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/resource"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var _ = Describe("IsMissingNamespaceErr", func() {
+	When("the error isn't NotFound", func() {
+		It("should return false", func() {
+			ok, _ := resource.IsMissingNamespaceErr(apierrors.NewBadRequest(""))
+			Expect(ok).To(BeFalse())
+		})
+	})
+
+	When("the error details specify a namespace", func() {
+		It("should return true and the name", func() {
+			ok, name := resource.IsMissingNamespaceErr(apierrors.NewNotFound(schema.GroupResource{
+				Resource: "namespaces",
+			}, "missing-ns"))
+			Expect(ok).To(BeTrue())
+			Expect(name).To(Equal("missing-ns"))
+		})
+	})
+
+	When("the error details does not specify a namespace", func() {
+		It("should return false", func() {
+			ok, _ := resource.IsMissingNamespaceErr(apierrors.NewNotFound(schema.GroupResource{
+				Resource: "pods",
+			}, "missing"))
+			Expect(ok).To(BeFalse())
+		})
+	})
+})


### PR DESCRIPTION
Backport of #905 on release-0.15.

#905: Add IsMissingNamespaceErr function

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.