### PR TITLE
Simplify FailingReactor

### DIFF
--- a/pkg/fake/failing_reactor.go
+++ b/pkg/fake/failing_reactor.go
@@ -54,79 +54,26 @@ func (f *FailingReactor) react(action testing.Action) (bool, runtime.Object, err
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
+	var fail *error
+
 	switch action.GetVerb() {
 	case "get":
-		return f.get()
+		fail = &f.failOnGet
 	case "create":
-		return f.create()
+		fail = &f.failOnCreate
 	case "update":
-		return f.update()
+		fail = &f.failOnUpdate
 	case "delete":
-		return f.delete()
+		fail = &f.failOnDelete
 	case "list":
-		return f.list()
+		fail = &f.failOnList
 	}
 
-	return false, nil, nil
-}
+	if *fail != nil {
+		err := *fail
 
-func (f *FailingReactor) get() (bool, runtime.Object, error) {
-	err := f.failOnGet
-	if err != nil {
 		if f.resetOnFailure {
-			f.failOnGet = nil
-		}
-
-		return true, nil, err
-	}
-
-	return false, nil, nil
-}
-
-func (f *FailingReactor) create() (bool, runtime.Object, error) {
-	err := f.failOnCreate
-	if err != nil {
-		if f.resetOnFailure {
-			f.failOnCreate = nil
-		}
-
-		return true, nil, err
-	}
-
-	return false, nil, nil
-}
-
-func (f *FailingReactor) update() (bool, runtime.Object, error) {
-	err := f.failOnUpdate
-	if err != nil {
-		if f.resetOnFailure {
-			f.failOnUpdate = nil
-		}
-
-		return true, nil, err
-	}
-
-	return false, nil, nil
-}
-
-func (f *FailingReactor) delete() (bool, runtime.Object, error) {
-	err := f.failOnDelete
-	if err != nil {
-		if f.resetOnFailure {
-			f.failOnDelete = nil
-		}
-
-		return true, nil, err
-	}
-
-	return false, nil, nil
-}
-
-func (f *FailingReactor) list() (bool, runtime.Object, error) {
-	err := f.failOnList
-	if err != nil {
-		if f.resetOnFailure {
-			f.failOnList = nil
+			*fail = nil
 		}
 
 		return true, nil, err


### PR DESCRIPTION
The various action implementation functions all follow the same pattern, and can be implemented in react() itself.

This also avoids linting failures with the latest versions of the unparam linter.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
