### PR TITLE
Use NewClientset instead of NewSimpleClientset

### DIFF
--- a/pkg/fake/basic_reactors_test.go
+++ b/pkg/fake/basic_reactors_test.go
@@ -329,7 +329,7 @@ func newBasicReactorsTestDriver() *basicReactorsTestDriver {
 	t := &basicReactorsTestDriver{}
 
 	BeforeEach(func() {
-		t.client = k8sfake.NewSimpleClientset()
+		t.client = k8sfake.NewClientset()
 		fake.AddBasicReactors(&t.client.Fake)
 
 		t.pod = &corev1.Pod{

--- a/pkg/finalizer/finalizer_test.go
+++ b/pkg/finalizer/finalizer_test.go
@@ -209,7 +209,7 @@ func newTestDriver() *testDriver {
 				Finalizers: []string{},
 			},
 		},
-		kubeClient: kubeFake.NewSimpleClientset(),
+		kubeClient: kubeFake.NewClientset(),
 	}
 
 	return t

--- a/pkg/syncer/resource_syncer_test.go
+++ b/pkg/syncer/resource_syncer_test.go
@@ -1257,7 +1257,7 @@ func testWithMissingNamespace() {
 			Resource: "namespaces",
 		}, transformedNamespace))
 
-		k8sClient = fakeK8s.NewSimpleClientset()
+		k8sClient = fakeK8s.NewClientset()
 		nsInformerFactory = informers.NewSharedInformerFactory(k8sClient, 0)
 		d.config.NamespaceInformer = nsInformerFactory.Core().V1().Namespaces().Informer()
 	})


### PR DESCRIPTION
The latter is deprecated in Kubernetes 1.31.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
