### PR TITLE
Automated backport of #1101: Add Context param to AwaitStopped

### DIFF
--- a/pkg/syncer/await_stopped_test.go
+++ b/pkg/syncer/await_stopped_test.go
@@ -1,0 +1,87 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package syncer_test
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/syncer"
+	"github.com/submariner-io/admiral/pkg/syncer/test"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func testAwaitStopped() {
+	t := newTestDriver(test.LocalNamespace, "", syncer.LocalToRemote)
+
+	BeforeEach(func() {
+		t.config.Federator = &blockingFederator{
+			distributeContinue: make(chan any),
+			distributeStarted:  make(chan any),
+		}
+
+		t.config.DrainWorkQueueTimeout = time.Millisecond * 80
+	})
+
+	It("should time out if the work queue is delayed stopping", func() {
+		defer func() {
+			t.stopCh = nil
+		}()
+
+		test.CreateResource(t.sourceClient, t.resource)
+		Eventually(t.config.Federator.(*blockingFederator).distributeStarted).Should(Receive())
+
+		close(t.stopCh)
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*300)
+		defer cancel()
+
+		Expect(t.syncer.AwaitStopped(ctx)).NotTo(Succeed())
+
+		t.config.Federator.(*blockingFederator).distributeContinue <- true
+
+		ctx, cancel = context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+
+		Expect(t.syncer.AwaitStopped(ctx)).To(Succeed())
+		Expect(t.syncer.AwaitStopped(ctx)).To(Succeed())
+	})
+}
+
+type blockingFederator struct {
+	distributeContinue chan any
+	distributeStarted  chan any
+	once               sync.Once
+}
+
+func (f *blockingFederator) Distribute(_ context.Context, _ runtime.Object) error {
+	f.once.Do(func() {
+		f.distributeStarted <- true
+		<-f.distributeContinue
+	})
+
+	return nil
+}
+
+func (f *blockingFederator) Delete(_ context.Context, _ runtime.Object) error {
+	return nil
+}

--- a/pkg/syncer/resource_syncer.go
+++ b/pkg/syncer/resource_syncer.go
@@ -192,6 +192,8 @@ type ResourceSyncerConfig struct {
 
 	// WorkQueueConfig if specified, configures the underlying work queue
 	WorkQueueConfig *workqueue.Config
+
+	DrainWorkQueueTimeout time.Duration
 }
 
 type resourceSyncer struct {
@@ -300,6 +302,10 @@ func newResourceSyncer(config *ResourceSyncerConfig) (*resourceSyncer, error) {
 		syncer.config.WaitForCacheSync = &wait
 	}
 
+	if syncer.config.DrainWorkQueueTimeout == 0 {
+		syncer.config.DrainWorkQueueTimeout = time.Second * 5
+	}
+
 	if syncer.config.SyncCounter != nil {
 		syncer.syncCounter = syncer.config.SyncCounter
 	} else if syncer.config.SyncCounterOpts != nil {
@@ -380,10 +386,9 @@ func (r *resourceSyncer) Start(stopCh <-chan struct{}) error {
 				r.unregHandler()
 			}
 
-			r.stopped <- struct{}{}
 			r.log.V(log.LIBDEBUG).Infof("Syncer %q stopped", r.config.Name)
 		}()
-		defer r.workQueue.ShutDownWithDrain()
+		defer r.shutDownWorkQueue()
 
 		if r.informer != nil {
 			r.informer.Run(stopCh)
@@ -398,15 +403,44 @@ func (r *resourceSyncer) Start(stopCh <-chan struct{}) error {
 		_ = cache.WaitForCacheSync(stopCh, r.cachesSynced...)
 	}
 
-	r.workQueue.Run(stopCh, r.processNextWorkItem)
+	r.workQueue.Run(r.processNextWorkItem)
 
 	r.log.V(log.LIBDEBUG).Infof("Syncer %q started", r.config.Name)
 
 	return nil
 }
 
-func (r *resourceSyncer) AwaitStopped() {
-	<-r.stopped
+func (r *resourceSyncer) shutDownWorkQueue() {
+	shutDownWithDrain := func() error {
+		ctx, cancel := context.WithTimeout(context.Background(), r.config.DrainWorkQueueTimeout)
+		defer cancel()
+
+		return r.workQueue.ShutDownWithDrain(ctx)
+	}
+
+	for {
+		err := shutDownWithDrain()
+		if err == nil {
+			break
+		}
+
+		r.log.Warningf(err.Error())
+	}
+
+	close(r.stopped)
+}
+
+func (r *resourceSyncer) AwaitStopped(ctx context.Context) error {
+	select {
+	case _, closed := <-r.stopped:
+		if closed {
+			return nil
+		}
+	case <-ctx.Done():
+		return errors.Wrapf(ctx.Err(), "syncer %q await stopped did not complete", r.config.Name)
+	}
+
+	return nil
 }
 
 func (r *resourceSyncer) GetResource(name, namespace string) (runtime.Object, bool, error) {

--- a/pkg/syncer/resource_syncer_test.go
+++ b/pkg/syncer/resource_syncer_test.go
@@ -79,6 +79,7 @@ var _ = Describe("Resource Syncer", func() {
 	Describe("With missing namespace", testWithMissingNamespace)
 	Describe("Event Ordering", testEventOrdering)
 	Describe("Priority Ordering", testPriorityOrdering)
+	Describe("AwaitStopped", testAwaitStopped)
 })
 
 func testReconcileLocalToRemote() {
@@ -1537,8 +1538,14 @@ func newTestDriver(sourceNamespace, localClusterID string, syncDirection syncer.
 	})
 
 	JustAfterEach(func() {
-		close(d.stopCh)
-		d.syncer.AwaitStopped()
+		if d.stopCh != nil {
+			close(d.stopCh)
+		}
+
+		ctx, cancel := context.WithTimeout(context.TODO(), time.Second*3)
+		defer cancel()
+		Expect(d.syncer.AwaitStopped(ctx)).To(Succeed())
+
 		utilruntime.ErrorHandlers = d.savedErrorHandlers
 	})
 

--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -19,13 +19,15 @@ limitations under the License.
 package syncer
 
 import (
+	"context"
+
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
 type Interface interface {
 	Start(stopCh <-chan struct{}) error
-	AwaitStopped()
+	AwaitStopped(ctx context.Context) error
 	GetResource(name, namespace string) (runtime.Object, bool, error)
 	RequeueResource(name, namespace string)
 	ListResources() []runtime.Object

--- a/pkg/syncer/syncer_suite_test.go
+++ b/pkg/syncer/syncer_suite_test.go
@@ -23,8 +23,22 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/submariner-io/admiral/pkg/log/kzerolog"
 )
+
+type EmptyRegisterer struct{}
+
+func (e EmptyRegisterer) Register(_ prometheus.Collector) error {
+	return nil
+}
+
+func (e EmptyRegisterer) MustRegister(_ ...prometheus.Collector) {
+}
+
+func (e EmptyRegisterer) Unregister(_ prometheus.Collector) bool {
+	return true
+}
 
 func init() {
 	flags := flag.NewFlagSet("kzerolog", flag.ExitOnError)
@@ -32,6 +46,8 @@ func init() {
 	_ = flags.Parse([]string{"-v=1"})
 
 	kzerolog.AddFlags(nil)
+
+	prometheus.DefaultRegisterer = &EmptyRegisterer{}
 }
 
 var _ = Describe("", func() {

--- a/pkg/workqueue/queue.go
+++ b/pkg/workqueue/queue.go
@@ -20,13 +20,13 @@ limitations under the License.
 package workqueue
 
 import (
+	"context"
 	"fmt"
-	"time"
 
+	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/log"
 	"golang.org/x/time/rate"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -43,9 +43,9 @@ type Interface interface {
 	Enqueue(obj interface{})
 	EnqueueWithOpts(obj interface{}, opts EnqueueOpts)
 	NumRequeues(key string) int
-	Run(stopCh <-chan struct{}, process ProcessFunc)
+	Run(process ProcessFunc)
 	ShutDown()
-	ShutDownWithDrain()
+	ShutDownWithDrain(ctx context.Context) error
 }
 
 type EnqueueOpts struct {
@@ -115,11 +115,11 @@ func (q *queueType) EnqueueWithOpts(obj interface{}, opts EnqueueOpts) {
 	}
 }
 
-func (q *queueType) Run(stopCh <-chan struct{}, process ProcessFunc) {
-	go wait.Until(func() {
+func (q *queueType) Run(process ProcessFunc) {
+	go func() {
 		for q.processNextWorkItem(process) {
 		}
-	}, time.Second, stopCh)
+	}()
 }
 
 func (q *queueType) processNextWorkItem(process ProcessFunc) bool {
@@ -152,18 +152,29 @@ func (q *queueType) NumRequeues(key string) int {
 	return q.TypedRateLimitingInterface.NumRequeues(key)
 }
 
-func (q *queueType) ShutDownWithDrain() {
+func (q *queueType) ShutDownWithDrain(ctx context.Context) error {
 	done := make(chan struct{})
 
-	// ShutDownWithDrain waits for all in-flight work to complete and thus could block indefinitely so put a deadline on it.
 	go func() {
-		q.TypedRateLimitingInterface.ShutDownWithDrain()
+		for {
+			q.TypedRateLimitingInterface.ShutDownWithDrain()
+
+			// The queue should be empty after ShutDownWithDrain returns, but sometimes it isn't so ensure it is.
+			if q.Len() == 0 {
+				break
+			}
+		}
+
 		done <- struct{}{}
 	}()
 
 	select {
 	case <-done:
-	case <-time.After(5 * time.Second):
-		logger.Warningf("%s: timed out draining the queue on shut down", q.name)
+	case <-ctx.Done():
+		// Calling ShutDown causes ShutDownWithDrain to return.
+		q.TypedRateLimitingInterface.ShutDown()
+		return errors.Wrapf(ctx.Err(), "%s: did not complete draining the queue on shut down", q.name)
 	}
+
+	return nil
 }

--- a/pkg/workqueue/queue_test.go
+++ b/pkg/workqueue/queue_test.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"strconv"
 	"sync"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -61,12 +62,10 @@ var _ = Describe("Work Queue", func() {
 	})
 
 	JustBeforeEach(func() {
-		stopCh := make(chan struct{})
-		wq.Run(stopCh, processFn)
+		wq.Run(processFn)
 
 		DeferCleanup(func() {
-			wq.ShutDownWithDrain()
-			close(stopCh)
+			wq.ShutDown()
 		})
 	})
 
@@ -216,6 +215,87 @@ var _ = Describe("Work Queue", func() {
 			Eventually(itemCh).Should(Receive(Equal(firstKey)))
 
 			Eventually(itemCh).Should(Receive(Equal(adjustedKey)))
+		})
+	})
+
+	Context("ShutDownWithDrain", func() {
+		var (
+			processContinue chan any
+			processStart    chan any
+			processed       sync.Map
+			once            sync.Once
+		)
+
+		BeforeEach(func() {
+			processContinue = make(chan any)
+			processStart = make(chan any)
+			processed = sync.Map{}
+			once = sync.Once{}
+
+			processFn = func(key, _, _ string) (bool, error) {
+				once.Do(func() {
+					processStart <- true
+					<-processContinue
+				})
+
+				processed.Store(key, true)
+
+				// Delay a bit to ensure the majority of the items are processed after ShutDownWithDrain has started.
+				time.Sleep(time.Millisecond * 20)
+
+				return false, nil
+			}
+		})
+
+		It("should process all previously queued items", func() {
+			count := 10
+
+			var keys []string
+			for i := 1; i <= count; i++ {
+				keys = append(keys, strconv.Itoa(i))
+			}
+
+			for _, key := range keys {
+				wq.EnqueueWithOpts(cache.ExplicitKey(key),
+					workqueue.EnqueueOpts{Priority: workqueue.NormalPriority, RateLimited: false})
+			}
+
+			Eventually(processStart).Should(Receive())
+
+			ctx, cancel := context.WithTimeout(context.TODO(), time.Second*5)
+			defer cancel()
+
+			processContinue <- true
+			Expect(wq.ShutDownWithDrain(ctx)).To(Succeed())
+
+			for _, key := range keys {
+				_, ok := processed.Load(key)
+				Expect(ok).To(BeTrue(), "%q was not processed", key)
+			}
+		})
+
+		It("should time out if the current item processing is delayed", func() {
+			itemKey := "item"
+
+			wq.EnqueueWithOpts(cache.ExplicitKey(itemKey),
+				workqueue.EnqueueOpts{Priority: workqueue.NormalPriority, RateLimited: false})
+
+			Eventually(processStart).Should(Receive())
+
+			ctx, cancel := context.WithTimeout(context.TODO(), time.Millisecond*100)
+			defer cancel()
+
+			Expect(wq.ShutDownWithDrain(ctx)).NotTo(Succeed())
+
+			processContinue <- true
+
+			ctx, cancel = context.WithTimeout(context.TODO(), time.Second*3)
+			defer cancel()
+
+			Expect(wq.ShutDownWithDrain(ctx)).To(Succeed())
+
+			_, ok := processed.Load(itemKey)
+			Expect(ok).To(BeTrue(), "Item was not processed")
 		})
 	})
 })


### PR DESCRIPTION
Backport of #1101 on release-0.20.

#1101: Add Context param to workqueue ShutDownWithDrain method

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.