### PR TITLE
Make log verbosity configurable in the work queue

### DIFF
--- a/pkg/log/kzerolog/kzerolog.go
+++ b/pkg/log/kzerolog/kzerolog.go
@@ -229,3 +229,7 @@ func (ctx *zeroLogContext) WithValues(kvList ...interface{}) logr.LogSink {
 
 	return &subCtx
 }
+
+func (ctx *zeroLogContext) SetMaxVerbosity(v int) {
+	ctx.maxVerbosity = v
+}

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -84,3 +84,10 @@ func (l Logger) V(level int) Logger {
 	l.Logger = l.Logger.V(level)
 	return l
 }
+
+func (l Logger) SetMaxVerbosity(v int) {
+	c, ok := l.Logger.GetSink().(interface{ SetMaxVerbosity(v int) })
+	if ok {
+		c.SetMaxVerbosity(v)
+	}
+}

--- a/pkg/workqueue/config.go
+++ b/pkg/workqueue/config.go
@@ -34,6 +34,7 @@ const (
 	OverallRateLimiterMaxDelayKey   = "overall-rate-limiter-max-delay"
 	BucketRateLimiterItemsPerSecKey = "bucket-rate-limiter-items-per-sec"
 	BucketRateLimiterMaxBurstKey    = "bucket-rate-limiter-max-burst"
+	MaxVerbosityKey                 = "max-verbosity"
 )
 
 type Config struct {
@@ -42,6 +43,7 @@ type Config struct {
 	OverallRateLimiterMaxDelay   time.Duration
 	BucketRateLimiterItemsPerSec int
 	BucketRateLimiterMaxBurst    int
+	MaxVerbosity                 int
 }
 
 func DefaultConfig() Config {
@@ -93,6 +95,9 @@ func ConfigFromConfigMap(configMap *corev1.ConfigMap, keyPrefix string, defaultC
 			utilruntime.Must(err)
 		case BucketRateLimiterMaxBurstKey:
 			config.BucketRateLimiterMaxBurst, err = strconv.Atoi(v)
+			utilruntime.Must(err)
+		case MaxVerbosityKey:
+			config.MaxVerbosity, err = strconv.Atoi(v)
 			utilruntime.Must(err)
 		}
 	}

--- a/pkg/workqueue/config_test.go
+++ b/pkg/workqueue/config_test.go
@@ -90,6 +90,7 @@ var _ = Describe("ConfigFromConfigMap", func() {
 				workqueue.ToConfigMapDataKey(keyPrefix, workqueue.OverallRateLimiterMaxDelayKey):   "2h",
 				workqueue.ToConfigMapDataKey(keyPrefix, workqueue.BucketRateLimiterItemsPerSecKey): "99",
 				workqueue.ToConfigMapDataKey(keyPrefix, workqueue.BucketRateLimiterMaxBurstKey):    "999",
+				workqueue.ToConfigMapDataKey(keyPrefix, workqueue.MaxVerbosityKey):                 "2",
 				workqueue.ToConfigMapDataKey("other", workqueue.BucketRateLimiterMaxBurstKey):      "888",
 			}
 
@@ -99,6 +100,7 @@ var _ = Describe("ConfigFromConfigMap", func() {
 				OverallRateLimiterMaxDelay:   time.Hour * 2,
 				BucketRateLimiterItemsPerSec: 99,
 				BucketRateLimiterMaxBurst:    999,
+				MaxVerbosity:                 2,
 			}))
 		})
 
@@ -128,6 +130,7 @@ var _ = Describe("ConfigFromConfigMap", func() {
 					OverallRateLimiterMaxDelay:   time.Hour * 2,
 					BucketRateLimiterItemsPerSec: 99,
 					BucketRateLimiterMaxBurst:    workqueue.DefaultConfig().BucketRateLimiterMaxBurst,
+					MaxVerbosity:                 0,
 				}))
 			})
 		})

--- a/pkg/workqueue/priority_queue.go
+++ b/pkg/workqueue/priority_queue.go
@@ -21,6 +21,9 @@ package workqueue
 import (
 	"container/heap"
 	"sync"
+
+	"github.com/submariner-io/admiral/pkg/log"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type itemType struct {
@@ -39,12 +42,16 @@ type PriorityQueue struct {
 	items      []itemType
 	indices    map[any]int
 	priorities sync.Map
+	name       string
+	logger     log.Logger
 }
 
-func NewPriorityQueue() *PriorityQueue {
+func NewPriorityQueue(name string) *PriorityQueue {
 	return &PriorityQueue{
+		name:    name,
 		items:   []itemType{},
 		indices: map[any]int{},
+		logger:  log.Logger{Logger: logf.Log.WithName("PriorityQueue")},
 	}
 }
 
@@ -63,8 +70,13 @@ func (p *PriorityQueue) Swap(i, j int) {
 }
 
 func (p *PriorityQueue) Push(item any) {
-	p.indices[item] = len(p.items)
-	p.items = append(p.items, itemType{value: item, priority: p.getPriority(item)})
+	index := len(p.items)
+	priority := p.getPriority(item)
+
+	p.logger.V(log.DEBUG).Infof("%s: Push \"%v\" at index %d, priority %d", p.name, item, index, priority)
+
+	p.indices[item] = index
+	p.items = append(p.items, itemType{value: item, priority: priority})
 }
 
 func (p *PriorityQueue) Pop() any {
@@ -76,6 +88,8 @@ func (p *PriorityQueue) Pop() any {
 
 	delete(p.indices, item.value)
 	p.priorities.Delete(item.value)
+
+	p.logger.V(log.DEBUG).Infof("%s: Pop \"%v\", size %d", p.name, item.value, len(p.items))
 
 	return item.value
 }

--- a/pkg/workqueue/priority_queue_test.go
+++ b/pkg/workqueue/priority_queue_test.go
@@ -31,7 +31,7 @@ var _ = Describe("PriorityQueue", func() {
 	var pq *workqueue.PriorityQueue
 
 	BeforeEach(func() {
-		pq = workqueue.NewPriorityQueue()
+		pq = workqueue.NewPriorityQueue("test")
 	})
 
 	JustBeforeEach(func() {

--- a/pkg/workqueue/queue.go
+++ b/pkg/workqueue/queue.go
@@ -58,18 +58,18 @@ type queueType struct {
 	workqueue.TypedRateLimitingInterface[string]
 	priorityQueue *PriorityQueue
 	name          string
+	logger        log.Logger
 }
-
-var logger = log.Logger{Logger: logf.Log.WithName("WorkQueue")}
 
 func New(name string) Interface {
 	return NewWithConfig(name, DefaultConfig())
 }
 
 func NewWithConfig(name string, config Config) Interface {
-	priorityQueue := NewPriorityQueue()
+	priorityQueue := NewPriorityQueue(name)
 
-	return &queueType{
+	q := &queueType{
+		logger:        log.Logger{Logger: logf.Log.WithName("WorkQueue")},
 		priorityQueue: priorityQueue,
 		TypedRateLimitingInterface: workqueue.NewTypedRateLimitingQueueWithConfig(
 			// caps the maximum wait
@@ -87,13 +87,20 @@ func NewWithConfig(name string, config Config) Interface {
 				DelayingQueue: workqueue.NewTypedDelayingQueueWithConfig(workqueue.TypedDelayingQueueConfig[string]{
 					Name: name,
 					Queue: workqueue.NewTypedWithConfig(workqueue.TypedQueueConfig[string]{
-						Name:  name,
-						Queue: &priorityWorkQueue[string]{priorityQueue: priorityQueue},
+						Name: name,
+						Queue: &priorityWorkQueue[string]{
+							priorityQueue: priorityQueue,
+						},
 					}),
 				}),
 			}),
 		name: name,
 	}
+
+	q.logger.SetMaxVerbosity(config.MaxVerbosity)
+	q.priorityQueue.logger.SetMaxVerbosity(config.MaxVerbosity)
+
+	return q
 }
 
 func (q *queueType) Enqueue(obj interface{}) {
@@ -104,7 +111,7 @@ func (q *queueType) EnqueueWithOpts(obj interface{}, opts EnqueueOpts) {
 	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 	utilruntime.Must(err)
 
-	logger.V(log.LIBTRACE).Infof("%s: enqueueing key %q for %T object with priority %d",
+	q.logger.V(log.DEBUG).Infof("%s: enqueueing key %q for %T object with priority %d",
 		q.name, key, obj, opts.Priority)
 
 	q.priorityQueue.SetPriority(key, opts.Priority)
@@ -141,7 +148,8 @@ func (q *queueType) processNextWorkItem(process ProcessFunc) bool {
 
 	if requeue {
 		q.AddRateLimited(key)
-		logger.V(log.LIBDEBUG).Infof("%s: enqueued %q for retry - # of times re-queued: %d", q.name, key, q.NumRequeues(key))
+		q.logger.V(log.DEBUG).Infof("%s: enqueued %q for retry - # of times re-queued: %d, queue size: %d",
+			q.name, key, q.NumRequeues(key), q.Len())
 	} else {
 		q.Forget(key)
 	}


### PR DESCRIPTION
...and add more logging.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
