### PR TITLE
Add a package for accessing global configuration

### DIFF
--- a/pkg/global/config.go
+++ b/pkg/global/config.go
@@ -1,0 +1,86 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package global
+
+import (
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/submariner-io/admiral/pkg/log"
+	corev1 "k8s.io/api/core/v1"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+type ValueType interface {
+	string | int | bool | time.Duration
+}
+
+var (
+	configMap sync.Map
+	logger    = log.Logger{Logger: logf.Log.WithName("Global")}
+)
+
+func Init(fromConfigMaps ...*corev1.ConfigMap) {
+	configMap.Clear()
+
+	for _, cm := range fromConfigMaps {
+		if cm == nil {
+			continue
+		}
+
+		for k, v := range cm.Data {
+			configMap.Store(k, v)
+		}
+	}
+}
+
+func Get[T ValueType](name string, defaultValue T) T {
+	v, exists := configMap.Load(name)
+	if !exists {
+		return defaultValue
+	}
+
+	var (
+		returnValue any
+		err         error
+	)
+
+	existing := v.(string)
+
+	switch any(defaultValue).(type) {
+	case string:
+		returnValue = v
+	case int:
+		returnValue, err = strconv.Atoi(existing)
+	case bool:
+		returnValue, err = strconv.ParseBool(existing)
+	case time.Duration:
+		returnValue, err = time.ParseDuration(existing)
+	}
+
+	if err != nil {
+		logger.Errorf(err, "Failed to parse config option %q value %q - using default value %v",
+			name, existing, defaultValue)
+
+		return defaultValue
+	}
+
+	return returnValue.(T)
+}

--- a/pkg/global/config_test.go
+++ b/pkg/global/config_test.go
@@ -1,0 +1,135 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package global_test
+
+import (
+	"strconv"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/global"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	stringKey            = "string-key"
+	intKey               = "int-key"
+	boolKey              = "bool-key"
+	durationKey          = "duration-key"
+	nonExistent          = "non-existent"
+	stringValue          = "string-value"
+	defaultStringValue   = "default"
+	intValue             = 10
+	defaultIntValue      = 99
+	durationValue        = time.Hour * 2
+	defaultDurationValue = time.Minute * 30
+)
+
+var _ = Describe("Global", func() {
+	configMap := &corev1.ConfigMap{
+		Data: map[string]string{
+			stringKey:   stringValue,
+			intKey:      strconv.Itoa(intValue),
+			boolKey:     strconv.FormatBool(true),
+			durationKey: durationValue.String(),
+		},
+	}
+
+	DescribeTableSubtree("",
+		func(configMaps ...*corev1.ConfigMap) {
+			BeforeEach(func() {
+				global.Init(configMaps...)
+			})
+
+			Context("Get should return the value for an existing", func() {
+				Specify("string", func() {
+					v := global.Get(stringKey, defaultStringValue)
+					Expect(v).To(Equal(stringValue))
+				})
+
+				Specify("int", func() {
+					v := global.Get(intKey, defaultIntValue)
+					Expect(v).To(Equal(intValue))
+				})
+
+				Specify("bool", func() {
+					v := global.Get(boolKey, false)
+					Expect(v).To(BeTrue())
+				})
+
+				Specify("time.Duration", func() {
+					v := global.Get(durationKey, defaultDurationValue)
+					Expect(v).To(Equal(durationValue))
+				})
+			})
+
+			Context("Get should return the default for a non-existent", func() {
+				Specify("string", func() {
+					v := global.Get(nonExistent, defaultStringValue)
+					Expect(v).To(Equal(defaultStringValue))
+				})
+
+				Specify("int", func() {
+					v := global.Get(nonExistent, defaultIntValue)
+					Expect(v).To(Equal(defaultIntValue))
+				})
+
+				Specify("bool", func() {
+					v := global.Get(nonExistent, true)
+					Expect(v).To(BeTrue())
+				})
+
+				Specify("time.Duration", func() {
+					v := global.Get(nonExistent, defaultDurationValue)
+					Expect(v).To(Equal(defaultDurationValue))
+				})
+			})
+		},
+		Entry("initialized with first ConfigMap nil", nil, configMap),
+		Entry("initialized with last ConfigMap nil", configMap, nil),
+	)
+
+	Context("Get should return the default for an invalid", func() {
+		BeforeEach(func() {
+			global.Init(&corev1.ConfigMap{
+				Data: map[string]string{
+					intKey:      "invalid",
+					boolKey:     "invalid",
+					durationKey: "invalid",
+				},
+			})
+		})
+
+		Specify("int", func() {
+			v := global.Get(intKey, defaultIntValue)
+			Expect(v).To(Equal(defaultIntValue))
+		})
+
+		Specify("bool", func() {
+			v := global.Get(boolKey, true)
+			Expect(v).To(BeTrue())
+		})
+
+		Specify("time.Duration", func() {
+			v := global.Get(durationKey, defaultDurationValue)
+			Expect(v).To(Equal(defaultDurationValue))
+		})
+	})
+})

--- a/pkg/global/global_suite_test.go
+++ b/pkg/global/global_suite_test.go
@@ -1,0 +1,40 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package global_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/log/kzerolog"
+)
+
+func init() {
+	kzerolog.AddFlags(nil)
+}
+
+var _ = Describe("", func() {
+	kzerolog.InitK8sLogging()
+})
+
+func TestGlobal(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Global Suite")
+}

--- a/pkg/log/kzerolog/kzerolog.go
+++ b/pkg/log/kzerolog/kzerolog.go
@@ -25,11 +25,13 @@ import (
 	"runtime"
 	"slices"
 	"strings"
+	"sync"
 	"sync/atomic"
 
 	"github.com/go-logr/logr"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+	"github.com/submariner-io/admiral/pkg/global"
 	loga "github.com/submariner-io/admiral/pkg/log"
 	"k8s.io/klog/v2"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -87,17 +89,18 @@ func formatCaller(i any) string {
 }
 
 type zeroLogContext struct {
-	zLogger      *zerolog.Logger
-	prefix       string
-	maxVerbosity int
-	skipFrames   atomic.Int32
+	zLogger              *zerolog.Logger
+	prefix               string
+	maxVerbosity         int
+	skipFrames           atomic.Int32
+	initMaxVerbosityOnce sync.Once
 }
 
 func (ctx *zeroLogContext) clone() zeroLogContext {
 	return zeroLogContext{
 		zLogger:      ctx.zLogger,
 		prefix:       ctx.prefix,
-		maxVerbosity: ctx.maxVerbosity,
+		maxVerbosity: ctx.getMaxVerbosity(),
 	}
 }
 
@@ -158,7 +161,7 @@ func (ctx *zeroLogContext) Init(logr.RuntimeInfo) {
 }
 
 func (ctx *zeroLogContext) Info(level int, msg string, kvList ...any) {
-	if level > ctx.maxVerbosity {
+	if level > ctx.getMaxVerbosity() {
 		return
 	}
 
@@ -209,7 +212,7 @@ func (ctx *zeroLogContext) Error(err error, msg string, kvList ...any) {
 }
 
 func (ctx *zeroLogContext) Enabled(level int) bool {
-	return level <= ctx.maxVerbosity
+	return level <= ctx.getMaxVerbosity()
 }
 
 func (ctx *zeroLogContext) WithName(name string) logr.LogSink {
@@ -233,4 +236,12 @@ func (ctx *zeroLogContext) WithValues(kvList ...any) logr.LogSink {
 
 func (ctx *zeroLogContext) SetMaxVerbosity(v int) {
 	ctx.maxVerbosity = v
+}
+
+func (ctx *zeroLogContext) getMaxVerbosity() int {
+	ctx.initMaxVerbosityOnce.Do(func() {
+		ctx.maxVerbosity = global.Get(fmt.Sprintf("log.%s.max-verbosity", ctx.prefix), ctx.maxVerbosity)
+	})
+
+	return ctx.maxVerbosity
 }

--- a/pkg/log/kzerolog/kzerolog_test.go
+++ b/pkg/log/kzerolog/kzerolog_test.go
@@ -21,12 +21,15 @@ package kzerolog_test
 import (
 	"errors"
 	"flag"
+	"strconv"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/global"
 	"github.com/submariner-io/admiral/pkg/log"
 	"github.com/submariner-io/admiral/pkg/log/kzerolog"
+	corev1 "k8s.io/api/core/v1"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -46,7 +49,7 @@ func init() {
 
 // We don't explicitly verify anything in this test. The purpose is to invoke the various log levels and visually inspect the output
 // for correctness.
-var _ = When("When zerolog is configured", func() {
+var _ = When("zerolog is configured", func() {
 	It("should output in the desired format", func() {
 		logger := log.Logger{Logger: logf.Log.WithName("test")}
 
@@ -63,5 +66,23 @@ var _ = When("When zerolog is configured", func() {
 		logger.V(log.TRACE).Info("Trace log")
 
 		logger.Logger.Error(nil, "Fatal log", log.FatalKey, "true")
+	})
+
+	Context("and max-verbosity is globally configured for a logger", func() {
+		It("should limit the output to the desired verbosity level", func() {
+			global.Init(&corev1.ConfigMap{
+				Data: map[string]string{
+					"log.TestModule.max-verbosity": strconv.Itoa(log.DEBUG),
+				},
+			})
+
+			logger := log.Logger{Logger: logf.Log.WithName("TestModule")}
+
+			// Should output at DEBUG level.
+			logger.V(log.DEBUG).Info("DEBUG level")
+
+			// Should not output at TRACE level.
+			logger.V(log.TRACE).Info("TRACE level")
+		})
 	})
 })

--- a/pkg/workqueue/config.go
+++ b/pkg/workqueue/config.go
@@ -20,12 +20,9 @@ package workqueue
 
 import (
 	"fmt"
-	"strconv"
-	"strings"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"github.com/submariner-io/admiral/pkg/global"
 )
 
 const (
@@ -64,43 +61,19 @@ func DefaultConfigIfNil(c *Config) Config {
 	return *c
 }
 
-func ConfigFromConfigMap(configMap *corev1.ConfigMap, keyPrefix string, defaultConfig *Config) *Config {
-	if configMap == nil {
-		return defaultConfig
-	}
-
+func ConfigFromGlobal(keyPrefix string, defaultConfig *Config) *Config {
 	config := DefaultConfigIfNil(defaultConfig)
-
-	keyPrefix = ToConfigMapDataKey(keyPrefix, "")
-
-	var err error
-
-	for k, v := range configMap.Data {
-		if !strings.HasPrefix(k, keyPrefix) {
-			continue
-		}
-
-		switch strings.Split(k, keyPrefix)[1] {
-		case ItemRateLimiterBaseDelayKey:
-			config.ItemRateLimiterBaseDelay, err = time.ParseDuration(v)
-			utilruntime.Must(err)
-		case ItemRateLimiterMaxDelayKey:
-			config.ItemRateLimiterMaxDelay, err = time.ParseDuration(v)
-			utilruntime.Must(err)
-		case OverallRateLimiterMaxDelayKey:
-			config.OverallRateLimiterMaxDelay, err = time.ParseDuration(v)
-			utilruntime.Must(err)
-		case BucketRateLimiterItemsPerSecKey:
-			config.BucketRateLimiterItemsPerSec, err = strconv.Atoi(v)
-			utilruntime.Must(err)
-		case BucketRateLimiterMaxBurstKey:
-			config.BucketRateLimiterMaxBurst, err = strconv.Atoi(v)
-			utilruntime.Must(err)
-		case MaxVerbosityKey:
-			config.MaxVerbosity, err = strconv.Atoi(v)
-			utilruntime.Must(err)
-		}
-	}
+	config.ItemRateLimiterBaseDelay = global.Get(ToConfigMapDataKey(keyPrefix, ItemRateLimiterBaseDelayKey),
+		config.ItemRateLimiterBaseDelay)
+	config.ItemRateLimiterMaxDelay = global.Get(ToConfigMapDataKey(keyPrefix, ItemRateLimiterMaxDelayKey),
+		config.ItemRateLimiterMaxDelay)
+	config.OverallRateLimiterMaxDelay = global.Get(ToConfigMapDataKey(keyPrefix, OverallRateLimiterMaxDelayKey),
+		config.OverallRateLimiterMaxDelay)
+	config.BucketRateLimiterItemsPerSec = global.Get(ToConfigMapDataKey(keyPrefix, BucketRateLimiterItemsPerSecKey),
+		config.BucketRateLimiterItemsPerSec)
+	config.BucketRateLimiterMaxBurst = global.Get(ToConfigMapDataKey(keyPrefix, BucketRateLimiterMaxBurstKey),
+		config.BucketRateLimiterMaxBurst)
+	config.MaxVerbosity = global.Get(ToConfigMapDataKey(keyPrefix, MaxVerbosityKey), config.MaxVerbosity)
 
 	return &config
 }

--- a/pkg/workqueue/config_test.go
+++ b/pkg/workqueue/config_test.go
@@ -23,9 +23,9 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/global"
 	"github.com/submariner-io/admiral/pkg/workqueue"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var customConfig = workqueue.Config{
@@ -34,6 +34,7 @@ var customConfig = workqueue.Config{
 	OverallRateLimiterMaxDelay:   time.Hour,
 	BucketRateLimiterItemsPerSec: 99,
 	BucketRateLimiterMaxBurst:    9999,
+	MaxVerbosity:                 2,
 }
 
 var _ = Describe("DefaultConfigIfNil", func() {
@@ -46,55 +47,43 @@ var _ = Describe("DefaultConfigIfNil", func() {
 	})
 })
 
-var _ = Describe("ConfigFromConfigMap", func() {
+var _ = Describe("ConfigFromGlobal", func() {
 	const keyPrefix = "pods"
 
-	var configMap *corev1.ConfigMap
-
-	BeforeEach(func() {
-		configMap = &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "workqueue-cm",
-				Namespace: "my-ns",
-			},
-			Data: map[string]string{},
-		}
-	})
-
-	mustConfigFromConfigMap := func(cm *corev1.ConfigMap, kp string, dc *workqueue.Config) workqueue.Config {
-		c := workqueue.ConfigFromConfigMap(cm, kp, dc)
+	mustConfigFromGlobal := func(kp string, dc *workqueue.Config) workqueue.Config {
+		c := workqueue.ConfigFromGlobal(kp, dc)
 		Expect(c).ToNot(BeNil())
 
 		return *c
 	}
 
-	When("the specified ConfigMap is nil", func() {
-		Context("and the specified default Config is nil", func() {
-			It("should return nil", func() {
-				Expect(workqueue.ConfigFromConfigMap(nil, keyPrefix, nil)).To(BeNil())
+	When("there's no global config settings", func() {
+		Context("and the specified custom default Config is nil", func() {
+			It("should return a Config the custom settings", func() {
+				Expect(mustConfigFromGlobal(keyPrefix, nil)).To(Equal(workqueue.DefaultConfig()))
 			})
 		})
 
-		Context("and the specified default Config is non-nil", func() {
-			It("should return the default Config", func() {
-				Expect(mustConfigFromConfigMap(nil, keyPrefix, &customConfig)).To(Equal(customConfig))
+		Context("and the specified custom default Config is non-nil", func() {
+			It("should return a Config with the custom settings", func() {
+				Expect(mustConfigFromGlobal(keyPrefix, &customConfig)).To(Equal(customConfig))
 			})
 		})
 	})
 
-	When("the specified ConfigMap is non-nil", func() {
-		It("should return a Config derived from the Data map", func() {
-			configMap.Data = map[string]string{
-				workqueue.ToConfigMapDataKey(keyPrefix, workqueue.ItemRateLimiterBaseDelayKey):     "20ms",
-				workqueue.ToConfigMapDataKey(keyPrefix, workqueue.ItemRateLimiterMaxDelayKey):      "40s",
-				workqueue.ToConfigMapDataKey(keyPrefix, workqueue.OverallRateLimiterMaxDelayKey):   "2h",
-				workqueue.ToConfigMapDataKey(keyPrefix, workqueue.BucketRateLimiterItemsPerSecKey): "99",
-				workqueue.ToConfigMapDataKey(keyPrefix, workqueue.BucketRateLimiterMaxBurstKey):    "999",
-				workqueue.ToConfigMapDataKey(keyPrefix, workqueue.MaxVerbosityKey):                 "2",
-				workqueue.ToConfigMapDataKey("other", workqueue.BucketRateLimiterMaxBurstKey):      "888",
-			}
-
-			Expect(mustConfigFromConfigMap(configMap, keyPrefix, nil)).To(Equal(workqueue.Config{
+	When("all settings are specified in the global config", func() {
+		It("should return a Config with the global settings", func() {
+			global.Init(&corev1.ConfigMap{
+				Data: map[string]string{
+					workqueue.ToConfigMapDataKey(keyPrefix, workqueue.ItemRateLimiterBaseDelayKey):     "20ms",
+					workqueue.ToConfigMapDataKey(keyPrefix, workqueue.ItemRateLimiterMaxDelayKey):      "40s",
+					workqueue.ToConfigMapDataKey(keyPrefix, workqueue.OverallRateLimiterMaxDelayKey):   "2h",
+					workqueue.ToConfigMapDataKey(keyPrefix, workqueue.BucketRateLimiterItemsPerSecKey): "99",
+					workqueue.ToConfigMapDataKey(keyPrefix, workqueue.BucketRateLimiterMaxBurstKey):    "999",
+					workqueue.ToConfigMapDataKey(keyPrefix, workqueue.MaxVerbosityKey):                 "2",
+				},
+			})
+			Expect(mustConfigFromGlobal(keyPrefix, nil)).To(Equal(workqueue.Config{
 				ItemRateLimiterBaseDelay:     time.Millisecond * 20,
 				ItemRateLimiterMaxDelay:      time.Second * 40,
 				OverallRateLimiterMaxDelay:   time.Hour * 2,
@@ -103,69 +92,42 @@ var _ = Describe("ConfigFromConfigMap", func() {
 				MaxVerbosity:                 2,
 			}))
 		})
+	})
 
-		Context("and contains only some settings in the Data map", func() {
-			It("should return a Config with ConfigMap settings merged with the defaults", func() {
-				configMap.Data = map[string]string{
-					workqueue.ToConfigMapDataKey(keyPrefix, workqueue.ItemRateLimiterMaxDelayKey):      "40s",
-					workqueue.ToConfigMapDataKey(keyPrefix, workqueue.OverallRateLimiterMaxDelayKey):   "2h",
+	When("some settings are specified in the global config", func() {
+		BeforeEach(func() {
+			global.Init(&corev1.ConfigMap{
+				Data: map[string]string{
+					workqueue.ToConfigMapDataKey(keyPrefix, workqueue.ItemRateLimiterBaseDelayKey):     "20ms",
 					workqueue.ToConfigMapDataKey(keyPrefix, workqueue.BucketRateLimiterItemsPerSecKey): "99",
-				}
+					workqueue.ToConfigMapDataKey(keyPrefix, workqueue.MaxVerbosityKey):                 "2",
+				},
+			})
+		})
 
-				Expect(mustConfigFromConfigMap(configMap, keyPrefix, &workqueue.Config{
-					ItemRateLimiterBaseDelay:  time.Millisecond * 33,
-					ItemRateLimiterMaxDelay:   time.Minute,
-					BucketRateLimiterMaxBurst: 888,
-				})).To(Equal(workqueue.Config{
-					ItemRateLimiterBaseDelay:     time.Millisecond * 33,
-					ItemRateLimiterMaxDelay:      time.Second * 40,
-					OverallRateLimiterMaxDelay:   time.Hour * 2,
-					BucketRateLimiterItemsPerSec: 99,
-					BucketRateLimiterMaxBurst:    888,
-				}))
-
-				Expect(mustConfigFromConfigMap(configMap, keyPrefix, nil)).To(Equal(workqueue.Config{
-					ItemRateLimiterBaseDelay:     workqueue.DefaultConfig().ItemRateLimiterBaseDelay,
-					ItemRateLimiterMaxDelay:      time.Second * 40,
-					OverallRateLimiterMaxDelay:   time.Hour * 2,
+		Context("and the specified custom default Config is nil", func() {
+			It("should return a Config with the default settings merged with the global settings", func() {
+				Expect(mustConfigFromGlobal(keyPrefix, nil)).To(Equal(workqueue.Config{
+					ItemRateLimiterBaseDelay:     time.Millisecond * 20,
+					ItemRateLimiterMaxDelay:      workqueue.DefaultConfig().ItemRateLimiterMaxDelay,
+					OverallRateLimiterMaxDelay:   workqueue.DefaultConfig().OverallRateLimiterMaxDelay,
 					BucketRateLimiterItemsPerSec: 99,
 					BucketRateLimiterMaxBurst:    workqueue.DefaultConfig().BucketRateLimiterMaxBurst,
-					MaxVerbosity:                 0,
+					MaxVerbosity:                 2,
 				}))
 			})
 		})
 
-		Context("and there's no settings in the Data map", func() {
-			It("should return a Config with the defaults", func() {
-				Expect(mustConfigFromConfigMap(configMap, keyPrefix, nil)).To(Equal(workqueue.DefaultConfig()))
-			})
-		})
-
-		Context("and there's invalid values in the Data map", func() {
-			It("should panic", func() {
-				configMap.Data = map[string]string{
-					workqueue.ToConfigMapDataKey(keyPrefix, workqueue.ItemRateLimiterBaseDelayKey): "2oms",
-				}
-
-				Expect(func() {
-					mustConfigFromConfigMap(configMap, keyPrefix, nil)
-				}).To(Panic())
-
-				configMap.Data = map[string]string{
-					workqueue.ToConfigMapDataKey(keyPrefix, workqueue.OverallRateLimiterMaxDelayKey): "2j",
-				}
-
-				Expect(func() {
-					mustConfigFromConfigMap(configMap, keyPrefix, nil)
-				}).To(Panic())
-
-				configMap.Data = map[string]string{
-					workqueue.ToConfigMapDataKey(keyPrefix, workqueue.BucketRateLimiterItemsPerSecKey): "invalid",
-				}
-
-				Expect(func() {
-					mustConfigFromConfigMap(configMap, keyPrefix, nil)
-				}).To(Panic())
+		Context("and the specified custom default Config is non-nil", func() {
+			It("should return a Config with the custom settings merged with the global settings", func() {
+				Expect(mustConfigFromGlobal(keyPrefix, &customConfig)).To(Equal(workqueue.Config{
+					ItemRateLimiterBaseDelay:     time.Millisecond * 20,
+					ItemRateLimiterMaxDelay:      customConfig.ItemRateLimiterMaxDelay,
+					OverallRateLimiterMaxDelay:   customConfig.OverallRateLimiterMaxDelay,
+					BucketRateLimiterItemsPerSec: 99,
+					BucketRateLimiterMaxBurst:    customConfig.BucketRateLimiterMaxBurst,
+					MaxVerbosity:                 2,
+				}))
 			})
 		})
 	})


### PR DESCRIPTION
...initialized from one or more `ConfigMaps`. Consumers call the `Get` function to obtain the configured value for a given key name converted to the desired type or a provided default value if none configured.

The global configuration is utilized by the `zerolog` implementation to determine the `maxVerbosity` for a logger via a name key of the form `log.<prefix>.max-verbosity`.

The global configuration is also utilized by the `workqueue` module for obtaining a `Config`.

