### PR TITLE
Remove references to the networkplugin syncer

### DIFF
--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -20,14 +20,13 @@ package names
 
 /* Component names. */
 const (
-	NetworkPluginSyncerComponent = "submariner-networkplugin-syncer"
-	RouteAgentComponent          = "submariner-routeagent"
-	GatewayComponent             = "submariner-gateway"
-	GlobalnetComponent           = "submariner-globalnet"
-	ServiceDiscoveryComponent    = "submariner-lighthouse-agent"
-	LighthouseCoreDNSComponent   = "submariner-lighthouse-coredns"
-	OperatorComponent            = "submariner-operator"
-	MetricsProxyComponent        = "submariner-metrics-proxy"
-	NettestComponent             = "submariner-nettest"
-	SubctlComponent              = "submariner-subctl"
+	RouteAgentComponent        = "submariner-routeagent"
+	GatewayComponent           = "submariner-gateway"
+	GlobalnetComponent         = "submariner-globalnet"
+	ServiceDiscoveryComponent  = "submariner-lighthouse-agent"
+	LighthouseCoreDNSComponent = "submariner-lighthouse-coredns"
+	OperatorComponent          = "submariner-operator"
+	MetricsProxyComponent      = "submariner-metrics-proxy"
+	NettestComponent           = "submariner-nettest"
+	SubctlComponent            = "submariner-subctl"
 )


### PR DESCRIPTION
The constant is no longer used anywhere.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
