### PR TITLE
Implement priority queueing in the resource syncer

### DIFF
--- a/pkg/federate/fake/federator.go
+++ b/pkg/federate/fake/federator.go
@@ -44,8 +44,8 @@ type Federator struct {
 
 func New() *Federator {
 	f := &Federator{
-		distribute: make(chan *unstructured.Unstructured, 100),
-		delete:     make(chan *unstructured.Unstructured, 100),
+		distribute: make(chan *unstructured.Unstructured, 200),
+		delete:     make(chan *unstructured.Unstructured, 200),
 	}
 	f.ResetOnFailure.Store(true)
 

--- a/pkg/syncer/broker/syncer.go
+++ b/pkg/syncer/broker/syncer.go
@@ -31,6 +31,7 @@ import (
 	"github.com/submariner-io/admiral/pkg/resource"
 	"github.com/submariner-io/admiral/pkg/syncer"
 	"github.com/submariner-io/admiral/pkg/util"
+	"github.com/submariner-io/admiral/pkg/workqueue"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -74,6 +75,9 @@ type ResourceConfig struct {
 	// Default is 0.
 	LocalResyncPeriod time.Duration
 
+	// LocalWorkQueueConfig if specified, configures the underlying work queue for processing local resources.
+	LocalWorkQueueConfig *workqueue.Config
+
 	// BrokerResourceType the type of the broker resources to sync to the local source.
 	BrokerResourceType runtime.Object
 
@@ -93,6 +97,9 @@ type ResourceConfig struct {
 	// BrokerResyncPeriod if non-zero, the period at which broker resources will be re-synced regardless if anything changed.
 	// Default is 0.
 	BrokerResyncPeriod time.Duration
+
+	// BrokerWorkQueueConfig if specified, configures the underlying work queue for processing broker resources.
+	BrokerWorkQueueConfig *workqueue.Config
 
 	// SyncCounterOpts used to pass name and help text to resource syncer Gauge
 	SyncCounterOpts *prometheus.GaugeOpts
@@ -227,6 +234,7 @@ func NewSyncer(config SyncerConfig) (*Syncer, error) { //nolint:gocritic // Mini
 			ResourcesEquivalent: rc.LocalResourcesEquivalent,
 			ShouldProcess:       rc.LocalShouldProcess,
 			WaitForCacheSync:    rc.LocalWaitForCacheSync,
+			WorkQueueConfig:     rc.LocalWorkQueueConfig,
 			Scheme:              config.Scheme,
 			ResyncPeriod:        rc.LocalResyncPeriod,
 			SyncCounter:         syncCounter,
@@ -255,6 +263,7 @@ func NewSyncer(config SyncerConfig) (*Syncer, error) { //nolint:gocritic // Mini
 			OnSuccessfulSync:    rc.OnSuccessfulSyncFromBroker,
 			ResourcesEquivalent: rc.BrokerResourcesEquivalent,
 			WaitForCacheSync:    &waitForCacheSync,
+			WorkQueueConfig:     rc.BrokerWorkQueueConfig,
 			Scheme:              config.Scheme,
 			ResyncPeriod:        rc.BrokerResyncPeriod,
 			SyncCounter:         syncCounter,

--- a/pkg/syncer/priority_ordering_test.go
+++ b/pkg/syncer/priority_ordering_test.go
@@ -1,0 +1,226 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package syncer_test
+
+import (
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/resource"
+	"github.com/submariner-io/admiral/pkg/syncer"
+	"github.com/submariner-io/admiral/pkg/syncer/test"
+	"github.com/submariner-io/admiral/pkg/workqueue"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+//nolint:gocognit // Ignore cognitive complexity for test cases
+func testPriorityOrdering() {
+	d := newTestDriver(test.LocalNamespace, "", syncer.LocalToRemote)
+
+	BeforeEach(func() {
+		wqc := workqueue.DefaultConfig()
+		wqc.ItemRateLimiterBaseDelay = 0
+		d.config.WorkQueueConfig = &wqc
+
+		for i := 1; i <= 100; i++ {
+			d.addInitialResource(&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      strconv.Itoa(i),
+					Namespace: d.config.SourceNamespace,
+				},
+			})
+		}
+	})
+
+	Context("resources updated", func() {
+		const numToUpdate = 5
+
+		var (
+			updatedResourcesQueuedCh chan []string
+			firstTransform           atomic.Bool
+			transformedCh            chan string
+		)
+
+		BeforeEach(func() {
+			firstTransform.Store(true)
+
+			transformedCh = make(chan string, 500)
+
+			var (
+				initialResourcesQueued atomic.Value
+				updatedResourcesQueued atomic.Value
+			)
+
+			initialResourcesQueued.Store([]string{})
+			updatedResourcesQueued.Store([]string{})
+
+			initialResourcesQueuedCh := make(chan []string, 1)
+			updatedResourcesQueuedCh = make(chan []string, 1)
+			allUpdatedResourcesAreQueuedCh := make(chan chan struct{})
+
+			d.config.ShouldProcess = func(obj *unstructured.Unstructured, op syncer.Operation) bool {
+				if op == syncer.Create {
+					q := append(initialResourcesQueued.Load().([]string), obj.GetName())
+					initialResourcesQueued.Store(q)
+
+					if len(q) == len(d.initialResources) {
+						initialResourcesQueuedCh <- q
+					}
+				} else if op == syncer.Update {
+					q := updatedResourcesQueued.Load().([]string)
+					if len(q) == numToUpdate-1 {
+						close(allUpdatedResourcesAreQueuedCh)
+						updatedResourcesQueuedCh <- q
+					} else {
+						updatedResourcesQueued.Store(append(q, obj.GetName()))
+					}
+				}
+
+				return true
+			}
+
+			d.config.Transform = func(from runtime.Object, _ int, _ syncer.Operation) (runtime.Object, bool) {
+				defer GinkgoRecover()
+
+				if firstTransform.CompareAndSwap(true, false) {
+					// We're processing the first initial resource. Block until all the initial resources have been
+					// enqueued (via ShouldProcess which is called prior to enqueueing) before updating any resources.
+					// This ensures that the updated resources should be dequeued and processed next.
+					var initialQueue []string
+
+					Eventually(initialResourcesQueuedCh).Should(Receive(&initialQueue))
+
+					// Choose a few resources from the queue to update. We want to ensure we choose ones that won't
+					// be at the front of the queue anyway. Logically we should pick from the back of the queue but
+					// the priority queue algorithm will swap items of equal priority between the two ends so choose
+					// resources from the middle.
+					for i := range numToUpdate {
+						name := initialQueue[len(initialQueue)/2+i]
+
+						test.UpdateResource(d.sourceClient, &corev1.Pod{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      name,
+								Namespace: d.config.SourceNamespace,
+								Labels:    map[string]string{"foo": "bar"},
+							},
+						})
+					}
+
+					// Block until all the updated resources have been queued.
+					Eventually(allUpdatedResourcesAreQueuedCh).Should(BeClosed())
+				} else {
+					transformedCh <- resource.MustToMeta(from).GetName()
+				}
+
+				return from, false
+			}
+		})
+
+		Specify("should be prioritized before the initial resources", func() {
+			var updatedQueue []string
+
+			Eventually(updatedResourcesQueuedCh).WithTimeout(time.Second * 5).Should(Receive(&updatedQueue))
+
+			for range updatedQueue {
+				var name string
+
+				Eventually(transformedCh).Should(Receive(&name))
+				Expect(updatedQueue).To(ContainElement(name))
+			}
+		})
+	})
+
+	Context("new resources created", func() {
+		var (
+			initialResourcesCount atomic.Int32
+			newResourcesCount     atomic.Int32
+			firstTransform        atomic.Bool
+			transformedCh         chan string
+		)
+
+		allInitialResourcesAreQueuedCh := make(chan struct{})
+		allNewResourcesAreQueuedCh := make(chan chan struct{})
+
+		BeforeEach(func() {
+			firstTransform.Store(true)
+
+			transformedCh = make(chan string, 500)
+
+			d.config.ShouldProcess = func(obj *unstructured.Unstructured, _ syncer.Operation) bool {
+				if strings.HasPrefix(obj.GetName(), "new") {
+					if int(newResourcesCount.Add(1)) == 2 {
+						close(allNewResourcesAreQueuedCh)
+					}
+				} else if int(initialResourcesCount.Add(1)) == len(d.initialResources) {
+					close(allInitialResourcesAreQueuedCh)
+				}
+
+				return true
+			}
+
+			d.config.Transform = func(from runtime.Object, _ int, _ syncer.Operation) (runtime.Object, bool) {
+				defer GinkgoRecover()
+
+				if firstTransform.CompareAndSwap(true, false) {
+					// We're processing the first initial resource. Block until all the initial resources have been
+					// enqueued (via ShouldProcess which is called prior to enqueueing) before creating the new
+					// resources. This ensures that the newly created resources should be dequeued and processed next.
+					Eventually(allInitialResourcesAreQueuedCh).Should(BeClosed())
+
+					test.CreateResource(d.sourceClient, &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "new1",
+							Namespace: d.config.SourceNamespace,
+						},
+					})
+
+					test.CreateResource(d.sourceClient, &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "new2",
+							Namespace: d.config.SourceNamespace,
+						},
+					})
+
+					// Block until all the newly created resources have been queued.
+					Eventually(allNewResourcesAreQueuedCh).Should(BeClosed())
+				} else {
+					transformedCh <- resource.MustToMeta(from).GetName()
+				}
+
+				return from, false
+			}
+		})
+
+		Specify("should be prioritized before the initial resources", func() {
+			Eventually(allNewResourcesAreQueuedCh).Should(BeClosed())
+
+			var actualName string
+
+			Eventually(transformedCh).Should(Receive(&actualName))
+			Expect(actualName).To(HavePrefix("new"))
+		})
+	})
+}

--- a/pkg/syncer/resource_syncer.go
+++ b/pkg/syncer/resource_syncer.go
@@ -767,7 +767,13 @@ func (r *resourceSyncer) onUpdate(oldObj, newObj interface{}) {
 		return
 	}
 
-	r.workQueue.Enqueue(newObj)
+	// If the resource version didn't change, that indicates a re-sync by the informer so enqueue at low priority.
+	// We want to prioritize processing resources that did actually change.
+	if oldResource.GetResourceVersion() == newResource.GetResourceVersion() {
+		r.workQueue.EnqueueWithOpts(newObj, workqueue.EnqueueOpts{Priority: workqueue.LowPriority})
+	} else {
+		r.workQueue.Enqueue(newObj)
+	}
 }
 
 func (r *resourceSyncer) onDelete(obj interface{}) {

--- a/pkg/syncer/resource_syncer.go
+++ b/pkg/syncer/resource_syncer.go
@@ -48,8 +48,7 @@ import (
 
 const (
 	OrigNamespaceLabelKey = "submariner-io/originatingNamespace"
-	namespaceAddedKey     = "$namespace-added$"
-	namespaceDeletedKey   = "$namespace-deleted$"
+	namespaceKey          = "$namespace-key$"
 )
 
 type SyncDirection int
@@ -190,6 +189,9 @@ type ResourceSyncerConfig struct {
 
 	// NamespaceInformer if specified, used to retry resources that initially failed due to missing namespace.
 	NamespaceInformer cache.SharedInformer
+
+	// WorkQueueConfig if specified, configures the underlying work queue
+	WorkQueueConfig *workqueue.Config
 }
 
 type resourceSyncer struct {
@@ -235,7 +237,7 @@ func NewResourceSyncer(config *ResourceSyncerConfig) (Interface, error) {
 		},
 		ObjectType:   rawType,
 		ResyncPeriod: config.ResyncPeriod,
-		Handler: cache.ResourceEventHandlerFuncs{
+		Handler: cache.ResourceEventHandlerDetailedFuncs{
 			AddFunc:    syncer.onCreate,
 			UpdateFunc: syncer.onUpdate,
 			DeleteFunc: syncer.onDelete,
@@ -256,7 +258,7 @@ func NewResourceSyncerWithSharedInformer(config *ResourceSyncerConfig, informer 
 
 	syncer.store = informer.GetStore()
 
-	reg, err := informer.AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
+	reg, err := informer.AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerDetailedFuncs{
 		AddFunc:    syncer.onCreate,
 		UpdateFunc: syncer.onUpdate,
 		DeleteFunc: syncer.onDelete,
@@ -312,18 +314,22 @@ func newResourceSyncer(config *ResourceSyncerConfig) (*resourceSyncer, error) {
 		prometheus.MustRegister(syncer.syncCounter)
 	}
 
-	syncer.workQueue = workqueue.New(config.Name)
+	syncer.workQueue = workqueue.NewWithConfig(config.Name, workqueue.DefaultConfigIfNil(syncer.config.WorkQueueConfig))
 
 	if config.NamespaceInformer != nil {
 		reg, err := config.NamespaceInformer.AddEventHandler(cache.ResourceEventHandlerDetailedFuncs{
 			AddFunc: func(obj interface{}, _ bool) {
-				syncer.workQueue.Enqueue(cache.ExplicitKey(cache.NewObjectName(namespaceAddedKey, resourceUtil.MustToMeta(obj).GetName()).String()))
+				key := cache.NewObjectName(namespaceKey, resourceUtil.MustToMeta(obj).GetName()).String()
+				syncer.operationQueues.add(key, createOperation(&unstructured.Unstructured{}))
+				syncer.workQueue.Enqueue(cache.ExplicitKey(key))
 			},
 			DeleteFunc: func(obj interface{}) {
 				objName, err := cache.DeletionHandlingObjectToName(obj)
 				utilruntime.Must(err)
 
-				syncer.workQueue.Enqueue(cache.ExplicitKey(cache.NewObjectName(namespaceDeletedKey, objName.Name).String()))
+				key := cache.NewObjectName(namespaceKey, objName.Name).String()
+				syncer.operationQueues.add(key, deleteOperation(&unstructured.Unstructured{}))
+				syncer.workQueue.Enqueue(cache.ExplicitKey(key))
 			},
 		})
 		if err != nil {
@@ -424,7 +430,7 @@ func (r *resourceSyncer) RequeueResource(name, namespace string) {
 	}
 
 	if exists {
-		r.onCreate(obj)
+		r.onCreate(obj, false)
 	}
 }
 
@@ -529,13 +535,20 @@ func (r *resourceSyncer) runIfCacheSynced(defaultReturn any, run func() any) any
 }
 
 func (r *resourceSyncer) processNextWorkItem(key, name, ns string) (bool, error) {
-	if ns == namespaceAddedKey {
-		r.handleNamespaceAdded(name)
-		return false, nil
-	}
+	resourceOp := r.operationQueues.peek(key)
 
-	if ns == namespaceDeletedKey {
-		r.handleNamespaceDeleted(name)
+	if ns == namespaceKey {
+		switch resourceOp.(type) {
+		case deleteOperation:
+			r.handleNamespaceDeleted(name)
+		case createOperation:
+			r.handleNamespaceAdded(name)
+		}
+
+		if r.operationQueues.remove(key, resourceOp) {
+			r.workQueue.Enqueue(cache.ExplicitKey(key))
+		}
+
 		return false, nil
 	}
 
@@ -543,8 +556,6 @@ func (r *resourceSyncer) processNextWorkItem(key, name, ns string) (bool, error)
 		requeue bool
 		err     error
 	)
-
-	resourceOp := r.operationQueues.peek(key)
 
 	switch t := resourceOp.(type) {
 	case deleteOperation:
@@ -721,7 +732,7 @@ func (r *resourceSyncer) onSuccessfulSync(resource, converted runtime.Object, op
 	return r.config.OnSuccessfulSync(converted, op)
 }
 
-func (r *resourceSyncer) onCreate(obj interface{}) {
+func (r *resourceSyncer) onCreate(obj interface{}, isInInitialList bool) {
 	resource := r.assertUnstructured(obj)
 
 	if !r.shouldProcess(resource, Create) {
@@ -731,7 +742,15 @@ func (r *resourceSyncer) onCreate(obj interface{}) {
 	key, _ := cache.MetaNamespaceKeyFunc(resource)
 
 	r.operationQueues.add(key, createOperation(resource))
-	r.workQueue.Enqueue(resource)
+
+	// If this is from the initial listing on startup then enqueue with low priority to prioritize newly
+	// created or updated resources. Also don't enqueue with rate limiting since we already know this is
+	// part of a one-time burst.
+	if isInInitialList {
+		r.workQueue.EnqueueWithOpts(resource, workqueue.EnqueueOpts{Priority: workqueue.LowPriority})
+	} else {
+		r.workQueue.Enqueue(resource)
+	}
 }
 
 func (r *resourceSyncer) onUpdate(oldObj, newObj interface{}) {

--- a/pkg/syncer/resource_syncer_test.go
+++ b/pkg/syncer/resource_syncer_test.go
@@ -914,8 +914,7 @@ func testUpdateSuppression() {
 
 		Context("and the resource's ObjectMeta is updated in the datastore", func() {
 			BeforeEach(func() {
-				t := metav1.Now()
-				d.resource.ObjectMeta.DeletionTimestamp = &t
+				d.resource.ObjectMeta.Finalizers = []string{"test"}
 			})
 
 			It("should distribute it", func() {
@@ -941,8 +940,7 @@ func testUpdateSuppression() {
 
 		Context("and the resource's ObjectMeta is updated in the datastore", func() {
 			BeforeEach(func() {
-				t := metav1.Now()
-				d.resource.ObjectMeta.DeletionTimestamp = &t
+				d.resource.ObjectMeta.Finalizers = []string{"test"}
 			})
 
 			It("should not distribute it", func() {
@@ -1474,7 +1472,11 @@ func newTestDriver(sourceNamespace, localClusterID string, syncDirection syncer.
 		restMapper, gvr := test.GetRESTMapperAndGroupVersionResourceFor(d.config.ResourceType)
 
 		d.config.RestMapper = restMapper
-		d.config.SourceClient = fakeClient.NewSimpleDynamicClient(d.config.Scheme, initObjs...)
+
+		dynClient := fakeClient.NewSimpleDynamicClient(d.config.Scheme, initObjs...)
+		fakereactor.AddBasicReactors(&dynClient.Fake)
+
+		d.config.SourceClient = dynClient
 
 		d.sourceClient = d.config.SourceClient.Resource(*gvr).Namespace(d.config.SourceNamespace)
 

--- a/pkg/syncer/resource_syncer_test.go
+++ b/pkg/syncer/resource_syncer_test.go
@@ -78,6 +78,7 @@ var _ = Describe("Resource Syncer", func() {
 	Describe("With SharedInformer", testWithSharedInformer)
 	Describe("With missing namespace", testWithMissingNamespace)
 	Describe("Event Ordering", testEventOrdering)
+	Describe("Priority Ordering", testPriorityOrdering)
 })
 
 func testReconcileLocalToRemote() {

--- a/pkg/workqueue/config.go
+++ b/pkg/workqueue/config.go
@@ -1,0 +1,105 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workqueue
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+)
+
+const (
+	ItemRateLimiterBaseDelayKey     = "item-rate-limiter-base-delay"
+	ItemRateLimiterMaxDelayKey      = "item-rate-limiter-max-delay"
+	OverallRateLimiterMaxDelayKey   = "overall-rate-limiter-max-delay"
+	BucketRateLimiterItemsPerSecKey = "bucket-rate-limiter-items-per-sec"
+	BucketRateLimiterMaxBurstKey    = "bucket-rate-limiter-max-burst"
+)
+
+type Config struct {
+	ItemRateLimiterBaseDelay     time.Duration
+	ItemRateLimiterMaxDelay      time.Duration
+	OverallRateLimiterMaxDelay   time.Duration
+	BucketRateLimiterItemsPerSec int
+	BucketRateLimiterMaxBurst    int
+}
+
+func DefaultConfig() Config {
+	return Config{
+		ItemRateLimiterBaseDelay:     time.Millisecond,
+		ItemRateLimiterMaxDelay:      30 * time.Second,
+		OverallRateLimiterMaxDelay:   5 * time.Minute,
+		BucketRateLimiterItemsPerSec: 10,
+		BucketRateLimiterMaxBurst:    500,
+	}
+}
+
+func DefaultConfigIfNil(c *Config) Config {
+	if c == nil {
+		return DefaultConfig()
+	}
+
+	return *c
+}
+
+func ConfigFromConfigMap(configMap *corev1.ConfigMap, keyPrefix string, defaultConfig *Config) *Config {
+	if configMap == nil {
+		return defaultConfig
+	}
+
+	config := DefaultConfigIfNil(defaultConfig)
+
+	keyPrefix = ToConfigMapDataKey(keyPrefix, "")
+
+	var err error
+
+	for k, v := range configMap.Data {
+		if !strings.HasPrefix(k, keyPrefix) {
+			continue
+		}
+
+		switch strings.Split(k, keyPrefix)[1] {
+		case ItemRateLimiterBaseDelayKey:
+			config.ItemRateLimiterBaseDelay, err = time.ParseDuration(v)
+			utilruntime.Must(err)
+		case ItemRateLimiterMaxDelayKey:
+			config.ItemRateLimiterMaxDelay, err = time.ParseDuration(v)
+			utilruntime.Must(err)
+		case OverallRateLimiterMaxDelayKey:
+			config.OverallRateLimiterMaxDelay, err = time.ParseDuration(v)
+			utilruntime.Must(err)
+		case BucketRateLimiterItemsPerSecKey:
+			config.BucketRateLimiterItemsPerSec, err = strconv.Atoi(v)
+			utilruntime.Must(err)
+		case BucketRateLimiterMaxBurstKey:
+			config.BucketRateLimiterMaxBurst, err = strconv.Atoi(v)
+			utilruntime.Must(err)
+		}
+	}
+
+	return &config
+}
+
+func ToConfigMapDataKey(prefix, name string) string {
+	return fmt.Sprintf("%s.workqueue/%s", prefix, name)
+}

--- a/pkg/workqueue/config_test.go
+++ b/pkg/workqueue/config_test.go
@@ -1,0 +1,169 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workqueue_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/workqueue"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var customConfig = workqueue.Config{
+	ItemRateLimiterBaseDelay:     time.Millisecond * 10,
+	ItemRateLimiterMaxDelay:      time.Minute,
+	OverallRateLimiterMaxDelay:   time.Hour,
+	BucketRateLimiterItemsPerSec: 99,
+	BucketRateLimiterMaxBurst:    9999,
+}
+
+var _ = Describe("DefaultConfigIfNil", func() {
+	Specify("should return the config when non-nil", func() {
+		Expect(workqueue.DefaultConfigIfNil(&customConfig)).To(Equal(customConfig))
+	})
+
+	Specify("should return the default when passed nil", func() {
+		Expect(workqueue.DefaultConfigIfNil(nil)).To(Equal(workqueue.DefaultConfig()))
+	})
+})
+
+var _ = Describe("ConfigFromConfigMap", func() {
+	const keyPrefix = "pods"
+
+	var configMap *corev1.ConfigMap
+
+	BeforeEach(func() {
+		configMap = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "workqueue-cm",
+				Namespace: "my-ns",
+			},
+			Data: map[string]string{},
+		}
+	})
+
+	mustConfigFromConfigMap := func(cm *corev1.ConfigMap, kp string, dc *workqueue.Config) workqueue.Config {
+		c := workqueue.ConfigFromConfigMap(cm, kp, dc)
+		Expect(c).ToNot(BeNil())
+
+		return *c
+	}
+
+	When("the specified ConfigMap is nil", func() {
+		Context("and the specified default Config is nil", func() {
+			It("should return nil", func() {
+				Expect(workqueue.ConfigFromConfigMap(nil, keyPrefix, nil)).To(BeNil())
+			})
+		})
+
+		Context("and the specified default Config is non-nil", func() {
+			It("should return the default Config", func() {
+				Expect(mustConfigFromConfigMap(nil, keyPrefix, &customConfig)).To(Equal(customConfig))
+			})
+		})
+	})
+
+	When("the specified ConfigMap is non-nil", func() {
+		It("should return a Config derived from the Data map", func() {
+			configMap.Data = map[string]string{
+				workqueue.ToConfigMapDataKey(keyPrefix, workqueue.ItemRateLimiterBaseDelayKey):     "20ms",
+				workqueue.ToConfigMapDataKey(keyPrefix, workqueue.ItemRateLimiterMaxDelayKey):      "40s",
+				workqueue.ToConfigMapDataKey(keyPrefix, workqueue.OverallRateLimiterMaxDelayKey):   "2h",
+				workqueue.ToConfigMapDataKey(keyPrefix, workqueue.BucketRateLimiterItemsPerSecKey): "99",
+				workqueue.ToConfigMapDataKey(keyPrefix, workqueue.BucketRateLimiterMaxBurstKey):    "999",
+				workqueue.ToConfigMapDataKey("other", workqueue.BucketRateLimiterMaxBurstKey):      "888",
+			}
+
+			Expect(mustConfigFromConfigMap(configMap, keyPrefix, nil)).To(Equal(workqueue.Config{
+				ItemRateLimiterBaseDelay:     time.Millisecond * 20,
+				ItemRateLimiterMaxDelay:      time.Second * 40,
+				OverallRateLimiterMaxDelay:   time.Hour * 2,
+				BucketRateLimiterItemsPerSec: 99,
+				BucketRateLimiterMaxBurst:    999,
+			}))
+		})
+
+		Context("and contains only some settings in the Data map", func() {
+			It("should return a Config with ConfigMap settings merged with the defaults", func() {
+				configMap.Data = map[string]string{
+					workqueue.ToConfigMapDataKey(keyPrefix, workqueue.ItemRateLimiterMaxDelayKey):      "40s",
+					workqueue.ToConfigMapDataKey(keyPrefix, workqueue.OverallRateLimiterMaxDelayKey):   "2h",
+					workqueue.ToConfigMapDataKey(keyPrefix, workqueue.BucketRateLimiterItemsPerSecKey): "99",
+				}
+
+				Expect(mustConfigFromConfigMap(configMap, keyPrefix, &workqueue.Config{
+					ItemRateLimiterBaseDelay:  time.Millisecond * 33,
+					ItemRateLimiterMaxDelay:   time.Minute,
+					BucketRateLimiterMaxBurst: 888,
+				})).To(Equal(workqueue.Config{
+					ItemRateLimiterBaseDelay:     time.Millisecond * 33,
+					ItemRateLimiterMaxDelay:      time.Second * 40,
+					OverallRateLimiterMaxDelay:   time.Hour * 2,
+					BucketRateLimiterItemsPerSec: 99,
+					BucketRateLimiterMaxBurst:    888,
+				}))
+
+				Expect(mustConfigFromConfigMap(configMap, keyPrefix, nil)).To(Equal(workqueue.Config{
+					ItemRateLimiterBaseDelay:     workqueue.DefaultConfig().ItemRateLimiterBaseDelay,
+					ItemRateLimiterMaxDelay:      time.Second * 40,
+					OverallRateLimiterMaxDelay:   time.Hour * 2,
+					BucketRateLimiterItemsPerSec: 99,
+					BucketRateLimiterMaxBurst:    workqueue.DefaultConfig().BucketRateLimiterMaxBurst,
+				}))
+			})
+		})
+
+		Context("and there's no settings in the Data map", func() {
+			It("should return a Config with the defaults", func() {
+				Expect(mustConfigFromConfigMap(configMap, keyPrefix, nil)).To(Equal(workqueue.DefaultConfig()))
+			})
+		})
+
+		Context("and there's invalid values in the Data map", func() {
+			It("should panic", func() {
+				configMap.Data = map[string]string{
+					workqueue.ToConfigMapDataKey(keyPrefix, workqueue.ItemRateLimiterBaseDelayKey): "2oms",
+				}
+
+				Expect(func() {
+					mustConfigFromConfigMap(configMap, keyPrefix, nil)
+				}).To(Panic())
+
+				configMap.Data = map[string]string{
+					workqueue.ToConfigMapDataKey(keyPrefix, workqueue.OverallRateLimiterMaxDelayKey): "2j",
+				}
+
+				Expect(func() {
+					mustConfigFromConfigMap(configMap, keyPrefix, nil)
+				}).To(Panic())
+
+				configMap.Data = map[string]string{
+					workqueue.ToConfigMapDataKey(keyPrefix, workqueue.BucketRateLimiterItemsPerSecKey): "invalid",
+				}
+
+				Expect(func() {
+					mustConfigFromConfigMap(configMap, keyPrefix, nil)
+				}).To(Panic())
+			})
+		})
+	})
+})

--- a/pkg/workqueue/priority_queue.go
+++ b/pkg/workqueue/priority_queue.go
@@ -1,0 +1,132 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workqueue
+
+import (
+	"container/heap"
+	"sync"
+)
+
+type itemType struct {
+	value    any
+	priority int
+}
+
+type priorityType struct {
+	priority int
+	dirty    bool
+}
+
+// PriorityQueue implements heap.Interface and orders items by descending priority such that
+// items with higher priority values are de-queued first.
+type PriorityQueue struct {
+	items      []itemType
+	indices    map[any]int
+	priorities sync.Map
+}
+
+func NewPriorityQueue() *PriorityQueue {
+	return &PriorityQueue{
+		items:   []itemType{},
+		indices: map[any]int{},
+	}
+}
+
+func (p *PriorityQueue) Len() int {
+	return len(p.items)
+}
+
+func (p *PriorityQueue) Less(i, j int) bool {
+	return p.items[i].priority > p.items[j].priority
+}
+
+func (p *PriorityQueue) Swap(i, j int) {
+	p.items[i], p.items[j] = p.items[j], p.items[i]
+	p.indices[p.items[i].value] = i
+	p.indices[p.items[j].value] = j
+}
+
+func (p *PriorityQueue) Push(item any) {
+	p.indices[item] = len(p.items)
+	p.items = append(p.items, itemType{value: item, priority: p.getPriority(item)})
+}
+
+func (p *PriorityQueue) Pop() any {
+	old := p.items
+	n := len(old)
+	item := old[n-1]
+	old[n-1].value = nil
+	p.items = old[0 : n-1]
+
+	delete(p.indices, item.value)
+	p.priorities.Delete(item.value)
+
+	return item.value
+}
+
+// SetPriority for an item. This must be called prior to pushing the item.
+func (p *PriorityQueue) SetPriority(item any, priority int) {
+	var priorityItem priorityType
+	priorityItem.priority = priority
+
+	v, found := p.priorities.Load(item)
+	if !found {
+		p.priorities.LoadOrStore(item, priorityItem)
+
+		return
+	}
+
+	existing := v.(priorityType)
+	priorityItem.dirty = existing.dirty
+
+	if existing.priority != priority {
+		priorityItem.dirty = true
+	}
+
+	p.priorities.CompareAndSwap(item, existing, priorityItem)
+}
+
+func (p *PriorityQueue) getPriority(item any) int {
+	v, found := p.priorities.Load(item)
+	if !found {
+		return 0
+	}
+
+	return v.(priorityType).priority
+}
+
+// Adjust the order of an existing item in the queue after it's priority has been changed.
+func (p *PriorityQueue) Adjust(item any) {
+	index, found := p.indices[item]
+	if !found {
+		return
+	}
+
+	v, found := p.priorities.Load(item)
+	if !found {
+		return
+	}
+
+	existing := v.(priorityType)
+	if existing.dirty {
+		p.priorities.CompareAndSwap(item, existing, priorityType{priority: existing.priority})
+		p.items[p.indices[item]].priority = existing.priority
+		heap.Fix(p, index)
+	}
+}

--- a/pkg/workqueue/priority_queue_test.go
+++ b/pkg/workqueue/priority_queue_test.go
@@ -1,0 +1,82 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workqueue_test
+
+import (
+	"container/heap"
+	"strconv"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/workqueue"
+)
+
+var _ = Describe("PriorityQueue", func() {
+	var pq *workqueue.PriorityQueue
+
+	BeforeEach(func() {
+		pq = workqueue.NewPriorityQueue()
+	})
+
+	JustBeforeEach(func() {
+		heap.Init(pq)
+	})
+
+	push := func(i string, p int) {
+		pq.SetPriority(i, p)
+		heap.Push(pq, i)
+	}
+
+	It("should retrieve in priority order", func() {
+		count := 10
+
+		for i := 0; i < count; i++ { //nolint:intrange // Ignore
+			push(strconv.Itoa(i), i)
+		}
+
+		Expect(pq.Len()).To(Equal(count))
+
+		for i := count - 1; i >= 0; i-- {
+			item := heap.Pop(pq)
+			Expect(item).To(Equal(strconv.Itoa(i)))
+		}
+	})
+
+	It("should adjust ordering when a priority is changed", func() {
+		push("first", 3)
+		push("second", 2)
+		push("third", 1)
+
+		pq.SetPriority("second", 20)
+		pq.SetPriority("second", 20) // should be a no-op
+		pq.Adjust("second")
+		pq.Adjust("second") // should be a no-op
+		Expect(heap.Pop(pq)).To(Equal("second"))
+		pq.Adjust("second") // should be a no-op
+
+		pq.SetPriority("third", 10)
+		pq.Adjust("third")
+		Expect(heap.Pop(pq)).To(Equal("third"))
+
+		push("fourth", 40)
+		pq.SetPriority("fourth", 0)
+		pq.Adjust("fourth")
+		Expect(heap.Pop(pq)).To(Equal("first"))
+	})
+})

--- a/pkg/workqueue/priority_work_queue.go
+++ b/pkg/workqueue/priority_work_queue.go
@@ -1,0 +1,43 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workqueue
+
+import (
+	"container/heap"
+)
+
+type priorityWorkQueue[T comparable] struct {
+	priorityQueue *PriorityQueue
+}
+
+func (p *priorityWorkQueue[T]) Touch(item T) {
+	p.priorityQueue.Adjust(item)
+}
+
+func (p *priorityWorkQueue[T]) Len() int {
+	return p.priorityQueue.Len()
+}
+
+func (p *priorityWorkQueue[T]) Push(item T) {
+	heap.Push(p.priorityQueue, item)
+}
+
+func (p *priorityWorkQueue[T]) Pop() T {
+	return heap.Pop(p.priorityQueue).(T)
+}

--- a/pkg/workqueue/queue.go
+++ b/pkg/workqueue/queue.go
@@ -51,16 +51,22 @@ type queueType struct {
 var logger = log.Logger{Logger: logf.Log.WithName("WorkQueue")}
 
 func New(name string) Interface {
+	return NewWithConfig(name, DefaultConfig())
+}
+
+func NewWithConfig(name string, config Config) Interface {
 	return &queueType{
 		TypedRateLimitingInterface: workqueue.NewTypedRateLimitingQueueWithConfig(
 			// caps the maximum wait
 			workqueue.NewTypedWithMaxWaitRateLimiter(
 				workqueue.NewTypedMaxOfRateLimiter(
 					// exponential per-item rate limiter
-					workqueue.NewTypedItemExponentialFailureRateLimiter[string](50*time.Millisecond, 30*time.Second),
+					workqueue.NewTypedItemExponentialFailureRateLimiter[string](
+						config.ItemRateLimiterBaseDelay, config.ItemRateLimiterMaxDelay),
 					// overall rate limiter (not per item)
-					&workqueue.TypedBucketRateLimiter[string]{Limiter: rate.NewLimiter(rate.Limit(10), 500)},
-				), 5*time.Minute),
+					&workqueue.TypedBucketRateLimiter[string]{Limiter: rate.NewLimiter(rate.Limit(config.BucketRateLimiterItemsPerSec),
+						config.BucketRateLimiterMaxBurst)},
+				), config.OverallRateLimiterMaxDelay),
 			workqueue.TypedRateLimitingQueueConfig[string]{
 				Name: name,
 			}),

--- a/pkg/workqueue/queue.go
+++ b/pkg/workqueue/queue.go
@@ -32,20 +32,31 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
+const (
+	LowPriority    = -100
+	NormalPriority = 0
+)
+
 type ProcessFunc func(key, name, namespace string) (bool, error)
 
 type Interface interface {
 	Enqueue(obj interface{})
+	EnqueueWithOpts(obj interface{}, opts EnqueueOpts)
 	NumRequeues(key string) int
 	Run(stopCh <-chan struct{}, process ProcessFunc)
 	ShutDown()
 	ShutDownWithDrain()
 }
 
+type EnqueueOpts struct {
+	RateLimited bool
+	Priority    int
+}
+
 type queueType struct {
 	workqueue.TypedRateLimitingInterface[string]
-
-	name string
+	priorityQueue *PriorityQueue
+	name          string
 }
 
 var logger = log.Logger{Logger: logf.Log.WithName("WorkQueue")}
@@ -55,7 +66,10 @@ func New(name string) Interface {
 }
 
 func NewWithConfig(name string, config Config) Interface {
+	priorityQueue := NewPriorityQueue()
+
 	return &queueType{
+		priorityQueue: priorityQueue,
 		TypedRateLimitingInterface: workqueue.NewTypedRateLimitingQueueWithConfig(
 			// caps the maximum wait
 			workqueue.NewTypedWithMaxWaitRateLimiter(
@@ -69,17 +83,36 @@ func NewWithConfig(name string, config Config) Interface {
 				), config.OverallRateLimiterMaxDelay),
 			workqueue.TypedRateLimitingQueueConfig[string]{
 				Name: name,
+				DelayingQueue: workqueue.NewTypedDelayingQueueWithConfig(workqueue.TypedDelayingQueueConfig[string]{
+					Name: name,
+					Queue: workqueue.NewTypedWithConfig(workqueue.TypedQueueConfig[string]{
+						Name:  name,
+						Queue: &priorityWorkQueue[string]{priorityQueue: priorityQueue},
+					}),
+				}),
 			}),
 		name: name,
 	}
 }
 
 func (q *queueType) Enqueue(obj interface{}) {
+	q.EnqueueWithOpts(obj, EnqueueOpts{Priority: NormalPriority, RateLimited: true})
+}
+
+func (q *queueType) EnqueueWithOpts(obj interface{}, opts EnqueueOpts) {
 	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 	utilruntime.Must(err)
 
-	logger.V(log.LIBTRACE).Infof("%s: enqueueing key %q for %T object", q.name, key, obj)
-	q.AddRateLimited(key)
+	logger.V(log.LIBTRACE).Infof("%s: enqueueing key %q for %T object with priority %d",
+		q.name, key, obj, opts.Priority)
+
+	q.priorityQueue.SetPriority(key, opts.Priority)
+
+	if opts.RateLimited {
+		q.AddRateLimited(key)
+	} else {
+		q.Add(key)
+	}
 }
 
 func (q *queueType) Run(stopCh <-chan struct{}, process ProcessFunc) {

--- a/pkg/workqueue/queue.go
+++ b/pkg/workqueue/queue.go
@@ -75,12 +75,8 @@ func NewWithConfig(name string, config Config) Interface {
 }
 
 func (q *queueType) Enqueue(obj interface{}) {
-	var key string
-	var err error
-	if key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(obj); err != nil {
-		utilruntime.HandleError(err)
-		return
-	}
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	utilruntime.Must(err)
 
 	logger.V(log.LIBTRACE).Infof("%s: enqueueing key %q for %T object", q.name, key, obj)
 	q.AddRateLimited(key)
@@ -101,14 +97,10 @@ func (q *queueType) processNextWorkItem(process ProcessFunc) bool {
 
 	defer q.Done(key)
 
-	requeue, err := func() (bool, error) {
-		ns, name, err := cache.SplitMetaNamespaceKey(key)
-		if err != nil {
-			panic(err)
-		}
+	ns, name, err := cache.SplitMetaNamespaceKey(key)
+	utilruntime.Must(err)
 
-		return process(key, name, ns)
-	}()
+	requeue, err := process(key, name, ns)
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("%s: Failed to process object with key %q using function %#v: %w", q.name, key, process, err))
 	}

--- a/pkg/workqueue/queue_test.go
+++ b/pkg/workqueue/queue_test.go
@@ -1,0 +1,158 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workqueue_test
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"sync"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/workqueue"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/utils/set"
+)
+
+var _ = Describe("Work Queue", func() {
+	var (
+		wq        workqueue.Interface
+		processFn workqueue.ProcessFunc
+		itemCh    chan string
+	)
+
+	BeforeEach(func() {
+		config := workqueue.DefaultConfig()
+		config.ItemRateLimiterBaseDelay = 0
+
+		wq = workqueue.NewWithConfig("test", config)
+		itemCh = make(chan string, 100)
+
+		processFn = func(key, name, namespace string) (bool, error) {
+			defer GinkgoRecover()
+
+			actualNS, actualName, err := cache.SplitMetaNamespaceKey(key)
+			Expect(err).To(Succeed())
+			Expect(actualNS).To(Equal(namespace))
+			Expect(actualName).To(Equal(name))
+
+			itemCh <- key
+
+			return false, nil
+		}
+	})
+
+	JustBeforeEach(func() {
+		stopCh := make(chan struct{})
+		wq.Run(stopCh, processFn)
+
+		DeferCleanup(func() {
+			wq.ShutDownWithDrain()
+			close(stopCh)
+		})
+	})
+
+	It("should notify of enqueued items", func() {
+		expKeys := set.Set[string]{}
+
+		for i := 1; i <= 10; i++ {
+			k := cache.ObjectName{Namespace: "ns", Name: strconv.Itoa(i)}.String()
+			expKeys.Insert(k)
+			wq.Enqueue(cache.ExplicitKey(k))
+		}
+
+		count := expKeys.Len()
+		for i := 1; i <= count; i++ {
+			var received string
+
+			Eventually(itemCh).Should(Receive(&received))
+			Expect(expKeys.Has(received)).To(BeTrue(), "Received unexpected %q", received)
+			expKeys.Delete(received)
+		}
+
+		Expect(expKeys.Len()).To(BeZero(), "Did not receive %v", expKeys.UnsortedList())
+		Consistently(itemCh).ShouldNot(Receive())
+	})
+
+	When("a DeletedFinalStateUnknown object is enqueued", func() {
+		It("should notify of the key", func() {
+			key := cache.ObjectName{Namespace: "ns", Name: "deleted"}.String()
+			wq.Enqueue(cache.DeletedFinalStateUnknown{Key: key})
+			Eventually(itemCh).Should(Receive(Equal(key)))
+		})
+	})
+
+	When("the processing function returns an error", func() {
+		var handledError chan error
+
+		BeforeEach(func() {
+			savedErrorHandlers := utilruntime.ErrorHandlers
+			DeferCleanup(func() {
+				utilruntime.ErrorHandlers = savedErrorHandlers
+			})
+
+			handledError = make(chan error, 50)
+
+			utilruntime.ErrorHandlers = append(utilruntime.ErrorHandlers,
+				func(_ context.Context, err error, _ string, _ ...interface{}) {
+					handledError <- err
+				})
+
+			processFn = func(_, _, _ string) (bool, error) {
+				return false, errors.New("processing error")
+			}
+		})
+
+		It("should log the error", func() {
+			key := cache.ObjectName{Name: "foo"}.String()
+			wq.Enqueue(cache.ExplicitKey(key))
+
+			Eventually(handledError).Should(Receive())
+			Consistently(handledError).ShouldNot(Receive())
+		})
+	})
+
+	When("a requeue is requested from the processing function", func() {
+		BeforeEach(func() {
+			var once sync.Once
+			processFn = func(key, _, _ string) (bool, error) {
+				itemCh <- key
+
+				requeue := false
+				once.Do(func() {
+					requeue = true
+				})
+
+				return requeue, nil
+			}
+		})
+
+		It("should notify of the item again", func() {
+			key := cache.ObjectName{Namespace: "foo", Name: "bar"}.String()
+			wq.Enqueue(cache.ExplicitKey(key))
+
+			Eventually(itemCh).Should(Receive(Equal(key)))
+			Eventually(itemCh).Should(Receive(Equal(key)))
+
+			Consistently(itemCh).ShouldNot(Receive())
+		})
+	})
+})

--- a/pkg/workqueue/queue_test.go
+++ b/pkg/workqueue/queue_test.go
@@ -155,4 +155,67 @@ var _ = Describe("Work Queue", func() {
 			Consistently(itemCh).ShouldNot(Receive())
 		})
 	})
+
+	Context("items enqueued with low priority", func() {
+		firstKey := cache.ObjectName{Name: "first"}.String()
+		lowKey1 := cache.ObjectName{Name: "lowKey1"}.String()
+		lowKey2 := cache.ObjectName{Name: "lowKey2"}.String()
+		normalKey1 := cache.ObjectName{Name: "normalKey1"}.String()
+		normalKey2 := cache.ObjectName{Name: "normalKey2"}.String()
+
+		BeforeEach(func() {
+			processFn = func(key, _, _ string) (bool, error) {
+				itemCh <- key
+
+				if key == firstKey {
+					wq.EnqueueWithOpts(cache.ExplicitKey(lowKey1), workqueue.EnqueueOpts{Priority: workqueue.LowPriority})
+					wq.Enqueue(cache.ExplicitKey(normalKey1))
+					wq.EnqueueWithOpts(cache.ExplicitKey(lowKey2), workqueue.EnqueueOpts{Priority: workqueue.LowPriority})
+					wq.Enqueue(cache.ExplicitKey(normalKey2))
+				}
+
+				return false, nil
+			}
+		})
+
+		Specify("should be processed after normal priority items", func() {
+			wq.Enqueue(cache.ExplicitKey(firstKey))
+			Eventually(itemCh).Should(Receive(Equal(firstKey)))
+
+			Eventually(itemCh).Should(Receive(HavePrefix("normal")))
+			Eventually(itemCh).Should(Receive(HavePrefix("normal")))
+			Eventually(itemCh).Should(Receive(HavePrefix("low")))
+			Eventually(itemCh).Should(Receive(HavePrefix("low")))
+		})
+	})
+
+	When("the priority for an item already in the queue is increased to normal", func() {
+		firstKey := cache.ObjectName{Name: "first"}.String()
+		adjustedKey := cache.ObjectName{Name: "adjusted"}.String()
+
+		BeforeEach(func() {
+			processFn = func(key, _, _ string) (bool, error) {
+				itemCh <- key
+
+				if key == firstKey {
+					for i := 1; i <= 50; i++ {
+						wq.EnqueueWithOpts(cache.ExplicitKey("low"+strconv.Itoa(i)), workqueue.EnqueueOpts{Priority: workqueue.LowPriority})
+					}
+
+					wq.EnqueueWithOpts(cache.ExplicitKey(adjustedKey), workqueue.EnqueueOpts{Priority: workqueue.LowPriority})
+					// Should cause it to be adjusted to the front of the queue
+					wq.Enqueue(cache.ExplicitKey(adjustedKey))
+				}
+
+				return false, nil
+			}
+		})
+
+		It("should adjust its position to the front of the queue", func() {
+			wq.Enqueue(cache.ExplicitKey(firstKey))
+			Eventually(itemCh).Should(Receive(Equal(firstKey)))
+
+			Eventually(itemCh).Should(Receive(Equal(adjustedKey)))
+		})
+	})
 })

--- a/pkg/workqueue/workqueue_suite_test.go
+++ b/pkg/workqueue/workqueue_suite_test.go
@@ -1,0 +1,40 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workqueue_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/log/kzerolog"
+)
+
+func TestWorkqueue(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Workqueue Suite")
+}
+
+func init() {
+	kzerolog.AddFlags(nil)
+}
+
+var _ = Describe("", func() {
+	kzerolog.InitK8sLogging()
+})


### PR DESCRIPTION
All pre-existing resources are queued by the informer on startup. With many resources in the hundreds or thousands it can take significant time to process them all and the work queue rate limiter can cause further significant delays. This can block newly created resources or existing resource updates for potentially minutes. Most of the time a pod restart is fairly quick so most resources didn't likely change so it makes sense to give newly created/updated resources higher priority and process them in a more timely manner.  

The **client-go** work queue allows the backend `Queue` implementation to be configurable. This PR adds an implementation to the **admiral** `workqueue` module that is backed by a priority queue that is used in conjunction with the `container/heap` module and implements `heap.Interface`. A new `EnqueueWithPriority` method was added to the **admiral** `workqueue.Interface` that allows the caller to specify the priority and whether or not to enqueue with rate limiting. The existing `Enqueue` method was modified to enqueue with normal priority 0. 

The resource syncer was modified to use the `EnqueueWithPriority` method to prioritize newly created/updated resources over pre-existing resources on startup. The `cache.ResourceEventHandler'`s `OnAdd` method has an `isInInitialList` param that indicates if the obj was pre-existing in the initial listing retrieved from the API server. If `isInInitialList` is true then enqueue with low priority otherwise use normal priority (`Enqueue` method).

See commits for more details.

Related to https://github.com/submariner-io/lighthouse/issues/1706