### PR TITLE
Fake signing requestor: use real certificates

### DIFF
--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -31,7 +31,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func CreatePEMEncodedKeyAndCertificate(commonName string, validFor time.Duration) ([]byte, []byte, error) {
+func CreateCAKeyAndCertificate(commonName string, validFor time.Duration) (*rsa.PrivateKey, *x509.Certificate, error) {
 	privateKey, err := rsa.GenerateKey(rand.Reader, RSABitSize)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "failed to generate RSA key")
@@ -42,7 +42,7 @@ func CreatePEMEncodedKeyAndCertificate(commonName string, validFor time.Duration
 		return nil, nil, errors.Wrapf(err, "failed to generate serial number")
 	}
 
-	certTemplate := x509.Certificate{
+	cert := &x509.Certificate{
 		SerialNumber: serialNumber,
 		Subject: pkix.Name{
 			CommonName:   commonName,
@@ -55,7 +55,16 @@ func CreatePEMEncodedKeyAndCertificate(commonName string, validFor time.Duration
 		IsCA:                  true,
 	}
 
-	certDER, err := x509.CreateCertificate(rand.Reader, &certTemplate, &certTemplate, &privateKey.PublicKey, privateKey)
+	return privateKey, cert, nil
+}
+
+func CreatePEMEncodedKeyAndCertificate(commonName string, validFor time.Duration) ([]byte, []byte, error) {
+	privateKey, certTemplate, err := CreateCAKeyAndCertificate(commonName, validFor)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, certTemplate, certTemplate, &privateKey.PublicKey, privateKey)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "failed to create CA certificate")
 	}

--- a/pkg/certificate/fake/signing_requestor.go
+++ b/pkg/certificate/fake/signing_requestor.go
@@ -20,12 +20,25 @@ package fake
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	_ "embed"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"time"
 
 	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/certificate"
 )
 
 type SigningRequestor struct {
+	caKey       *rsa.PrivateKey
+	caCert      *x509.Certificate
+	caPEM       []byte
 	issuedCh    chan []string
 	onUninstall chan struct{}
 }
@@ -33,19 +46,66 @@ type SigningRequestor struct {
 var _ certificate.SigningRequestor = &SigningRequestor{}
 
 func NewSigningRequestor() *SigningRequestor {
+	caKey, caCert, err := certificate.CreateCAKeyAndCertificate("CA", 24*365*10*time.Hour)
+	Expect(err).ToNot(HaveOccurred())
+	caDER, err := x509.CreateCertificate(rand.Reader, caCert, caCert, &caKey.PublicKey, caKey)
+	Expect(err).ToNot(HaveOccurred())
+
 	return &SigningRequestor{
+		caKey:       caKey,
+		caCert:      caCert,
+		caPEM:       pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER}),
 		issuedCh:    make(chan []string, 10),
 		onUninstall: make(chan struct{}, 1),
 	}
 }
 
-func (s *SigningRequestor) Issue(_ context.Context, _ string, sanIPs []string, onSigned certificate.OnSignedFn) error {
+func (s *SigningRequestor) Issue(_ context.Context, name string, sanIPs []string, onSigned certificate.OnSignedFn) error {
+	privateKey, err := rsa.GenerateKey(rand.Reader, certificate.RSABitSize)
+	if err != nil {
+		return errors.Wrap(err, "failed to generate RSA key")
+	}
+
+	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return errors.Wrap(err, "failed to generate serial number")
+	}
+
+	ipAddresses := []net.IP{}
+
+	for _, ip := range sanIPs {
+		parsed := net.ParseIP(ip)
+		if parsed == nil {
+			return errors.New("invalid IP address in SAN: " + ip)
+		}
+
+		ipAddresses = append(ipAddresses, parsed)
+	}
+
+	cert := &x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			CommonName:   name,
+			Organization: []string{"submariner.io"},
+		},
+		IPAddresses: ipAddresses,
+		NotBefore:   time.Now(),
+		NotAfter:    time.Now().AddDate(10, 0, 0),
+		KeyUsage:    x509.KeyUsageDigitalSignature,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, cert, s.caCert, &privateKey.PublicKey, s.caKey)
+	if err != nil {
+		return err
+	}
+
 	s.issuedCh <- sanIPs
 
 	certData := map[string][]byte{
-		certificate.TLSDataKey:        []byte("mock-tls-cert"),
-		certificate.PrivateKeyDataKey: []byte("mock-tls-key"),
-		certificate.CADataKey:         []byte("mock-ca-cert"),
+		certificate.TLSDataKey:        pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER}),
+		certificate.PrivateKeyDataKey: pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(privateKey)}),
+		certificate.CADataKey:         s.caPEM,
 	}
 
 	return onSigned(certData)


### PR DESCRIPTION
This allows tests to parse the certificates and act on them as they would with real certificates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved certificate generation architecture with better separation of concerns between key creation, certificate generation, and encoding processes.

* **Tests**
  * Enhanced certificate signing infrastructure to generate cryptographically authentic material for more accurate and reliable testing scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->