### PR TITLE
Elide setting CreationTimestamp if already set in fake createReactor

### DIFF
--- a/pkg/fake/basic_reactors_test.go
+++ b/pkg/fake/basic_reactors_test.go
@@ -58,10 +58,17 @@ var _ = Describe("Create", func() {
 		Expect(actual.UID).ToNot(BeEmpty())
 	})
 
-	It("should set the CreationTimestamp field", func() {
+	Specify("should set the CreationTimestamp field if not specified", func() {
 		now := metav1.Now()
 		actual := t.assertCreateSuccess(t.pod)
 		Expect(actual.CreationTimestamp.After(now.Add(-time.Second * 5))).To(BeTrue())
+	})
+
+	Specify("should not set the CreationTimestamp field if specified", func() {
+		cst := metav1.Time{Time: metav1.Now().Add(time.Hour)}
+		t.pod.CreationTimestamp = cst
+		actual := t.assertCreateSuccess(t.pod)
+		Expect(actual.CreationTimestamp).To(Equal(cst))
 	})
 
 	When("the Name and GenerateName fields are empty", func() {

--- a/pkg/fake/create_reactor.go
+++ b/pkg/fake/create_reactor.go
@@ -64,7 +64,10 @@ func (r *createReactor) react(a testing.Action) (bool, runtime.Object, error) {
 	}
 
 	target.SetResourceVersion("1")
-	target.SetCreationTimestamp(metav1.Now())
+
+	if target.GetCreationTimestamp().Time.IsZero() {
+		target.SetCreationTimestamp(metav1.Now())
+	}
 
 	if !target.GetDeletionTimestamp().IsZero() {
 		target.SetDeletionTimestamp(nil)


### PR DESCRIPTION
...to allow callers to specify their own time stamp as they see fit.
