### PR TITLE
Bump anchore/scan-action from 3.6.4 to 4.1.0

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Check out the repository
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
       - name: Run Anchore vulnerability scanner
-        uses: anchore/scan-action@3343887d815d7b07465f6fdcd395bd66508d486a
+        uses: anchore/scan-action@d43cc1dfea6a99ed123bf8f3133f1797c9b44492
         id: scan
         with:
           path: "."

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Check out the repository
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
       - name: Run Anchore vulnerability scanner
-        uses: anchore/scan-action@3343887d815d7b07465f6fdcd395bd66508d486a
+        uses: anchore/scan-action@d43cc1dfea6a99ed123bf8f3133f1797c9b44492
         id: scan
         with:
           path: "."


### PR DESCRIPTION
Dependabot will not update major versions.

This gets us the latest Grype vuln scanner as well as Node 20.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
