### PR TITLE
Automated backport of #1244: Add workflow to trigger CodeRabbit review for Bot PRs

### DIFF
--- a/.github/workflows/coderabbit-review.yml
+++ b/.github/workflows/coderabbit-review.yml
@@ -1,0 +1,16 @@
+---
+name: Trigger CodeRabbit for Bot PRs
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  trigger-review:
+    uses: submariner-io/submariner-bot/.github/workflows/coderabbit-trigger.yml@devel
+    with:
+      pr_number: ${{ github.event.pull_request.number }}
+    secrets: inherit


### PR DESCRIPTION
Backport of #1244 on release-0.18.

#1244: Add workflow to trigger CodeRabbit review for Bot PRs

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline infrastructure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->