### PR TITLE
Use informer to retry failed resources due to missing namespace

### DIFF
--- a/pkg/fake/basic_reactors_test.go
+++ b/pkg/fake/basic_reactors_test.go
@@ -74,6 +74,31 @@ var _ = Describe("Create", func() {
 			Expect(err).To(HaveOccurred())
 		})
 	})
+
+	Context("with namespace verification", func() {
+		BeforeEach(func() {
+			fake.AddVerifyNamespaceReactor(&t.client.Fake, "pods")
+		})
+
+		When("the namespace does not exist", func() {
+			It("should return an error", func() {
+				_, err := t.doCreate(t.pod)
+				Expect(resource.IsMissingNamespaceErr(err)).To(BeTrue())
+				Expect(resource.ExtractMissingNamespaceFromErr(err)).To(Equal(testNamespace))
+			})
+		})
+
+		When("the namespace does exist", func() {
+			It("should succeed", func() {
+				_, err := t.client.CoreV1().Namespaces().Create(context.TODO(), &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{Name: testNamespace},
+				}, metav1.CreateOptions{})
+				Expect(err).To(Succeed())
+
+				t.assertCreateSuccess(t.pod)
+			})
+		})
+	})
 })
 
 var _ = Describe("Update", func() {

--- a/pkg/fake/verify_namespace_reactor.go
+++ b/pkg/fake/verify_namespace_reactor.go
@@ -1,0 +1,50 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/testing"
+)
+
+func AddVerifyNamespaceReactor(f *testing.Fake, resources ...string) {
+	f.Lock()
+	defer f.Unlock()
+
+	reactors := f.ReactionChain[0:]
+
+	react := func(a testing.Action) (bool, runtime.Object, error) {
+		action := a.(testing.CreateAction)
+
+		namespace := action.GetNamespace()
+
+		_, err := invokeReactors(testing.NewGetAction(corev1.SchemeGroupVersion.WithResource("namespaces"), "", namespace),
+			reactors)
+		if err != nil {
+			return true, nil, err
+		}
+
+		return false, nil, nil
+	}
+
+	for _, res := range resources {
+		f.PrependReactor("create", res, react)
+	}
+}

--- a/pkg/syncer/broker/syncer.go
+++ b/pkg/syncer/broker/syncer.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/utils/ptr"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -134,6 +135,9 @@ type SyncerConfig struct {
 
 	// Scheme used to convert resource objects. By default the global k8s Scheme is used.
 	Scheme *runtime.Scheme
+
+	// NamespaceInformer if specified, used to retry local resources that initially failed due to missing namespace.
+	NamespaceInformer cache.SharedInformer
 }
 
 type Syncer struct {
@@ -254,6 +258,7 @@ func NewSyncer(config SyncerConfig) (*Syncer, error) { //nolint:gocritic // Mini
 			Scheme:              config.Scheme,
 			ResyncPeriod:        rc.BrokerResyncPeriod,
 			SyncCounter:         syncCounter,
+			NamespaceInformer:   config.NamespaceInformer,
 		})
 		if err != nil {
 			return nil, errors.Wrap(err, "error creating remote resource syncer")


### PR DESCRIPTION
...rather than exponential re-queuing which is problematic at scale. The user can specify a `SharedInformer` that is used to requeue resources that had previously failed when a missing namespace is later created.
