### PR TITLE
Automated backport of #1023: Check that dependencies don't include unmerged commits

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -33,6 +33,15 @@ jobs:
           flags: 'i'
           error: 'Fixup commits should be squashed into the commits under review'
 
+  check-branch-dependencies:
+    name: Check branch dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
+      - name: Check that no dependencies include unmerged commits
+        run: make check-non-release-versions
+
   gitlint:
     name: Commit Message(s)
     runs-on: ubuntu-latest


### PR DESCRIPTION
Backport of #1023 on release-0.18.

#1023: Check that dependencies don't include unmerged commits

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.