### PR TITLE
Don't re-queue a create operation if the resource no longer exists

### DIFF
--- a/pkg/syncer/resource_syncer.go
+++ b/pkg/syncer/resource_syncer.go
@@ -703,7 +703,7 @@ func (r *resourceSyncer) transform(from *unstructured.Unstructured, key string,
 	converted := r.mustConvert(from)
 
 	transformed, requeue := r.config.Transform(converted, r.workQueue.NumRequeues(key), op)
-	if transformed == nil {
+	if transformed == nil || reflect.ValueOf(transformed).IsNil() {
 		r.log.V(log.LIBDEBUG).Infof("Syncer %q: transform function returned nil - not syncing - requeue: %v", r.config.Name, requeue)
 		return nil, nil, requeue
 	}

--- a/pkg/syncer/resource_syncer.go
+++ b/pkg/syncer/resource_syncer.go
@@ -638,6 +638,11 @@ func (r *resourceSyncer) handleCreatedOrUpdated(key string, created *unstructure
 		r.log.V(log.LIBDEBUG).Infof("Syncer %q successfully synced %q", r.config.Name, resource.GetName())
 	}
 
+	if requeue && op == Create && !exists {
+		// Don't requeue a create operation if the resource no longer exists.
+		requeue = false
+	}
+
 	return requeue, nil
 }
 

--- a/pkg/syncer/resource_syncer.go
+++ b/pkg/syncer/resource_syncer.go
@@ -627,13 +627,7 @@ func (r *resourceSyncer) handleCreatedOrUpdated(key string, created *unstructure
 
 		r.recordNamespaceSeen(resource.GetNamespace())
 
-		if r.syncCounter != nil {
-			r.syncCounter.With(prometheus.Labels{
-				DirectionLabel:  r.config.Direction.String(),
-				OperationLabel:  op.String(),
-				SyncerNameLabel: r.config.Name,
-			}).Inc()
-		}
+		r.incOpCounter(op)
 
 		r.log.V(log.LIBDEBUG).Infof("Syncer %q successfully synced %q", r.config.Name, resource.GetName())
 	}
@@ -672,19 +666,23 @@ func (r *resourceSyncer) handleDeleted(key string, deletedResource *unstructured
 		}
 
 		if deleted {
-			if r.syncCounter != nil {
-				r.syncCounter.With(prometheus.Labels{
-					DirectionLabel:  r.config.Direction.String(),
-					OperationLabel:  Delete.String(),
-					SyncerNameLabel: r.config.Name,
-				}).Inc()
-			}
+			r.incOpCounter(Delete)
 
 			r.log.V(log.LIBDEBUG).Infof("Syncer %q successfully deleted %q", r.config.Name, resource.GetName())
 		}
 	}
 
 	return requeue, nil
+}
+
+func (r *resourceSyncer) incOpCounter(op Operation) {
+	if r.syncCounter != nil {
+		r.syncCounter.With(prometheus.Labels{
+			DirectionLabel:  r.config.Direction.String(),
+			OperationLabel:  op.String(),
+			SyncerNameLabel: r.config.Name,
+		}).Inc()
+	}
 }
 
 func (r *resourceSyncer) mustConvert(from interface{}) runtime.Object {

--- a/pkg/syncer/resource_syncer_test.go
+++ b/pkg/syncer/resource_syncer_test.go
@@ -337,6 +337,7 @@ func testRemoteToLocalWithoutLocalClusterID() {
 	})
 }
 
+//nolint:maintidx // Ignore Maintainability Index threshold exceeded.
 func testTransformFunction() {
 	d := newTestDriver(test.LocalNamespace, "", syncer.RemoteToLocal)
 	ctx := context.TODO()
@@ -344,7 +345,7 @@ func testTransformFunction() {
 	var transformed *corev1.Pod
 	var expOperation chan syncer.Operation
 	var invocationCount int32
-	var requeue bool
+	var requeueOnOp *syncer.Operation
 
 	BeforeEach(func() {
 		test.SetClusterIDLabel(d.resource, "remote")
@@ -352,7 +353,7 @@ func testTransformFunction() {
 
 		expOperation = make(chan syncer.Operation, 20)
 		transformed = test.NewPodWithImage(d.config.SourceNamespace, "transformed")
-		requeue = false
+		requeueOnOp = nil
 
 		d.config.Transform = func(from runtime.Object, _ int, op syncer.Operation) (runtime.Object, bool) {
 			defer GinkgoRecover()
@@ -364,7 +365,18 @@ func testTransformFunction() {
 				"Expected:\n%#v\n to be equivalent to: \n%#v", pod.Spec, d.resource.Spec)
 			expOperation <- op
 
-			return transformed, requeue
+			requeue := false
+
+			if requeueOnOp != nil {
+				requeue = *requeueOnOp == op
+			}
+
+			retObj := transformed
+			if requeue {
+				retObj = nil
+			}
+
+			return retObj, requeue
 		}
 	})
 
@@ -391,7 +403,7 @@ func testTransformFunction() {
 
 		Context("and the transform function specifies to re-queue", func() {
 			BeforeEach(func() {
-				requeue = true
+				requeueOnOp = ptr.To(syncer.Create)
 			})
 
 			It("should eventually retry", func() {
@@ -424,7 +436,6 @@ func testTransformFunction() {
 		})
 
 		JustBeforeEach(func() {
-			verifyDistribute()
 			Eventually(expOperation).Should(Receive(Equal(syncer.Create)))
 			atomic.StoreInt32(&invocationCount, 0)
 		})
@@ -439,8 +450,8 @@ func testTransformFunction() {
 		})
 
 		Context("and the transform function specifies to re-queue", func() {
-			JustBeforeEach(func() {
-				requeue = true
+			BeforeEach(func() {
+				requeueOnOp = ptr.To(syncer.Delete)
 			})
 
 			It("should eventually retry", func() {
@@ -448,6 +459,18 @@ func testTransformFunction() {
 				Eventually(func() int {
 					return int(atomic.LoadInt32(&invocationCount))
 				}, 3).Should(BeNumerically(">", 1))
+			})
+		})
+
+		Context("after the create operation is re-queued", func() {
+			BeforeEach(func() {
+				requeueOnOp = ptr.To(syncer.Create)
+			})
+
+			It("should not retry the create operation", func() {
+				Expect(d.sourceClient.Delete(ctx, d.resource.GetName(), metav1.DeleteOptions{})).To(Succeed())
+				Eventually(expOperation).Should(Receive(Equal(syncer.Delete)))
+				Consistently(expOperation).ShouldNot(Receive(Equal(syncer.Create)))
 			})
 		})
 	})


### PR DESCRIPTION
...otherwise it's continuously re-queued as long as the transform function keeps specifying to re-queue.

Also, the change to `handleCreatedOrUpdated` triggered the cyclomatic complexity linter so refactored to reduce it. See commits for more details.
