### PR TITLE
Automated backport of #1112: Add default timeout in AwaitStopped and ShutDownWithDrain

### DIFF
--- a/pkg/syncer/await_stopped_test.go
+++ b/pkg/syncer/await_stopped_test.go
@@ -63,7 +63,7 @@ func testAwaitStopped() {
 		defer cancel()
 
 		Expect(t.syncer.AwaitStopped(ctx)).To(Succeed())
-		Expect(t.syncer.AwaitStopped(ctx)).To(Succeed())
+		Expect(t.syncer.AwaitStopped(context.TODO())).To(Succeed())
 	})
 }
 

--- a/pkg/syncer/resource_syncer.go
+++ b/pkg/syncer/resource_syncer.go
@@ -431,14 +431,15 @@ func (r *resourceSyncer) shutDownWorkQueue() {
 }
 
 func (r *resourceSyncer) AwaitStopped(ctx context.Context) error {
-	ctx, cancel := context.WithTimeout(ctx, r.config.DrainWorkQueueTimeout)
-	defer cancel()
+	if _, ok := ctx.Deadline(); !ok {
+		var cancel context.CancelFunc
+
+		ctx, cancel = context.WithTimeout(ctx, r.config.DrainWorkQueueTimeout)
+		defer cancel()
+	}
 
 	select {
-	case _, closed := <-r.stopped:
-		if closed {
-			return nil
-		}
+	case <-r.stopped:
 	case <-ctx.Done():
 		return errors.Wrapf(ctx.Err(), "syncer %q await stopped did not complete", r.config.Name)
 	}

--- a/pkg/syncer/resource_syncer.go
+++ b/pkg/syncer/resource_syncer.go
@@ -431,6 +431,9 @@ func (r *resourceSyncer) shutDownWorkQueue() {
 }
 
 func (r *resourceSyncer) AwaitStopped(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, r.config.DrainWorkQueueTimeout)
+	defer cancel()
+
 	select {
 	case _, closed := <-r.stopped:
 		if closed {

--- a/pkg/syncer/resource_syncer_test.go
+++ b/pkg/syncer/resource_syncer_test.go
@@ -1542,9 +1542,7 @@ func newTestDriver(sourceNamespace, localClusterID string, syncDirection syncer.
 			close(d.stopCh)
 		}
 
-		ctx, cancel := context.WithTimeout(context.TODO(), time.Second*3)
-		defer cancel()
-		Expect(d.syncer.AwaitStopped(ctx)).To(Succeed())
+		Expect(d.syncer.AwaitStopped(context.TODO())).To(Succeed())
 
 		utilruntime.ErrorHandlers = d.savedErrorHandlers
 	})

--- a/pkg/workqueue/queue.go
+++ b/pkg/workqueue/queue.go
@@ -169,8 +169,12 @@ func (q *queueType) ShutDownWithDrain(ctx context.Context) error {
 		done <- struct{}{}
 	}()
 
-	ctx, cancel := context.WithTimeout(ctx, time.Second*5)
-	defer cancel()
+	if _, ok := ctx.Deadline(); !ok {
+		var cancel context.CancelFunc
+
+		ctx, cancel = context.WithTimeout(ctx, time.Second*5)
+		defer cancel()
+	}
 
 	select {
 	case <-done:

--- a/pkg/workqueue/queue.go
+++ b/pkg/workqueue/queue.go
@@ -22,6 +22,7 @@ package workqueue
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/log"
@@ -167,6 +168,9 @@ func (q *queueType) ShutDownWithDrain(ctx context.Context) error {
 
 		done <- struct{}{}
 	}()
+
+	ctx, cancel := context.WithTimeout(ctx, time.Second*5)
+	defer cancel()
 
 	select {
 	case <-done:

--- a/pkg/workqueue/queue_test.go
+++ b/pkg/workqueue/queue_test.go
@@ -262,11 +262,8 @@ var _ = Describe("Work Queue", func() {
 
 			Eventually(processStart).Should(Receive())
 
-			ctx, cancel := context.WithTimeout(context.TODO(), time.Second*5)
-			defer cancel()
-
 			processContinue <- true
-			Expect(wq.ShutDownWithDrain(ctx)).To(Succeed())
+			Expect(wq.ShutDownWithDrain(context.TODO())).To(Succeed())
 
 			for _, key := range keys {
 				_, ok := processed.Load(key)


### PR DESCRIPTION
Backport of #1112 on release-0.20.

#1112: Add default timeout in AwaitStopped and ShutDownWithDrain

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.