### PR TITLE
Check the GenerateName field when retrieving existing resource

### DIFF
--- a/pkg/util/create_or_update.go
+++ b/pkg/util/create_or_update.go
@@ -21,6 +21,7 @@ package util
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/pkg/errors"
@@ -160,7 +161,7 @@ func maybeCreateOrUpdate[T runtime.Object](ctx context.Context, options CreateOr
 		objMeta := resource.MustToMeta(toUpdate)
 		objMeta.SetResourceVersion(origObj.GetResourceVersion())
 		objMeta.SetName(origObj.GetName())
-		objMeta.SetGenerateName("")
+		objMeta.SetGenerateName(resource.MustToMeta(options.Obj).GetGenerateName())
 
 		newObj := resource.MustToUnstructuredUsingDefaultConverter(toUpdate)
 
@@ -227,6 +228,14 @@ func getResource[T runtime.Object](ctx context.Context, options *CreateOrUpdateO
 	if err != nil {
 		return *new(T), err
 	}
+
+	// Filter out resources whose GenerateName field doesn't match.
+	list = slices.DeleteFunc(list, func(t T) bool {
+		gn := resource.MustToMeta(t).GetGenerateName()
+		// Don't filter out the resource if it's GenerateName is empty. This shouldn't be the case but
+		// the prior release erroneously set GenerateName to empty.
+		return gn != "" && gn != objMeta.GetGenerateName()
+	})
 
 	count := len(list)
 	if count == 0 {

--- a/pkg/util/create_or_update_test.go
+++ b/pkg/util/create_or_update_test.go
@@ -423,7 +423,7 @@ func (t *createOrUpdateTestDriver) testUpdate(doUpdate func(util.OperationResult
 		Context("and GenerateName is set", func() {
 			BeforeEach(func() {
 				t.pod.Name = ""
-				t.pod.GenerateName = "name-prefix-g"
+				t.pod.GenerateName = "name-prefix"
 				t.pod.Labels = map[string]string{"label1": "value1", "label2": "value2"}
 			})
 
@@ -432,6 +432,13 @@ func (t *createOrUpdateTestDriver) testUpdate(doUpdate func(util.OperationResult
 			})
 
 			It("should update the resource", func() {
+				test.CreateResource(t.client, &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "other-prefix",
+						Labels:       t.pod.Labels,
+					},
+				})
+
 				Expect(doUpdate(util.OperationResultUpdated)).To(Succeed())
 				t.verifyPod()
 			})
@@ -440,8 +447,8 @@ func (t *createOrUpdateTestDriver) testUpdate(doUpdate func(util.OperationResult
 				It("should return an error", func() {
 					test.CreateResource(t.client, &corev1.Pod{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:   "another",
-							Labels: t.pod.Labels,
+							GenerateName: t.pod.GenerateName,
+							Labels:       t.pod.Labels,
 						},
 					})
 					Expect(doUpdate(util.OperationResultNone)).ToNot(Succeed())


### PR DESCRIPTION
...in `CreateOrUpdate`. We use the identifying labels to search b/c the exact name isn't known but we do know the partial name from the `GenerateName` field.
