### PR TITLE
Make IsMissingNamespaceErr return bool only, split func

### DIFF
--- a/pkg/resource/errors.go
+++ b/pkg/resource/errors.go
@@ -43,9 +43,9 @@ func IsNotFoundErr(err error) bool {
 	return false
 }
 
-func IsMissingNamespaceErr(err error) (bool, string) {
+func IsMissingNamespaceErr(err error) bool {
 	if !apierrors.IsNotFound(err) {
-		return false, ""
+		return false
 	}
 
 	var status apierrors.APIStatus
@@ -53,5 +53,18 @@ func IsMissingNamespaceErr(err error) (bool, string) {
 
 	d := status.Status().Details
 
-	return d != nil && d.Kind == "namespaces" && d.Group == "", d.Name
+	return d != nil && d.Kind == "namespaces" && d.Group == ""
+}
+
+func ExtractMissingNamespaceFromErr(err error) string {
+	if !IsMissingNamespaceErr(err) {
+		return ""
+	}
+
+	var status apierrors.APIStatus
+	_ = errors.As(err, &status)
+
+	d := status.Status().Details
+
+	return d.Name
 }

--- a/pkg/resource/errors_test.go
+++ b/pkg/resource/errors_test.go
@@ -68,30 +68,28 @@ var _ = Describe("IsNotFoundErr", func() {
 	})
 })
 
-var _ = Describe("IsMissingNamespaceErr", func() {
+var _ = Describe("IsMissingNamespaceErr and ExtractMissingNamespaceFromErr", func() {
 	When("the error isn't NotFound", func() {
 		It("should return false", func() {
-			ok, _ := resource.IsMissingNamespaceErr(apierrors.NewBadRequest(""))
-			Expect(ok).To(BeFalse())
+			Expect(resource.IsMissingNamespaceErr(apierrors.NewBadRequest(""))).To(BeFalse())
 		})
 	})
 
 	When("the error details specify a namespace", func() {
-		It("should return true and the name", func() {
-			ok, name := resource.IsMissingNamespaceErr(apierrors.NewNotFound(schema.GroupResource{
+		It("should return true, and the name should be retrievable", func() {
+			err := apierrors.NewNotFound(schema.GroupResource{
 				Resource: "namespaces",
-			}, "missing-ns"))
-			Expect(ok).To(BeTrue())
-			Expect(name).To(Equal("missing-ns"))
+			}, "missing-ns")
+			Expect(resource.IsMissingNamespaceErr(err)).To(BeTrue())
+			Expect(resource.ExtractMissingNamespaceFromErr(err)).To(Equal("missing-ns"))
 		})
 	})
 
 	When("the error details does not specify a namespace", func() {
 		It("should return false", func() {
-			ok, _ := resource.IsMissingNamespaceErr(apierrors.NewNotFound(schema.GroupResource{
+			Expect(resource.IsMissingNamespaceErr(apierrors.NewNotFound(schema.GroupResource{
 				Resource: "pods",
-			}, "missing"))
-			Expect(ok).To(BeFalse())
+			}, "missing"))).To(BeFalse())
 		})
 	})
 })


### PR DESCRIPTION
In practice I find IsMissingNamespaceErr cumbersome to use, since it always requires storing its result in variables even though common usage patterns involve if statements.

Splitting it into two functions this. The repeated processing shouldn't be an issue in practice, especially since (current) uses of this function only happen once in the lifetime of a given program.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
