### PR TITLE
Add default timeout in AwaitStopped and ShutDownWithDrain

### DIFF
--- a/pkg/syncer/resource_syncer.go
+++ b/pkg/syncer/resource_syncer.go
@@ -431,6 +431,9 @@ func (r *resourceSyncer) shutDownWorkQueue() {
 }
 
 func (r *resourceSyncer) AwaitStopped(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, r.config.DrainWorkQueueTimeout)
+	defer cancel()
+
 	select {
 	case _, closed := <-r.stopped:
 		if closed {

--- a/pkg/workqueue/queue.go
+++ b/pkg/workqueue/queue.go
@@ -22,6 +22,7 @@ package workqueue
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/log"
@@ -175,6 +176,9 @@ func (q *queueType) ShutDownWithDrain(ctx context.Context) error {
 
 		done <- struct{}{}
 	}()
+
+	ctx, cancel := context.WithTimeout(ctx, time.Second*5)
+	defer cancel()
 
 	select {
 	case <-done:

--- a/pkg/workqueue/queue_test.go
+++ b/pkg/workqueue/queue_test.go
@@ -332,11 +332,8 @@ var _ = Describe("Work Queue", func() {
 
 			Eventually(processStart).Should(Receive())
 
-			ctx, cancel := context.WithTimeout(context.TODO(), time.Second*5)
-			defer cancel()
-
 			processContinue <- true
-			Expect(wq.ShutDownWithDrain(ctx)).To(Succeed())
+			Expect(wq.ShutDownWithDrain(context.TODO())).To(Succeed())
 
 			for _, key := range keys {
 				_, ok := processed.Load(key)


### PR DESCRIPTION
...in case the caller doesn't set a deadline in the `Context`. This preserves the previous behavior of `ShutDownWithDrain` which did set a deadline internally.