### PR TITLE
Pass expiry params to certificate Signer and Requestor

### DIFF
--- a/pkg/certificate/integration_test.go
+++ b/pkg/certificate/integration_test.go
@@ -41,20 +41,10 @@ var _ = Describe("Integration", func() {
 			return tS.dynClient, nil
 		}
 
-		savedCertCheckInterval := certificate.CertCheckInterval
-		certificate.CertCheckInterval = time.Millisecond * 200
+		tS.config.CertValidity = time.Second * 3
 
-		savedCertValidity := certificate.CertValidity
-		certificate.CertValidity = time.Second * 3
-
-		savedCertRenewBefore := certificate.CertRenewBefore
-		certificate.CertRenewBefore = time.Second
-
-		DeferCleanup(func() {
-			certificate.CertCheckInterval = savedCertCheckInterval
-			certificate.CertValidity = savedCertValidity
-			certificate.CertRenewBefore = savedCertRenewBefore
-		})
+		tSR.certCheckInterval = time.Millisecond * 200
+		tSR.certRenewBefore = time.Second
 	})
 
 	Specify("an issued request should get signed", func() {
@@ -74,7 +64,7 @@ var _ = Describe("Integration", func() {
 			s := awaitSecret(tSR.localSecretClient())
 			g.Expect(s.Data[certificate.TLSDataKey]).NotTo(Equal(localSecret.Data[certificate.TLSDataKey]))
 			localSecret = s
-		}).Within(certificate.CACertValidity + time.Second).To(Succeed())
+		}).Within(tS.config.CertValidity + time.Second).To(Succeed())
 
 		Eventually(tSR.signedDataCh).Should(Receive(Equal(localSecret.Data)))
 	})

--- a/pkg/certificate/signer.go
+++ b/pkg/certificate/signer.go
@@ -51,12 +51,20 @@ const (
 	CAKeyFileName       = "ca.key"
 	CACertFileName      = "ca.crt"
 	CAVersionAnnotation = "submariner.io/ca-version"
+	CACheckInterval     = 24 * time.Hour            // Check CA daily
+	CACertValidity      = 10 * 365 * 24 * time.Hour // 10 years
+	RotateBefore        = 90 * 24 * time.Hour       // 90 days
+	CertValidity        = 365 * 24 * time.Hour      // 1 year
 )
 
 type SignerConfig struct {
-	RestConfig *rest.Config
-	DynClient  dynamic.Interface
-	RestMapper meta.RESTMapper
+	RestConfig      *rest.Config
+	DynClient       dynamic.Interface
+	RestMapper      meta.RESTMapper
+	CACheckInterval time.Duration
+	CACertValidity  time.Duration
+	RotateBefore    time.Duration
+	CertValidity    time.Duration
 }
 
 type Signer interface {
@@ -65,20 +73,30 @@ type Signer interface {
 }
 
 type signerImpl struct {
+	SignerConfig
 	restMapper meta.RESTMapper
 	dynClient  dynamic.Interface
 	syncerMap  sync.Map
 }
 
-var (
-	CACheckInterval = 24 * time.Hour            // Check CA daily
-	CACertValidity  = 10 * 365 * 24 * time.Hour // 10 years
-	RotateBefore    = 90 * 24 * time.Hour       // 90 days
-	CertValidity    = 365 * 24 * time.Hour      // 1 year
-)
-
 func NewSigner(config SignerConfig) (Signer, error) {
-	s := &signerImpl{}
+	s := &signerImpl{SignerConfig: config}
+
+	if s.CACheckInterval == 0 {
+		s.CACheckInterval = CACheckInterval
+	}
+
+	if s.CACertValidity == 0 {
+		s.CACertValidity = CACertValidity
+	}
+
+	if s.RotateBefore == 0 {
+		s.RotateBefore = RotateBefore
+	}
+
+	if s.CertValidity == 0 {
+		s.CertValidity = CertValidity
+	}
 
 	var (
 		err  error
@@ -207,7 +225,7 @@ func (s *signerImpl) signSecret(ctx context.Context, secret *corev1.Secret) erro
 		SerialNumber: serialNumber,
 		Subject:      csr.Subject,
 		NotBefore:    time.Now().Add(-5 * time.Minute),
-		NotAfter:     time.Now().Add(CertValidity),
+		NotAfter:     time.Now().Add(s.CertValidity),
 		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment | x509.KeyUsageDataEncipherment,
 		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
 		IPAddresses:  csr.IPAddresses, // Copy IP SANs from CSR
@@ -284,7 +302,7 @@ func (s *signerImpl) issueCA(ctx context.Context, namespace string) error {
 // signCASecret generates and signs a CA certificate, storing it in the provided secret.
 func (s *signerImpl) signCASecret(secret *corev1.Secret, version string) error {
 	// Generate new CA certificate
-	keyPEM, certPEM, err := CreatePEMEncodedKeyAndCertificate("submariner-ca", CACertValidity)
+	keyPEM, certPEM, err := CreatePEMEncodedKeyAndCertificate("submariner-ca", s.CACertValidity)
 
 	maps.Ensure(&secret.Data)[CAKeyFileName] = keyPEM
 	secret.Data[CACertFileName] = certPEM
@@ -314,7 +332,7 @@ func (s *signerImpl) shouldReissueCA(secret *corev1.Secret, namespace string) (b
 	logger.V(log.TRACE).Info("Existing CA", "namespace", namespace, "expiresIn", timeRemaining.String(),
 		"notAfter", cert.NotAfter.Format(time.RFC3339), "version", currentVersion)
 
-	if timeRemaining < RotateBefore {
+	if timeRemaining < s.RotateBefore {
 		newVersion := s.incrementVersion(currentVersion)
 		logger.Infof("CA is expiring in %s — rotating it for namespace %s from version %s to %s",
 			timeRemaining, namespace, currentVersion, newVersion)
@@ -348,9 +366,9 @@ func (s *signerImpl) startPeriodicCACheck(namespace string, stopCh <-chan struct
 		if err := s.issueCA(wait.ContextForChannel(stopCh), namespace); err != nil {
 			logger.Errorf(err, "Failed periodic CA check for namespace %q", namespace)
 		}
-	}, CACheckInterval, stopCh)
+	}, s.CACheckInterval, stopCh)
 
-	logger.Infof("Started periodic CA check for namespace %s with interval %s", namespace, CACheckInterval)
+	logger.Infof("Started periodic CA check for namespace %s with interval %s", namespace, s.CACheckInterval)
 }
 
 // resignAllCSRs finds all existing CSR secrets and re-signs them with the new CA.

--- a/pkg/certificate/signer_test.go
+++ b/pkg/certificate/signer_test.go
@@ -46,6 +46,7 @@ var _ = Describe("Signer", func() {
 type signerTestDriver struct {
 	dynClient *dynamicfake.FakeDynamicClient
 	signer    certificate.Signer
+	config    certificate.SignerConfig
 }
 
 func (t *signerTestDriver) testStart() {
@@ -165,12 +166,7 @@ func (t *signerTestDriver) testExpiration() {
 	)
 
 	BeforeEach(func() {
-		savedCACheckInterval := certificate.CACheckInterval
-		certificate.CACheckInterval = time.Millisecond * 20
-
-		DeferCleanup(func() {
-			certificate.CACheckInterval = savedCACheckInterval
-		})
+		t.config.CACheckInterval = time.Millisecond * 20
 	})
 
 	JustBeforeEach(func() {
@@ -200,16 +196,8 @@ func (t *signerTestDriver) testExpiration() {
 
 	When("the CA certificate expires", func() {
 		BeforeEach(func() {
-			savedCACertValidity := certificate.CACertValidity
-			certificate.CACertValidity = time.Second * 2
-
-			savedRotateBefore := certificate.RotateBefore
-			certificate.RotateBefore = time.Second
-
-			DeferCleanup(func() {
-				certificate.CACertValidity = savedCACertValidity
-				certificate.RotateBefore = savedRotateBefore
-			})
+			t.config.CACertValidity = time.Second * 2
+			t.config.RotateBefore = time.Second
 		})
 
 		It("should rotate it and re-sign all CSRs", func() {
@@ -220,7 +208,7 @@ func (t *signerTestDriver) testExpiration() {
 				s = resource.MustFromUnstructured(test.AwaitResource(t.secretClient(), certificate.CASecretName), &corev1.Secret{})
 				g.Expect(s.Annotations).NotTo(Equal(caSecret.Annotations))
 				g.Expect(s.Data).NotTo(Equal(caSecret.Data))
-			}).Within(certificate.CACertValidity + time.Second).To(Succeed())
+			}).Within(t.config.CACertValidity + time.Second).To(Succeed())
 		})
 	})
 }
@@ -233,6 +221,12 @@ func newSignerTestDriver() *signerTestDriver {
 	t := &signerTestDriver{}
 
 	BeforeEach(func() {
+		t.config = certificate.SignerConfig{
+			RestConfig: &rest.Config{
+				Host: "https://local",
+			},
+		}
+
 		t.dynClient = dynamicfake.NewSimpleDynamicClient(scheme.Scheme)
 
 		resource.NewDynamicClient = func(_ *rest.Config) (dynamic.Interface, error) {
@@ -243,11 +237,7 @@ func newSignerTestDriver() *signerTestDriver {
 	JustBeforeEach(func() {
 		var err error
 
-		t.signer, err = certificate.NewSigner(certificate.SignerConfig{
-			RestConfig: &rest.Config{
-				Host: "https://local",
-			},
-		})
+		t.signer, err = certificate.NewSigner(t.config)
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(t.signer.Start(ctx, brokerNamespace)).To(Succeed())

--- a/pkg/certificate/signing_requestor.go
+++ b/pkg/certificate/signing_requestor.go
@@ -54,6 +54,9 @@ const (
 	CSRDataKey             = "csr.pem"
 	TLSDataKey             = "tls.crt"
 	CADataKey              = "ca.crt"
+	// Certificate renewal constants.
+	CertRenewBefore   = 30 * 24 * time.Hour // Renew 30 days before expiration
+	CertCheckInterval = 12 * time.Hour      // Check certificate expiration every 12 hours
 )
 
 type OnSignedFn func(secretData map[string][]byte) error
@@ -74,6 +77,8 @@ type signingRequestorImpl struct {
 	localClusterID     string
 	localSecretClient  dynamic.ResourceInterface
 	brokerSecretClient dynamic.ResourceInterface
+	certRenewBefore    time.Duration
+	certCheckInterval  time.Duration
 
 	// Certificate management fields
 	issuedCerts sync.Map // map[secretName]certInfo
@@ -81,17 +86,20 @@ type signingRequestorImpl struct {
 
 var logger = log.Logger{Logger: logf.Log.WithName("Certificate")}
 
-var (
-	// Certificate renewal constants.
-	CertRenewBefore   = 30 * 24 * time.Hour // Renew 30 days before expiration
-	CertCheckInterval = 12 * time.Hour      // Check certificate expiration every 12 hours
-)
-
 //nolint:gocritic // Ignore hugeParam - minimal performance hit, we modify our copy
 func StartSigningRequestor(syncerConfig broker.SyncerConfig, stopCh <-chan struct{}) (SigningRequestor, error) {
+	return StartSigningRequestorWithOpts(syncerConfig, stopCh, CertCheckInterval, CertRenewBefore)
+}
+
+//nolint:gocritic // Ignore hugeParam - minimal performance hit, we modify our copy
+func StartSigningRequestorWithOpts(syncerConfig broker.SyncerConfig, stopCh <-chan struct{}, certCheckInterval time.Duration,
+	certRenewBefore time.Duration,
+) (SigningRequestor, error) {
 	sr := &signingRequestorImpl{
-		localNamespace: syncerConfig.LocalNamespace,
-		localClusterID: syncerConfig.LocalClusterID,
+		localNamespace:    syncerConfig.LocalNamespace,
+		localClusterID:    syncerConfig.LocalClusterID,
+		certRenewBefore:   certRenewBefore,
+		certCheckInterval: certCheckInterval,
 	}
 
 	syncerConfig.Name = "CertSR"
@@ -342,9 +350,9 @@ func deleteIfPresent(ctx context.Context, client dynamic.ResourceInterface, name
 func (s *signingRequestorImpl) startCertificateRenewalMonitoring(stopCh <-chan struct{}) {
 	go wait.Until(func() {
 		s.checkCertificateRenewal(wait.ContextForChannel(stopCh))
-	}, CertCheckInterval, stopCh)
+	}, s.certCheckInterval, stopCh)
 
-	logger.Infof("Started certificate renewal monitoring with interval %s", CertCheckInterval)
+	logger.Infof("Started certificate renewal monitoring with interval %s", s.certCheckInterval)
 }
 
 // updateCertificateExpiration extracts and stores the certificate expiration time.
@@ -380,7 +388,7 @@ func (s *signingRequestorImpl) checkCertificateRenewal(ctx context.Context) {
 
 		// Check if certificate needs renewal
 		timeUntilExpiry := time.Until(info.expiresAt)
-		if timeUntilExpiry <= CertRenewBefore {
+		if timeUntilExpiry <= s.certRenewBefore {
 			logger.Infof("Certificate %q expires in %s, renewing", secretName, timeUntilExpiry.String())
 
 			// Renew the certificate by clearing the signed annotation.

--- a/pkg/certificate/signing_requestor_test.go
+++ b/pkg/certificate/signing_requestor_test.go
@@ -63,11 +63,13 @@ var _ = Describe("SigningRequestor", func() {
 })
 
 type signingRequestorTestDriver struct {
-	signingRequestor certificate.SigningRequestor
-	localDynClient   *dynamicfake.FakeDynamicClient
-	brokerDynClient  *dynamicfake.FakeDynamicClient
-	onSigned         certificate.OnSignedFn
-	signedDataCh     chan map[string][]byte
+	signingRequestor  certificate.SigningRequestor
+	localDynClient    *dynamicfake.FakeDynamicClient
+	brokerDynClient   *dynamicfake.FakeDynamicClient
+	onSigned          certificate.OnSignedFn
+	signedDataCh      chan map[string][]byte
+	certRenewBefore   time.Duration
+	certCheckInterval time.Duration
 }
 
 func (t *signingRequestorTestDriver) testIssue() {
@@ -311,12 +313,8 @@ func (t *signingRequestorTestDriver) testSigned() {
 
 func (t *signingRequestorTestDriver) testExpiration() {
 	BeforeEach(func() {
-		savedCertCheckInterval := certificate.CertCheckInterval
-		certificate.CertCheckInterval = time.Millisecond * 20
-
-		DeferCleanup(func() {
-			certificate.CertCheckInterval = savedCertCheckInterval
-		})
+		t.certCheckInterval = time.Millisecond * 20
+		t.certRenewBefore = certificate.CertRenewBefore
 	})
 
 	JustBeforeEach(func() {
@@ -423,14 +421,21 @@ func newSigningRequestorTestDriver() *signingRequestorTestDriver {
 
 		stopCh := make(chan struct{})
 
-		t.signingRequestor, err = certificate.StartSigningRequestor(broker.SyncerConfig{
+		syncerConfig := broker.SyncerConfig{
 			LocalNamespace:  localNamespace,
 			LocalClusterID:  localClusterID,
 			LocalClient:     t.localDynClient,
 			BrokerNamespace: brokerNamespace,
 			BrokerClient:    t.brokerDynClient,
 			RestMapper:      test.GetRESTMapperFor(&corev1.Secret{}),
-		}, stopCh)
+		}
+
+		if t.certCheckInterval > 0 {
+			t.signingRequestor, err = certificate.StartSigningRequestorWithOpts(syncerConfig, stopCh, t.certCheckInterval, t.certRenewBefore)
+		} else {
+			t.signingRequestor, err = certificate.StartSigningRequestor(syncerConfig, stopCh)
+		}
+
 		Expect(err).NotTo(HaveOccurred())
 
 		DeferCleanup(func() {


### PR DESCRIPTION
...instead of unit tests modifying global vars, which can cause sporadic date race failures since they're accessed on different threads.
