### PR TITLE
Automated backport of #895: Add support for resource syncer to use a shared informer
#913: Use informer to retry failed resources due to missing

### DIFF
--- a/pkg/fake/basic_reactors_test.go
+++ b/pkg/fake/basic_reactors_test.go
@@ -74,6 +74,32 @@ var _ = Describe("Create", func() {
 			Expect(err).To(HaveOccurred())
 		})
 	})
+
+	Context("with namespace verification", func() {
+		BeforeEach(func() {
+			fake.AddVerifyNamespaceReactor(&t.client.Fake, "pods")
+		})
+
+		When("the namespace does not exist", func() {
+			It("should return an error", func() {
+				_, err := t.doCreate(t.pod)
+				missing, ns := resource.IsMissingNamespaceErr(err)
+				Expect(missing).To(BeTrue())
+				Expect(ns).To(Equal(testNamespace))
+			})
+		})
+
+		When("the namespace does exist", func() {
+			It("should succeed", func() {
+				_, err := t.client.CoreV1().Namespaces().Create(context.TODO(), &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{Name: testNamespace},
+				}, metav1.CreateOptions{})
+				Expect(err).To(Succeed())
+
+				t.assertCreateSuccess(t.pod)
+			})
+		})
+	})
 })
 
 var _ = Describe("Update", func() {

--- a/pkg/fake/verify_namespace_reactor.go
+++ b/pkg/fake/verify_namespace_reactor.go
@@ -1,0 +1,50 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/testing"
+)
+
+func AddVerifyNamespaceReactor(f *testing.Fake, resources ...string) {
+	f.Lock()
+	defer f.Unlock()
+
+	reactors := f.ReactionChain[0:]
+
+	react := func(a testing.Action) (bool, runtime.Object, error) {
+		action := a.(testing.CreateAction)
+
+		namespace := action.GetNamespace()
+
+		_, err := invokeReactors(testing.NewGetAction(corev1.SchemeGroupVersion.WithResource("namespaces"), "", namespace),
+			reactors)
+		if err != nil {
+			return true, nil, err
+		}
+
+		return false, nil, nil
+	}
+
+	for _, res := range resources {
+		f.PrependReactor("create", res, react)
+	}
+}

--- a/pkg/resource/util.go
+++ b/pkg/resource/util.go
@@ -125,3 +125,14 @@ func ToJSON(o any) string {
 	out, _ := json.MarshalIndent(o, "", "  ")
 	return string(out)
 }
+
+// TrimManagedFields is a cache.TransformFunc that removes the ManagedFields metadata field if present. Note that if 'obj' does not
+// implement metav1.Object then it is ignored and no error is returned.
+func TrimManagedFields(obj interface{}) (interface{}, error) {
+	objMeta, err := meta.Accessor(obj)
+	if err == nil && len(objMeta.GetManagedFields()) > 0 {
+		objMeta.SetManagedFields(nil)
+	}
+
+	return obj, nil
+}

--- a/pkg/syncer/broker/syncer.go
+++ b/pkg/syncer/broker/syncer.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/utils/ptr"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -134,6 +135,9 @@ type SyncerConfig struct {
 
 	// Scheme used to convert resource objects. By default the global k8s Scheme is used.
 	Scheme *runtime.Scheme
+
+	// NamespaceInformer if specified, used to retry local resources that initially failed due to missing namespace.
+	NamespaceInformer cache.SharedInformer
 }
 
 type Syncer struct {
@@ -254,6 +258,7 @@ func NewSyncer(config SyncerConfig) (*Syncer, error) { //nolint:gocritic // Mini
 			Scheme:              config.Scheme,
 			ResyncPeriod:        rc.BrokerResyncPeriod,
 			SyncCounter:         syncCounter,
+			NamespaceInformer:   config.NamespaceInformer,
 		})
 		if err != nil {
 			return nil, errors.Wrap(err, "error creating remote resource syncer")

--- a/pkg/syncer/resource_syncer.go
+++ b/pkg/syncer/resource_syncer.go
@@ -257,7 +257,11 @@ func NewResourceSyncer(config *ResourceSyncerConfig) (Interface, error) {
 		UpdateFunc: syncer.onUpdate,
 		DeleteFunc: syncer.onDelete,
 	}, func(obj interface{}) (interface{}, error) {
-		resourceUtil.MustToMeta(obj).SetManagedFields(nil)
+		objMeta, err := meta.Accessor(obj)
+		if err == nil && len(objMeta.GetManagedFields()) > 0 {
+			objMeta.SetManagedFields(nil)
+		}
+
 		return obj, nil
 	})
 

--- a/pkg/syncer/resource_syncer.go
+++ b/pkg/syncer/resource_syncer.go
@@ -241,8 +241,7 @@ func NewResourceSyncer(config *ResourceSyncerConfig) (Interface, error) {
 
 	resourceClient := config.SourceClient.Resource(*gvr).Namespace(config.SourceNamespace)
 
-	//nolint:wrapcheck // These are wrapper functions.
-	syncer.store, syncer.informer = cache.NewInformer(&cache.ListWatch{
+	syncer.store, syncer.informer = cache.NewTransformingInformer(&cache.ListWatch{
 		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 			options.LabelSelector = config.SourceLabelSelector
 			options.FieldSelector = config.SourceFieldSelector
@@ -257,6 +256,9 @@ func NewResourceSyncer(config *ResourceSyncerConfig) (Interface, error) {
 		AddFunc:    syncer.onCreate,
 		UpdateFunc: syncer.onUpdate,
 		DeleteFunc: syncer.onDelete,
+	}, func(obj interface{}) (interface{}, error) {
+		resourceUtil.MustToMeta(obj).SetManagedFields(nil)
+		return obj, nil
 	})
 
 	return syncer, nil

--- a/pkg/syncer/resource_syncer.go
+++ b/pkg/syncer/resource_syncer.go
@@ -256,14 +256,7 @@ func NewResourceSyncer(config *ResourceSyncerConfig) (Interface, error) {
 		AddFunc:    syncer.onCreate,
 		UpdateFunc: syncer.onUpdate,
 		DeleteFunc: syncer.onDelete,
-	}, func(obj interface{}) (interface{}, error) {
-		objMeta, err := meta.Accessor(obj)
-		if err == nil && len(objMeta.GetManagedFields()) > 0 {
-			objMeta.SetManagedFields(nil)
-		}
-
-		return obj, nil
-	})
+	}, resourceUtil.TrimManagedFields)
 
 	return syncer, nil
 }

--- a/pkg/syncer/resource_syncer.go
+++ b/pkg/syncer/resource_syncer.go
@@ -43,10 +43,14 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/utils/set"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-const OrigNamespaceLabelKey = "submariner-io/originatingNamespace"
+const (
+	OrigNamespaceLabelKey = "submariner-io/originatingNamespace"
+	namespaceKey          = "$namespace$"
+)
 
 type SyncDirection int
 
@@ -183,24 +187,31 @@ type ResourceSyncerConfig struct {
 
 	// SyncCounter if specified, used to record counter metrics.
 	SyncCounter *prometheus.GaugeVec
+
+	// NamespaceInformer if specified, used to retry resources that initially failed due to missing namespace.
+	NamespaceInformer cache.SharedInformer
 }
 
 type resourceSyncer struct {
-	workQueue   workqueue.Interface
-	hasSynced   func() bool
-	informer    cache.Controller
-	store       cache.Store
-	config      ResourceSyncerConfig
-	deleted     sync.Map
-	created     sync.Map
-	stopped     chan struct{}
-	syncCounter *prometheus.GaugeVec
-	stopCh      <-chan struct{}
-	log         log.Logger
+	workQueue         workqueue.Interface
+	hasSynced         func() bool
+	informer          cache.Controller
+	store             cache.Store
+	config            ResourceSyncerConfig
+	deleted           sync.Map
+	created           sync.Map
+	stopped           chan struct{}
+	syncCounter       *prometheus.GaugeVec
+	stopCh            <-chan struct{}
+	log               log.Logger
+	missingNamespaces map[string]set.Set[string]
 }
 
 func NewResourceSyncer(config *ResourceSyncerConfig) (Interface, error) {
-	syncer := newResourceSyncer(config)
+	syncer, err := newResourceSyncer(config)
+	if err != nil {
+		return nil, err
+	}
 
 	rawType, gvr, err := util.ToUnstructuredResource(config.ResourceType, config.RestMapper)
 	if err != nil {
@@ -233,7 +244,11 @@ func NewResourceSyncer(config *ResourceSyncerConfig) (Interface, error) {
 }
 
 func NewResourceSyncerWithSharedInformer(config *ResourceSyncerConfig, informer cache.SharedInformer) (Interface, error) {
-	syncer := newResourceSyncer(config)
+	syncer, err := newResourceSyncer(config)
+	if err != nil {
+		return nil, err
+	}
+
 	syncer.store = informer.GetStore()
 
 	reg, err := informer.AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
@@ -242,7 +257,7 @@ func NewResourceSyncerWithSharedInformer(config *ResourceSyncerConfig, informer 
 		DeleteFunc: syncer.onDelete,
 	}, config.ResyncPeriod)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error registering even handler")
+		return nil, errors.Wrapf(err, "error registering event handler")
 	}
 
 	syncer.hasSynced = reg.HasSynced
@@ -250,11 +265,12 @@ func NewResourceSyncerWithSharedInformer(config *ResourceSyncerConfig, informer 
 	return syncer, nil
 }
 
-func newResourceSyncer(config *ResourceSyncerConfig) *resourceSyncer {
+func newResourceSyncer(config *ResourceSyncerConfig) (*resourceSyncer, error) {
 	syncer := &resourceSyncer{
-		config:  *config,
-		stopped: make(chan struct{}),
-		log:     log.Logger{Logger: logf.Log.WithName("ResourceSyncer")},
+		config:            *config,
+		stopped:           make(chan struct{}),
+		log:               log.Logger{Logger: logf.Log.WithName("ResourceSyncer")},
+		missingNamespaces: map[string]set.Set[string]{},
 	}
 
 	if syncer.config.Scheme == nil {
@@ -286,7 +302,18 @@ func newResourceSyncer(config *ResourceSyncerConfig) *resourceSyncer {
 
 	syncer.workQueue = workqueue.New(config.Name)
 
-	return syncer
+	if config.NamespaceInformer != nil {
+		_, err := config.NamespaceInformer.AddEventHandler(cache.ResourceEventHandlerDetailedFuncs{
+			AddFunc: func(obj interface{}, _ bool) {
+				syncer.workQueue.Enqueue(cache.ExplicitKey(cache.NewObjectName(namespaceKey, resourceUtil.MustToMeta(obj).GetName()).String()))
+			},
+		})
+		if err != nil {
+			return nil, errors.Wrapf(err, "error registering namespace handler")
+		}
+	}
+
+	return syncer, nil
 }
 
 func NewSharedInformer(config *ResourceSyncerConfig) (cache.SharedInformer, error) {
@@ -478,7 +505,12 @@ func (r *resourceSyncer) runIfCacheSynced(defaultReturn any, run func() any) any
 	return run()
 }
 
-func (r *resourceSyncer) processNextWorkItem(key, _, _ string) (bool, error) {
+func (r *resourceSyncer) processNextWorkItem(key, name, ns string) (bool, error) {
+	if ns == namespaceKey {
+		r.handleNamespaceAdded(name)
+		return false, nil
+	}
+
 	obj, exists, err := r.store.GetByKey(key)
 	if err != nil {
 		return true, errors.Wrapf(err, "error retrieving resource %q", key)
@@ -515,6 +547,13 @@ func (r *resourceSyncer) processNextWorkItem(key, _, _ string) (bool, error) {
 
 		err = r.config.Federator.Distribute(context.Background(), resource)
 		if err != nil || r.onSuccessfulSync(resource, transformed, op) {
+			missing, namespace := resourceUtil.IsMissingNamespaceErr(err)
+			if missing {
+				r.handleMissingNamespace(key, namespace)
+
+				return false, nil
+			}
+
 			return true, errors.Wrapf(err, "error distributing resource %q", key)
 		}
 
@@ -728,6 +767,36 @@ func (r *resourceSyncer) assertUnstructured(obj interface{}) *unstructured.Unstr
 	}
 
 	return u
+}
+
+func (r *resourceSyncer) handleMissingNamespace(key, namespace string) {
+	r.log.Warningf("Syncer %q: Unable to distribute resource %q due to missing namespace %q", r.config.Name, key, namespace)
+
+	if r.config.NamespaceInformer == nil {
+		return
+	}
+
+	keys, ok := r.missingNamespaces[namespace]
+	if !ok {
+		keys = set.New[string]()
+		r.missingNamespaces[namespace] = keys
+	}
+
+	keys.Insert(key)
+}
+
+func (r *resourceSyncer) handleNamespaceAdded(namespace string) {
+	keys, ok := r.missingNamespaces[namespace]
+	if ok {
+		r.log.V(log.LIBDEBUG).Infof("Syncer %q: namespace %q created - re-queueing %d resources", r.config.Name, namespace, keys.Len())
+
+		for _, k := range keys.UnsortedList() {
+			ns, name, _ := cache.SplitMetaNamespaceKey(k)
+			r.RequeueResource(name, ns)
+		}
+
+		delete(r.missingNamespaces, namespace)
+	}
 }
 
 func getClusterIDLabel(resource runtime.Object) (string, bool) {

--- a/pkg/syncer/syncer_suite_test.go
+++ b/pkg/syncer/syncer_suite_test.go
@@ -18,6 +18,7 @@ limitations under the License.
 package syncer_test
 
 import (
+	"flag"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -26,6 +27,10 @@ import (
 )
 
 func init() {
+	flags := flag.NewFlagSet("kzerolog", flag.ExitOnError)
+	kzerolog.AddFlags(flags)
+	_ = flags.Parse([]string{"-v=1"})
+
 	kzerolog.AddFlags(nil)
 }
 

--- a/test/e2e/watcher/watcher.go
+++ b/test/e2e/watcher/watcher.go
@@ -36,6 +36,7 @@ var _ = Describe("[watcher] Resource watcher tests", func() {
 		It("should notify the handler of each event", func() {
 			clusterName := framework.TestContext.ClusterIDs[framework.ClusterA]
 			toaster := util.CreateToaster(t.client, util.NewToaster("test-toaster", t.framework.Namespace), clusterName)
+			toaster.SetManagedFields(nil)
 			Eventually(t.created).Should(Receive(Equal(toaster)))
 
 			util.DeleteToaster(t.client, toaster, clusterName)


### PR DESCRIPTION
Backport of #895 #913 on release-0.17.

#895: Add support for resource syncer to use a shared informer
#913: Use informer to retry failed resources due to missing

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.