### PR TITLE
Add MaxLogVerbosity to the resource and broker syncers

### DIFF
--- a/pkg/federate/base_federator.go
+++ b/pkg/federate/base_federator.go
@@ -23,6 +23,7 @@ import (
 	"context"
 
 	"github.com/submariner-io/admiral/pkg/log"
+	"github.com/submariner-io/admiral/pkg/resource"
 	"github.com/submariner-io/admiral/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -39,14 +40,15 @@ type baseFederator struct {
 	targetNamespace    string
 	keepMetadataFields map[string]bool
 	eventLogName       string
+	logger             log.Logger
+	maxVerbosity       int
 }
-
-var logger = log.Logger{Logger: logf.Log.WithName("Federator")}
 
 func newBaseFederator(dynClient dynamic.Interface, restMapper meta.RESTMapper, targetNamespace string,
 	keepMetadataField []string,
 ) *baseFederator {
 	b := &baseFederator{
+		logger:          log.Logger{Logger: logf.Log.WithName("Federator")},
 		dynClient:       dynClient,
 		restMapper:      restMapper,
 		targetNamespace: targetNamespace,
@@ -55,6 +57,8 @@ func newBaseFederator(dynClient dynamic.Interface, restMapper meta.RESTMapper, t
 			util.LabelsField: true, util.AnnotationsField: true,
 		},
 	}
+
+	b.logger.SetMaxVerbosity(0)
 
 	for _, field := range keepMetadataField {
 		b.keepMetadataFields[field] = true
@@ -69,12 +73,12 @@ func (f *baseFederator) Delete(ctx context.Context, obj runtime.Object) error {
 		return err
 	}
 
-	logger.V(log.LIBTRACE).Infof("Deleting resource: %#v", toDelete)
+	f.logger.V(log.DEBUG).Infof("Deleting resource: %s", resource.JSONStringer{Obj: toDelete})
 
 	err = resourceClient.Delete(ctx, toDelete.GetName(), metav1.DeleteOptions{})
 
 	if f.eventLogName != "" && err == nil {
-		logger.Infof("%s: Deleted %s \"%s/%s\" ", f.eventLogName, toDelete.GetKind(), toDelete.GetNamespace(), toDelete.GetName())
+		f.logger.Infof("%s: Deleted %s \"%s/%s\" ", f.eventLogName, toDelete.GetKind(), toDelete.GetNamespace(), toDelete.GetName())
 	}
 
 	return err
@@ -82,6 +86,13 @@ func (f *baseFederator) Delete(ctx context.Context, obj runtime.Object) error {
 
 func (f *baseFederator) LogEvents(withName string) {
 	f.eventLogName = withName
+}
+
+func (f *baseFederator) SetMaxVerbosity(v int) {
+	if v > f.maxVerbosity {
+		f.maxVerbosity = v
+		f.logger.SetMaxVerbosity(v)
+	}
 }
 
 func (f *baseFederator) toUnstructured(from runtime.Object) (*unstructured.Unstructured, dynamic.ResourceInterface, error) {

--- a/pkg/federate/create_federator.go
+++ b/pkg/federate/create_federator.go
@@ -22,6 +22,7 @@ import (
 	"context"
 
 	"github.com/submariner-io/admiral/pkg/log"
+	"github.com/submariner-io/admiral/pkg/resource"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -41,7 +42,7 @@ func NewCreateFederator(dynClient dynamic.Interface, restMapper meta.RESTMapper,
 
 //nolint:wrapcheck // This function is effectively a wrapper so no need to wrap errors.
 func (f *createFederator) Distribute(ctx context.Context, obj runtime.Object) error {
-	logger.V(log.LIBTRACE).Infof("In Distribute for %#v", obj)
+	f.logger.V(log.DEBUG).Infof("In Distribute for %s", resource.JSONStringer{Obj: obj})
 
 	toDistribute, resourceClient, err := f.toUnstructured(obj)
 	if err != nil {
@@ -56,7 +57,7 @@ func (f *createFederator) Distribute(ctx context.Context, obj runtime.Object) er
 	}
 
 	if f.eventLogName != "" && err == nil {
-		logger.Infof("%s: Created %s \"%s/%s\" ", f.eventLogName, toDistribute.GetKind(), toDistribute.GetNamespace(),
+		f.logger.Infof("%s: Created %s \"%s/%s\" ", f.eventLogName, toDistribute.GetKind(), toDistribute.GetNamespace(),
 			toDistribute.GetName())
 	}
 

--- a/pkg/federate/create_or_update_federator.go
+++ b/pkg/federate/create_or_update_federator.go
@@ -59,7 +59,7 @@ func NewCreateOrUpdateFederator(options CreateOrUpdateOptions) FederatorExt {
 }
 
 func (f *createOrUpdateFederator) Distribute(ctx context.Context, obj runtime.Object) error {
-	logger.V(log.LIBTRACE).Infof("In Distribute for %#v", obj)
+	f.logger.V(log.DEBUG).Infof("In Distribute for %s", resource.JSONStringer{Obj: obj})
 
 	toDistribute, resourceClient, err := f.toUnstructured(obj)
 	if err != nil {
@@ -84,10 +84,10 @@ func (f *createOrUpdateFederator) Distribute(ctx context.Context, obj runtime.Ob
 
 	if f.eventLogName != "" {
 		if result == util.OperationResultCreated {
-			logger.Infof("%s: Created %s \"%s/%s\" ", f.eventLogName, newObj.GetKind(), newObj.GetNamespace(),
+			f.logger.Infof("%s: Created %s \"%s/%s\" ", f.eventLogName, newObj.GetKind(), newObj.GetNamespace(),
 				newObj.GetName())
 		} else if result == util.OperationResultUpdated {
-			logger.Infof("%s: Updated %s \"%s/%s\" ", f.eventLogName, newObj.GetKind(), newObj.GetNamespace(),
+			f.logger.Infof("%s: Updated %s \"%s/%s\" ", f.eventLogName, newObj.GetKind(), newObj.GetNamespace(),
 				newObj.GetName())
 		}
 	}

--- a/pkg/federate/fake/federator.go
+++ b/pkg/federate/fake/federator.go
@@ -27,9 +27,11 @@ import (
 
 	. "github.com/onsi/gomega"
 	"github.com/submariner-io/admiral/pkg/federate"
+	"github.com/submariner-io/admiral/pkg/log"
 	"github.com/submariner-io/admiral/pkg/resource"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type Federator struct {
@@ -39,6 +41,7 @@ type Federator struct {
 	delegator        federate.Federator
 	failOnDistribute error
 	failOnDelete     error
+	logger           log.Logger
 	ResetOnFailure   atomic.Bool
 }
 
@@ -46,10 +49,18 @@ func New() *Federator {
 	f := &Federator{
 		distribute: make(chan *unstructured.Unstructured, 200),
 		delete:     make(chan *unstructured.Unstructured, 200),
+		logger:     log.Logger{Logger: logf.Log.WithName("FakeFederator")},
 	}
 	f.ResetOnFailure.Store(true)
 
 	return f
+}
+
+func (f *Federator) LogEvents(_ string) {
+}
+
+func (f *Federator) SetMaxVerbosity(v int) {
+	f.logger.SetMaxVerbosity(v)
 }
 
 func (f *Federator) SetDelegator(d federate.Federator) {
@@ -74,6 +85,8 @@ func (f *Federator) FailOnDelete(err error) {
 }
 
 func (f *Federator) Distribute(ctx context.Context, obj runtime.Object) error {
+	f.logger.V(log.DEBUG).Infof("In Distribute for %s", resource.JSONStringer{Obj: obj})
+
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
@@ -98,6 +111,8 @@ func (f *Federator) Distribute(ctx context.Context, obj runtime.Object) error {
 }
 
 func (f *Federator) Delete(ctx context.Context, obj runtime.Object) error {
+	f.logger.V(log.DEBUG).Infof("In Delete for %s", resource.JSONStringer{Obj: obj})
+
 	f.lock.Lock()
 	defer f.lock.Unlock()
 

--- a/pkg/federate/federator.go
+++ b/pkg/federate/federator.go
@@ -48,6 +48,7 @@ type FederatorExt interface {
 	Federator
 
 	LogEvents(withName string)
+	SetMaxVerbosity(v int)
 }
 
 type FederatorFuncs struct {

--- a/pkg/federate/federator_test.go
+++ b/pkg/federate/federator_test.go
@@ -26,6 +26,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/submariner-io/admiral/pkg/fake"
 	"github.com/submariner-io/admiral/pkg/federate"
+	"github.com/submariner-io/admiral/pkg/log"
 	"github.com/submariner-io/admiral/pkg/resource"
 	"github.com/submariner-io/admiral/pkg/syncer/test"
 	assert "github.com/submariner-io/admiral/pkg/test"
@@ -77,6 +78,7 @@ func testCreateOrUpdateFederator() {
 		})
 
 		f.LogEvents("test")
+		f.SetMaxVerbosity(log.TRACE)
 	})
 
 	When("the resource does not already exist in the datastore", func() {

--- a/pkg/federate/update_federator.go
+++ b/pkg/federate/update_federator.go
@@ -53,7 +53,7 @@ func NewUpdateStatusFederator(dynClient dynamic.Interface, restMapper meta.RESTM
 }
 
 func (f *updateFederator) Distribute(ctx context.Context, obj runtime.Object) error {
-	logger.V(log.LIBTRACE).Infof("In Distribute for %#v", obj)
+	f.logger.V(log.DEBUG).Infof("In Distribute for %s", resource.JSONStringer{Obj: obj})
 
 	toUpdate, resourceClient, err := f.toUnstructured(obj)
 	if err != nil {

--- a/pkg/resource/util.go
+++ b/pkg/resource/util.go
@@ -119,6 +119,14 @@ func EnsureValidName(name string) string {
 	return strings.Trim(name, "-")
 }
 
+type JSONStringer struct {
+	Obj any
+}
+
+func (s JSONStringer) String() string {
+	return ToJSON(s.Obj)
+}
+
 func ToJSON(o any) string {
 	out, err := json.MarshalIndent(o, "", "  ")
 	utilruntime.Must(err)

--- a/pkg/syncer/broker/syncer.go
+++ b/pkg/syncer/broker/syncer.go
@@ -156,6 +156,9 @@ type SyncerConfig struct {
 
 	// NamespaceInformer if specified, used to retry local resources that initially failed due to missing namespace.
 	NamespaceInformer cache.SharedInformer
+
+	// MaxLogVerbosity configures the maximum verbosity for debug logging. Default is 0 which disables debug logging.
+	MaxLogVerbosity int
 }
 
 type Syncer struct {
@@ -251,6 +254,7 @@ func NewSyncer(config SyncerConfig) (*Syncer, error) { //nolint:gocritic // Mini
 			Scheme:              config.Scheme,
 			ResyncPeriod:        rc.LocalResyncPeriod,
 			SyncCounter:         syncCounter,
+			MaxLogVerbosity:     config.MaxLogVerbosity,
 		})
 		if err != nil {
 			return nil, errors.Wrap(err, "error creating local resource syncer")
@@ -291,6 +295,7 @@ func NewSyncer(config SyncerConfig) (*Syncer, error) { //nolint:gocritic // Mini
 			ResyncPeriod:        rc.BrokerResyncPeriod,
 			SyncCounter:         syncCounter,
 			NamespaceInformer:   config.NamespaceInformer,
+			MaxLogVerbosity:     config.MaxLogVerbosity,
 		})
 		if err != nil {
 			return nil, errors.Wrap(err, "error creating remote resource syncer")

--- a/pkg/syncer/resource_syncer.go
+++ b/pkg/syncer/resource_syncer.go
@@ -193,7 +193,12 @@ type ResourceSyncerConfig struct {
 	// WorkQueueConfig if specified, configures the underlying work queue
 	WorkQueueConfig *workqueue.Config
 
+	// DrainWorkQueueTimeout configures the maximum amount of time to wait for the work queue to drain on shutdown.
+	// Default is 5 seconds.
 	DrainWorkQueueTimeout time.Duration
+
+	// MaxLogVerbosity configures the maximum verbosity for debug logging. Default is 0 which disables debug logging.
+	MaxLogVerbosity int
 }
 
 type resourceSyncer struct {
@@ -289,6 +294,12 @@ func newResourceSyncer(config *ResourceSyncerConfig) (*resourceSyncer, error) {
 		missingNamespaces: map[string]set.Set[string]{},
 	}
 
+	syncer.log.SetMaxVerbosity(config.MaxLogVerbosity)
+
+	if f, ok := syncer.config.Federator.(federate.FederatorExt); ok {
+		f.SetMaxVerbosity(config.MaxLogVerbosity)
+	}
+
 	if syncer.config.Scheme == nil {
 		syncer.config.Scheme = scheme.Scheme
 	}
@@ -320,7 +331,12 @@ func newResourceSyncer(config *ResourceSyncerConfig) (*resourceSyncer, error) {
 		prometheus.MustRegister(syncer.syncCounter)
 	}
 
-	syncer.workQueue = workqueue.NewWithConfig(config.Name, workqueue.DefaultConfigIfNil(syncer.config.WorkQueueConfig))
+	workqueueConfig := workqueue.DefaultConfigIfNil(syncer.config.WorkQueueConfig)
+	if config.MaxLogVerbosity > workqueueConfig.MaxVerbosity {
+		workqueueConfig.MaxVerbosity = config.MaxLogVerbosity
+	}
+
+	syncer.workQueue = workqueue.NewWithConfig(config.Name, workqueueConfig)
 
 	if config.NamespaceInformer != nil {
 		reg, err := config.NamespaceInformer.AddEventHandler(cache.ResourceEventHandlerDetailedFuncs{
@@ -372,7 +388,7 @@ func NewSharedInformer(config *ResourceSyncerConfig) (cache.SharedInformer, erro
 }
 
 func (r *resourceSyncer) Start(stopCh <-chan struct{}) error {
-	r.log.V(log.LIBDEBUG).Infof("Starting syncer %q", r.config.Name)
+	r.log.V(log.DEBUG).Infof("Starting syncer %q", r.config.Name)
 
 	r.stopCh = stopCh
 
@@ -386,7 +402,7 @@ func (r *resourceSyncer) Start(stopCh <-chan struct{}) error {
 				r.unregHandler()
 			}
 
-			r.log.V(log.LIBDEBUG).Infof("Syncer %q stopped", r.config.Name)
+			r.log.V(log.DEBUG).Infof("Syncer %q stopped", r.config.Name)
 		}()
 		defer r.shutDownWorkQueue()
 
@@ -398,14 +414,14 @@ func (r *resourceSyncer) Start(stopCh <-chan struct{}) error {
 	}()
 
 	if *r.config.WaitForCacheSync {
-		r.log.V(log.LIBDEBUG).Infof("Syncer %q waiting for informer cache to sync", r.config.Name)
+		r.log.V(log.DEBUG).Infof("Syncer %q waiting for informer cache to sync", r.config.Name)
 
 		_ = cache.WaitForCacheSync(stopCh, r.cachesSynced...)
 	}
 
 	r.workQueue.Run(r.processNextWorkItem)
 
-	r.log.V(log.LIBDEBUG).Infof("Syncer %q started", r.config.Name)
+	r.log.V(log.DEBUG).Infof("Syncer %q started", r.config.Name)
 
 	return nil
 }
@@ -635,7 +651,8 @@ func (r *resourceSyncer) handleCreatedOrUpdated(key string, created *unstructure
 		return false, nil
 	}
 
-	r.log.V(log.LIBTRACE).Infof("Syncer %q retrieved %sd resource %q: %#v", r.config.Name, op, resource.GetName(), resource)
+	r.log.V(log.DEBUG).Infof("Syncer %q retrieved %sd resource %q", r.config.Name, op, resource.GetName())
+	r.log.V(log.TRACE).Infof("Syncer %q resource: %s", r.config.Name, resourceUtil.JSONStringer{Obj: resource})
 
 	if !r.shouldSync(resource) {
 		return false, nil
@@ -649,7 +666,7 @@ func (r *resourceSyncer) handleCreatedOrUpdated(key string, created *unstructure
 				util.MetadataField, util.LabelsField, OrigNamespaceLabelKey)
 		}
 
-		r.log.V(log.LIBDEBUG).Infof("Syncer %q syncing resource %q", r.config.Name, resource.GetName())
+		r.log.V(log.DEBUG).Infof("Syncer %q syncing resource %q", r.config.Name, resource.GetName())
 
 		err = r.config.Federator.Distribute(context.Background(), resource)
 		if err != nil || r.onSuccessfulSync(resource, transformed, op) {
@@ -667,7 +684,7 @@ func (r *resourceSyncer) handleCreatedOrUpdated(key string, created *unstructure
 
 		r.incOpCounter(op)
 
-		r.log.V(log.LIBDEBUG).Infof("Syncer %q successfully synced %q", r.config.Name, resource.GetName())
+		r.log.V(log.DEBUG).Infof("Syncer %q successfully synced %q", r.config.Name, resource.GetName())
 	}
 
 	if requeue && op == Create && !exists {
@@ -679,7 +696,7 @@ func (r *resourceSyncer) handleCreatedOrUpdated(key string, created *unstructure
 }
 
 func (r *resourceSyncer) handleDeleted(key string, deletedResource *unstructured.Unstructured) (bool, error) {
-	r.log.V(log.LIBDEBUG).Infof("Syncer %q informed of deleted resource %q", r.config.Name, key)
+	r.log.V(log.DEBUG).Infof("Syncer %q informed of deleted resource %q", r.config.Name, key)
 
 	if !r.shouldSync(deletedResource) {
 		return false, nil
@@ -687,13 +704,13 @@ func (r *resourceSyncer) handleDeleted(key string, deletedResource *unstructured
 
 	resource, transformed, requeue := r.transform(deletedResource, key, Delete)
 	if resource != nil {
-		r.log.V(log.LIBDEBUG).Infof("Syncer %q deleting resource %q: %#v", r.config.Name, resource.GetName(), resource)
+		r.log.V(log.DEBUG).Infof("Syncer %q deleting resource %q", r.config.Name, resource.GetName())
 
 		deleted := true
 
 		err := r.config.Federator.Delete(context.Background(), resource)
 		if apierrors.IsNotFound(err) {
-			r.log.V(log.LIBDEBUG).Infof("Syncer %q: resource %q not found", r.config.Name, resource.GetName())
+			r.log.V(log.DEBUG).Infof("Syncer %q: resource %q not found", r.config.Name, resource.GetName())
 
 			deleted = false
 			err = nil
@@ -706,7 +723,7 @@ func (r *resourceSyncer) handleDeleted(key string, deletedResource *unstructured
 		if deleted {
 			r.incOpCounter(Delete)
 
-			r.log.V(log.LIBDEBUG).Infof("Syncer %q successfully deleted %q", r.config.Name, resource.GetName())
+			r.log.V(log.DEBUG).Infof("Syncer %q successfully deleted %q", r.config.Name, resource.GetName())
 		}
 	}
 
@@ -744,7 +761,7 @@ func (r *resourceSyncer) transform(from *unstructured.Unstructured, key string,
 
 	transformed, requeue := r.config.Transform(converted, r.workQueue.NumRequeues(key), op)
 	if transformed == nil || reflect.ValueOf(transformed).IsNil() {
-		r.log.V(log.LIBDEBUG).Infof("Syncer %q: transform function returned nil - not syncing - requeue: %v", r.config.Name, requeue)
+		r.log.V(log.DEBUG).Infof("Syncer %q: transform function returned nil - not syncing - requeue: %v", r.config.Name, requeue)
 		return nil, nil, requeue
 	}
 
@@ -767,7 +784,7 @@ func (r *resourceSyncer) onSuccessfulSync(resource, converted runtime.Object, op
 		converted = r.mustConvert(resource)
 	}
 
-	r.log.V(log.LIBTRACE).Infof("Syncer %q: invoking OnSuccessfulSync function with: %#v", r.config.Name, converted)
+	r.log.V(log.TRACE).Infof("Syncer %q: invoking OnSuccessfulSync function with: %#v", r.config.Name, converted)
 
 	return r.config.OnSuccessfulSync(converted, op)
 }
@@ -802,7 +819,7 @@ func (r *resourceSyncer) onUpdate(oldObj, newObj any) {
 	newResource := r.assertUnstructured(newObj)
 
 	if r.config.ResourcesEquivalent(oldResource, newResource) {
-		r.log.V(log.LIBTRACE).Infof("Syncer %q: objects equivalent on update - not queueing resource\nOLD: %#v\nNEW: %#v",
+		r.log.V(log.TRACE).Infof("Syncer %q: objects equivalent on update - not queueing resource\nOLD: %#v\nNEW: %#v",
 			r.config.Name, oldResource, newResource)
 		return
 	}
@@ -851,14 +868,14 @@ func (r *resourceSyncer) shouldSync(resource *unstructured.Unstructured) bool {
 		if found {
 			// This is the local -> remote case - only sync local resources w/o the label, assuming any resource with the
 			// label originated from a remote source.
-			r.log.V(log.LIBDEBUG).Infof("Syncer %q: found cluster ID label %q - not syncing resource %q", r.config.Name,
+			r.log.V(log.DEBUG).Infof("Syncer %q: found cluster ID label %q - not syncing resource %q", r.config.Name,
 				clusterID, resource.GetName())
 			return false
 		}
 	case RemoteToLocal:
 		if r.config.LocalClusterID != "" && (!found || clusterID == r.config.LocalClusterID) {
 			// This is the remote -> local case - do not sync local resources
-			r.log.V(log.LIBDEBUG).Infof("Syncer %q: cluster ID label %q not present or matches local cluster ID %q - not syncing resource %q",
+			r.log.V(log.DEBUG).Infof("Syncer %q: cluster ID label %q not present or matches local cluster ID %q - not syncing resource %q",
 				r.config.Name, clusterID, r.config.LocalClusterID, resource.GetName())
 			return false
 		}
@@ -898,7 +915,7 @@ func (r *resourceSyncer) handleMissingNamespace(key, namespace string) {
 func (r *resourceSyncer) handleNamespaceAdded(namespace string) {
 	keys, ok := r.missingNamespaces[namespace]
 	if ok {
-		r.log.V(log.LIBDEBUG).Infof("Syncer %q: namespace %q created - re-queueing %d resources", r.config.Name, namespace, keys.Len())
+		r.log.V(log.DEBUG).Infof("Syncer %q: namespace %q created - re-queueing %d resources", r.config.Name, namespace, keys.Len())
 
 		for _, k := range keys.UnsortedList() {
 			ns, name, _ := cache.SplitMetaNamespaceKey(k)

--- a/pkg/syncer/resource_syncer_test.go
+++ b/pkg/syncer/resource_syncer_test.go
@@ -235,14 +235,26 @@ func testLocalToRemote() {
 	})
 
 	When("a resource without a cluster ID label is created in the local datastore", func() {
+		BeforeEach(func() {
+			d.config.MaxLogVerbosity = 2
+		})
+
 		d.verifyDistributeOnCreateTest("")
 	})
 
 	When("a resource without a cluster ID label is updated in the local datastore", func() {
+		BeforeEach(func() {
+			d.config.MaxLogVerbosity = 2
+		})
+
 		d.verifyDistributeOnUpdateTest("")
 	})
 
 	When("a resource without a cluster ID label is deleted from the local datastore", func() {
+		BeforeEach(func() {
+			d.config.MaxLogVerbosity = 2
+		})
+
 		d.verifyDistributeOnDeleteTest("")
 	})
 

--- a/pkg/workqueue/priority_queue.go
+++ b/pkg/workqueue/priority_queue.go
@@ -73,7 +73,7 @@ func (p *PriorityQueue) Push(item any) {
 	index := len(p.items)
 	priority := p.getPriority(item)
 
-	p.logger.V(log.DEBUG).Infof("%s: Push \"%v\" at index %d, priority %d", p.name, item, index, priority)
+	p.logger.V(log.TRACE).Infof("%s: Push \"%v\" at index %d, priority %d", p.name, item, index, priority)
 
 	p.indices[item] = index
 	p.items = append(p.items, itemType{value: item, priority: priority})
@@ -89,7 +89,7 @@ func (p *PriorityQueue) Pop() any {
 	delete(p.indices, item.value)
 	p.priorities.Delete(item.value)
 
-	p.logger.V(log.DEBUG).Infof("%s: Pop \"%v\", size %d", p.name, item.value, len(p.items))
+	p.logger.V(log.TRACE).Infof("%s: Pop \"%v\", size %d", p.name, item.value, len(p.items))
 
 	return item.value
 }


### PR DESCRIPTION
...and propagate `MaxLogVerbosity` to the `workqueue` and `Federator`.

Also change log levels to DEBUG and TRACE rather than LIBDEBUG and LIBTRACE since max verbosity is now set per syncer.
