### PR TITLE
EnsureValidName should strip leading or trailing dash

### DIFF
--- a/pkg/resource/resource_test.go
+++ b/pkg/resource/resource_test.go
@@ -43,8 +43,17 @@ var _ = Describe("EnsureValidName", func() {
 	})
 
 	When("the string has non-alphanumeric letters", func() {
-		It("should convert them approriately", func() {
+		It("should convert them appropriately", func() {
 			Expect(resource.EnsureValidName("no-!@*()#$-chars")).To(Equal("no---------chars"))
+		})
+	})
+
+	When("the string starts or ends with an invalid char", func() {
+		It("should strip the char", func() {
+			Expect(resource.EnsureValidName("-abc")).To(Equal("abc"))
+			Expect(resource.EnsureValidName("abc-")).To(Equal("abc"))
+			Expect(resource.EnsureValidName("-abc-")).To(Equal("abc"))
+			Expect(resource.EnsureValidName("%abc*")).To(Equal("abc"))
 		})
 	})
 })

--- a/pkg/resource/util.go
+++ b/pkg/resource/util.go
@@ -111,7 +111,7 @@ func MustToMeta(obj interface{}) metav1.Object {
 func EnsureValidName(name string) string {
 	// K8s only allows lower case alphanumeric characters, '-' or '.'. Regex used for validation is
 	// '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'
-	return strings.Map(func(c rune) rune {
+	name = strings.Map(func(c rune) rune {
 		c = unicode.ToLower(c)
 		if !unicode.IsDigit(c) && !unicode.IsLower(c) && c != '-' && c != '.' {
 			return '-'
@@ -119,6 +119,8 @@ func EnsureValidName(name string) string {
 
 		return c
 	}, name)
+
+	return strings.Trim(name, "-")
 }
 
 func ToJSON(o any) string {


### PR DESCRIPTION
`EnsureValidName` converts all invalid chars to a dash ('-') but that could leave a leading or trailing dash which is invalid so just strip a leading or trailing dash.
