### PR TITLE
Automated backport of #1079: Fix panic in MustExtractList if passed a nil interface

### DIFF
--- a/pkg/resource/interface.go
+++ b/pkg/resource/interface.go
@@ -20,6 +20,7 @@ package resource
 
 import (
 	"context"
+	"reflect"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -90,7 +91,9 @@ func DefaultUpdateStatus[T runtime.Object](_ context.Context, _ T, _ metav1.Upda
 }
 
 func MustExtractList[T runtime.Object](from runtime.Object) []T {
-	if from == nil {
+	// If 'from' is a typed interface pointer whose underlying value is nil, equality check will return false so
+	// also check nil via reflection.
+	if from == nil || reflect.ValueOf(from).IsNil() {
 		return nil
 	}
 

--- a/pkg/resource/interface_test.go
+++ b/pkg/resource/interface_test.go
@@ -217,6 +217,20 @@ var _ = Describe("Interface", func() {
 	})
 })
 
+var _ = Describe("MustExtractList", func() {
+	Specify("should handle nil input", func() {
+		r := resource.MustExtractList[*unstructured.Unstructured](nil)
+		Expect(r).To(BeEmpty())
+
+		// Test case with a typed interface pointer whose underlying value is nil. In this case, equality check,
+		// ie "from == nil", returns false.
+		var l *unstructured.UnstructuredList
+
+		r = resource.MustExtractList[*unstructured.Unstructured](l)
+		Expect(r).To(BeEmpty())
+	})
+})
+
 func testInterfaceFuncs[T runtime.Object](newInterface func() resource.Interface[T], initialObj T) {
 	Specify("verify functions", func() {
 		sanitize := func(o T) T {


### PR DESCRIPTION
Backport of #1079 on release-0.20.

#1079: Fix panic in MustExtractList if passed a nil interface

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.