### PR TITLE
Use Ginkgo context instead of global variables

### DIFF
--- a/pkg/certificate/integration_test.go
+++ b/pkg/certificate/integration_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Integration", func() {
 		tSR.certRenewBefore = time.Second
 	})
 
-	Specify("an issued request should get signed", func() {
+	Specify("an issued request should get signed", func(ctx SpecContext) {
 		Expect(tSR.signingRequestor.Issue(ctx, secretName, ips, tSR.onSigned)).To(Succeed())
 
 		var localSecret *corev1.Secret

--- a/pkg/certificate/signer_test.go
+++ b/pkg/certificate/signer_test.go
@@ -51,7 +51,7 @@ type signerTestDriver struct {
 
 func (t *signerTestDriver) testStart() {
 	When("a CSR Secret is created and updated", func() {
-		It("should sign it", func() {
+		It("should sign it", func(ctx SpecContext) {
 			secret := newCSR()
 			test.CreateResource(t.secretClient(), secret)
 
@@ -94,7 +94,7 @@ func (t *signerTestDriver) testStart() {
 	Context("with multiple namespaces", func() {
 		const namespace2 = "broker2"
 
-		It("should not interfere with each other", func() {
+		It("should not interfere with each other", func(ctx SpecContext) {
 			client1 := secretClient(t.dynClient, brokerNamespace)
 			client2 := secretClient(t.dynClient, namespace2)
 
@@ -234,7 +234,7 @@ func newSignerTestDriver() *signerTestDriver {
 		}
 	})
 
-	JustBeforeEach(func() {
+	JustBeforeEach(func(ctx SpecContext) {
 		var err error
 
 		t.signer, err = certificate.NewSigner(t.config)

--- a/pkg/certificate/signing_requestor_test.go
+++ b/pkg/certificate/signing_requestor_test.go
@@ -47,10 +47,7 @@ const (
 	secretName      = "ipsec"
 )
 
-var (
-	ips = []string{"10.253.4.6", "172.19.22.8"}
-	ctx = context.TODO()
-)
+var ips = []string{"10.253.4.6", "172.19.22.8"}
 
 var _ = Describe("SigningRequestor", func() {
 	t := newSigningRequestorTestDriver()
@@ -73,7 +70,7 @@ type signingRequestorTestDriver struct {
 }
 
 func (t *signingRequestorTestDriver) testIssue() {
-	It("should create a CSR Secret and sync to the broker", func() {
+	It("should create a CSR Secret and sync to the broker", func(ctx SpecContext) {
 		Expect(t.signingRequestor.Issue(ctx, secretName, ips, t.onSigned)).To(Succeed())
 
 		localSecret := awaitSecret(t.localSecretClient())
@@ -105,13 +102,13 @@ func (t *signingRequestorTestDriver) testIssue() {
 	})
 
 	When("a nil OnSigned function passed", func() {
-		It("should return an error", func() {
+		It("should return an error", func(ctx SpecContext) {
 			Expect(t.signingRequestor.Issue(ctx, secretName, ips, nil)).NotTo(Succeed())
 		})
 	})
 
 	When("empty IPs are passed", func() {
-		It("should return an error", func() {
+		It("should return an error", func(ctx SpecContext) {
 			Expect(t.signingRequestor.Issue(ctx, secretName, nil, t.onSigned)).NotTo(Succeed())
 		})
 	})
@@ -119,11 +116,11 @@ func (t *signingRequestorTestDriver) testIssue() {
 
 func (t *signingRequestorTestDriver) testSigned() {
 	When("a local Secret is signed on the broker", func() {
-		JustBeforeEach(func() {
+		JustBeforeEach(func(ctx SpecContext) {
 			Expect(t.signingRequestor.Issue(ctx, secretName, ips, t.onSigned)).To(Succeed())
 		})
 
-		It("should be synced locally", func() {
+		It("should be synced locally", func(ctx SpecContext) {
 			brokerSecret := t.awaitAndSignBrokerSecret()
 
 			var localSecret *corev1.Secret
@@ -204,7 +201,7 @@ func (t *signingRequestorTestDriver) testSigned() {
 	})
 
 	When("the OnSigned callback fails", func() {
-		It("should retry", func() {
+		It("should retry", func(ctx SpecContext) {
 			var onSignedErr atomic.Value
 
 			onSignedErr.Store("mock OnSigned error")
@@ -225,7 +222,7 @@ func (t *signingRequestorTestDriver) testSigned() {
 	})
 
 	When("a existing request is signed just prior to re-issuing the request", func() {
-		It("should notify the OnSigned function", func() {
+		It("should notify the OnSigned function", func(ctx SpecContext) {
 			test.CreateResource(t.localSecretClient(), &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: fmt.Sprintf("%s-%s", secretName, localClusterID),
@@ -276,7 +273,7 @@ func (t *signingRequestorTestDriver) testSigned() {
 			}))
 		})
 
-		It("should notify the OnSigned function", func() {
+		It("should notify the OnSigned function", func(ctx SpecContext) {
 			time.Sleep(500 * time.Millisecond)
 			Expect(t.signingRequestor.Issue(ctx, secretName, ips, t.onSigned)).To(Succeed())
 			Eventually(t.signedDataCh).Within(5 * time.Second).Should(Receive())
@@ -317,7 +314,7 @@ func (t *signingRequestorTestDriver) testExpiration() {
 		t.certRenewBefore = certificate.CertRenewBefore
 	})
 
-	JustBeforeEach(func() {
+	JustBeforeEach(func(ctx SpecContext) {
 		Expect(t.signingRequestor.Issue(ctx, secretName, ips, t.onSigned)).To(Succeed())
 	})
 
@@ -345,7 +342,7 @@ func (t *signingRequestorTestDriver) testExpiration() {
 }
 
 func (t *signingRequestorTestDriver) testRemove() {
-	It("should remove a previously issued request", func() {
+	It("should remove a previously issued request", func(ctx SpecContext) {
 		Expect(t.signingRequestor.Issue(ctx, secretName, ips, t.onSigned)).To(Succeed())
 
 		secret := awaitSecret(t.localSecretClient())
@@ -357,18 +354,18 @@ func (t *signingRequestorTestDriver) testRemove() {
 		test.AwaitNoResource(t.brokerSecretClient(), secret.Name)
 	})
 
-	It("should not return an error if not previously issued", func() {
+	It("should not return an error if not previously issued", func(ctx SpecContext) {
 		Expect(t.signingRequestor.Remove(ctx, secretName)).To(Succeed())
 	})
 }
 
 func (t *signingRequestorTestDriver) testUninstall() {
-	It("should remove all local Secret requests", func() {
+	It("should remove all local Secret requests", func(ctx SpecContext) {
 		Expect(t.signingRequestor.Issue(ctx, "secret1", ips, t.onSigned)).To(Succeed())
 		Expect(t.signingRequestor.Issue(ctx, "secret2", ips, t.onSigned)).To(Succeed())
 
-		Eventually(func(g Gomega) {
-			list, err := t.brokerSecretClient().List(context.TODO(), metav1.ListOptions{})
+		Eventually(ctx, func(g Gomega, ctx context.Context) {
+			list, err := t.brokerSecretClient().List(ctx, metav1.ListOptions{})
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(list.Items).To(HaveLen(2))
 		}).To(Succeed())
@@ -382,16 +379,16 @@ func (t *signingRequestorTestDriver) testUninstall() {
 			},
 		})
 
-		Expect(t.signingRequestor.Uninstall(context.TODO())).To(Succeed())
+		Expect(t.signingRequestor.Uninstall(ctx)).To(Succeed())
 
-		Eventually(func(g Gomega) {
-			list, err := t.localSecretClient().List(context.TODO(), metav1.ListOptions{})
+		Eventually(ctx, func(g Gomega, ctx context.Context) {
+			list, err := t.localSecretClient().List(ctx, metav1.ListOptions{})
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(list.Items).To(BeEmpty())
 		}).To(Succeed())
 
-		Eventually(func(g Gomega) {
-			list, err := t.brokerSecretClient().List(context.TODO(), metav1.ListOptions{})
+		Eventually(ctx, func(g Gomega, ctx context.Context) {
+			list, err := t.brokerSecretClient().List(ctx, metav1.ListOptions{})
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(list.Items).To(HaveLen(1))
 			g.Expect(list.Items[0].GetName()).To(Equal(otherSecret.Name))

--- a/pkg/configmap/config_map_test.go
+++ b/pkg/configmap/config_map_test.go
@@ -54,8 +54,8 @@ func testGet() {
 	})
 
 	When("the ConfigMap exists", func() {
-		It("should return it", func() {
-			expected, err := client.Create(context.TODO(), &corev1.ConfigMap{
+		It("should return it", func(ctx SpecContext) {
+			expected, err := client.Create(ctx, &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cm",
 				},
@@ -63,15 +63,15 @@ func testGet() {
 			}, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			actual, err := configmap.Get(context.TODO(), client, expected.Name)
+			actual, err := configmap.Get(ctx, client, expected.Name)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(actual).To(Equal(expected))
 		})
 	})
 
 	When("the ConfigMap does not exist", func() {
-		It("should return an empty ConfigMap", func() {
-			cm, err := configmap.Get(context.TODO(), client, "test-cm")
+		It("should return an empty ConfigMap", func(ctx SpecContext) {
+			cm, err := configmap.Get(ctx, client, "test-cm")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(cm.Name).To(Equal("test-cm"))
 			Expect(cm.Data).To(BeEmpty())
@@ -79,10 +79,10 @@ func testGet() {
 	})
 
 	When("ConfigMap retrieval fails", func() {
-		It("should return an error", func() {
+		It("should return an error", func(ctx SpecContext) {
 			fake.FailOnAction(&k8sClient.Fake, "configmaps", "get", nil, false)
 
-			_, err := configmap.Get(context.TODO(), client, "test-cm")
+			_, err := configmap.Get(ctx, client, "test-cm")
 			Expect(err).To(HaveOccurred())
 		})
 	})

--- a/pkg/fake/basic_reactors_test.go
+++ b/pkg/fake/basic_reactors_test.go
@@ -42,47 +42,47 @@ var _ = Describe("Create", func() {
 	t := newBasicReactorsTestDriver()
 
 	When("the GenerateName field is set", func() {
-		It("should set Name field", func() {
-			actual := t.assertCreateSuccess(t.pod)
+		It("should set Name field", func(ctx SpecContext) {
+			actual := t.assertCreateSuccess(ctx, t.pod)
 			Expect(actual.Name).To(HavePrefix(t.pod.GenerateName))
 		})
 	})
 
-	It("should set the ResourceVersion field", func() {
-		actual := t.assertCreateSuccess(t.pod)
+	It("should set the ResourceVersion field", func(ctx SpecContext) {
+		actual := t.assertCreateSuccess(ctx, t.pod)
 		Expect(actual.ResourceVersion).To(Equal("1"))
 	})
 
-	It("should set the UID field", func() {
-		actual := t.assertCreateSuccess(t.pod)
+	It("should set the UID field", func(ctx SpecContext) {
+		actual := t.assertCreateSuccess(ctx, t.pod)
 		Expect(actual.UID).ToNot(BeEmpty())
 	})
 
-	Specify("should set the CreationTimestamp field if not specified", func() {
+	Specify("should set the CreationTimestamp field if not specified", func(ctx SpecContext) {
 		now := metav1.Now()
-		actual := t.assertCreateSuccess(t.pod)
+		actual := t.assertCreateSuccess(ctx, t.pod)
 		Expect(actual.CreationTimestamp.After(now.Add(-time.Second * 5))).To(BeTrue())
 	})
 
-	Specify("should not set the CreationTimestamp field if specified", func() {
+	Specify("should not set the CreationTimestamp field if specified", func(ctx SpecContext) {
 		cst := metav1.Time{Time: metav1.Now().Add(time.Hour)}
 		t.pod.CreationTimestamp = cst
-		actual := t.assertCreateSuccess(t.pod)
+		actual := t.assertCreateSuccess(ctx, t.pod)
 		Expect(actual.CreationTimestamp).To(Equal(cst))
 	})
 
 	When("the Name and GenerateName fields are empty", func() {
-		It("should return an error", func() {
+		It("should return an error", func(ctx SpecContext) {
 			t.pod.GenerateName = ""
-			_, err := t.doCreate(t.pod)
+			_, err := t.doCreate(ctx, t.pod)
 			Expect(err).To(HaveOccurred())
 		})
 	})
 
 	When("the ResourceVersion field is set", func() {
-		It("should return an error", func() {
+		It("should return an error", func(ctx SpecContext) {
 			t.pod.ResourceVersion = "2"
-			_, err := t.doCreate(t.pod)
+			_, err := t.doCreate(ctx, t.pod)
 			Expect(err).To(HaveOccurred())
 		})
 	})
@@ -91,8 +91,8 @@ var _ = Describe("Create", func() {
 var _ = Describe("Update", func() {
 	t := newBasicReactorsTestDriver()
 
-	JustBeforeEach(func() {
-		t.pod = t.assertCreateSuccess(t.pod)
+	JustBeforeEach(func(ctx SpecContext) {
+		t.pod = t.assertCreateSuccess(ctx, t.pod)
 		t.pod.Namespace = ""
 		t.pod.Spec = corev1.PodSpec{
 			Containers: []corev1.Container{
@@ -104,24 +104,24 @@ var _ = Describe("Update", func() {
 		}
 	})
 
-	It("should update the resource", func() {
-		actual := t.doUpdateSuccess()
+	It("should update the resource", func(ctx SpecContext) {
+		actual := t.doUpdateSuccess(ctx)
 		Expect(actual.Spec).To(Equal(t.pod.Spec))
 		Expect(actual.ResourceVersion > t.pod.ResourceVersion).To(BeTrue())
 	})
 
 	When("the Name field is empty", func() {
-		It("should return an Invalid error", func() {
+		It("should return an Invalid error", func(ctx SpecContext) {
 			t.pod.Name = ""
-			_, err := t.doUpdate()
+			_, err := t.doUpdate(ctx)
 			Expect(apierrors.IsInvalid(err)).To(BeTrue())
 		})
 	})
 
 	When("the ResourceVersion field doesn't match", func() {
-		It("should return a Conflict error", func() {
+		It("should return a Conflict error", func(ctx SpecContext) {
 			t.pod.ResourceVersion = "111"
-			_, err := t.doUpdate()
+			_, err := t.doUpdate(ctx)
 			Expect(apierrors.IsConflict(err)).To(BeTrue())
 		})
 	})
@@ -131,15 +131,15 @@ var _ = Describe("Update", func() {
 			t.pod.Finalizers = []string{"some-finalizer"}
 		})
 
-		It("should delete the resource", func() {
+		It("should delete the resource", func(ctx SpecContext) {
 			t.pod.SetDeletionTimestamp(ptr.To(metav1.Now()))
-			t.pod = t.doUpdateSuccess()
+			t.pod = t.doUpdateSuccess(ctx)
 
 			t.pod.Finalizers = nil
-			_, err := t.doUpdate()
+			_, err := t.doUpdate(ctx)
 			Expect(err).To(Succeed())
 
-			_, err = t.doGet(t.pod.Name)
+			_, err = t.doGet(ctx, t.pod.Name)
 			Expect(apierrors.IsNotFound(err)).To(BeTrue())
 		})
 	})
@@ -148,32 +148,32 @@ var _ = Describe("Update", func() {
 var _ = Describe("Delete", func() {
 	t := newBasicReactorsTestDriver()
 
-	JustBeforeEach(func() {
-		t.pod = t.assertCreateSuccess(t.pod)
+	JustBeforeEach(func(ctx SpecContext) {
+		t.pod = t.assertCreateSuccess(ctx, t.pod)
 	})
 
-	It("should delete the resource", func() {
-		Expect(t.doDelete(metav1.DeleteOptions{})).To(Succeed())
-		_, err := t.doGet(t.pod.Name)
+	It("should delete the resource", func(ctx SpecContext) {
+		Expect(t.doDelete(ctx, metav1.DeleteOptions{})).To(Succeed())
+		_, err := t.doGet(ctx, t.pod.Name)
 		Expect(apierrors.IsNotFound(err)).To(BeTrue())
 	})
 
 	When("a specific ResourceVersion is requested", func() {
 		Context("and it matches", func() {
-			It("should delete the resource", func() {
-				Expect(t.doDelete(metav1.DeleteOptions{
+			It("should delete the resource", func(ctx SpecContext) {
+				Expect(t.doDelete(ctx, metav1.DeleteOptions{
 					Preconditions: &metav1.Preconditions{
 						ResourceVersion: &t.pod.ResourceVersion,
 					},
 				})).To(Succeed())
-				_, err := t.doGet(t.pod.Name)
+				_, err := t.doGet(ctx, t.pod.Name)
 				Expect(apierrors.IsNotFound(err)).To(BeTrue())
 			})
 		})
 
 		Context("and it doesn't match", func() {
-			It("should return a Conflict error", func() {
-				err := t.doDelete(metav1.DeleteOptions{
+			It("should return a Conflict error", func(ctx SpecContext) {
+				err := t.doDelete(ctx, metav1.DeleteOptions{
 					Preconditions: &metav1.Preconditions{
 						ResourceVersion: ptr.To("111"),
 					},
@@ -188,14 +188,14 @@ var _ = Describe("Delete", func() {
 			t.pod.Finalizers = []string{"some-finalizer"}
 		})
 
-		It("should set the DeletionTimestamp field", func() {
-			Expect(t.doDelete(metav1.DeleteOptions{})).To(Succeed())
-			actual, err := t.doGet(t.pod.Name)
+		It("should set the DeletionTimestamp field", func(ctx SpecContext) {
+			Expect(t.doDelete(ctx, metav1.DeleteOptions{})).To(Succeed())
+			actual, err := t.doGet(ctx, t.pod.Name)
 			Expect(err).To(Succeed())
 			Expect(actual.GetDeletionTimestamp()).ToNot(BeNil())
 
-			Expect(t.doDelete(metav1.DeleteOptions{})).To(Succeed())
-			unchanged, err := t.doGet(t.pod.Name)
+			Expect(t.doDelete(ctx, metav1.DeleteOptions{})).To(Succeed())
+			unchanged, err := t.doGet(ctx, t.pod.Name)
 			Expect(err).To(Succeed())
 			Expect(unchanged.GetResourceVersion()).To(Equal(actual.GetResourceVersion()))
 		})
@@ -205,9 +205,9 @@ var _ = Describe("Delete", func() {
 var _ = Describe("List", func() {
 	t := newBasicReactorsTestDriver()
 
-	JustBeforeEach(func() {
-		t.pod = t.assertCreateSuccess(t.pod)
-		t.assertCreateSuccess(&corev1.Pod{
+	JustBeforeEach(func(ctx SpecContext) {
+		t.pod = t.assertCreateSuccess(ctx, t.pod)
+		t.assertCreateSuccess(ctx, &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "other-pod",
 			},
@@ -215,8 +215,8 @@ var _ = Describe("List", func() {
 	})
 
 	When("a field selector is specified", func() {
-		It("should return the correct resources", func() {
-			list, err := t.client.CoreV1().Pods(testNamespace).List(context.Background(), metav1.ListOptions{
+		It("should return the correct resources", func(ctx SpecContext) {
+			list, err := t.client.CoreV1().Pods(testNamespace).List(ctx, metav1.ListOptions{
 				FieldSelector: fields.OneTermEqualSelector("metadata.name", t.pod.Name).String(),
 			})
 
@@ -232,10 +232,10 @@ var _ = Describe("Watch", func() {
 
 	var watcher watch.Interface
 
-	JustBeforeEach(func() {
+	JustBeforeEach(func(ctx SpecContext) {
 		var err error
 
-		watcher, err = t.client.CoreV1().Pods(testNamespace).Watch(context.Background(), metav1.ListOptions{
+		watcher, err = t.client.CoreV1().Pods(testNamespace).Watch(ctx, metav1.ListOptions{
 			LabelSelector: k8slabels.SelectorFromSet(t.pod.Labels).String(),
 		})
 		Expect(err).To(Succeed())
@@ -246,8 +246,8 @@ var _ = Describe("Watch", func() {
 	})
 
 	When("a label selector is specified", func() {
-		It("should correctly filter the resources", func() {
-			t.pod = t.assertCreateSuccess(t.pod)
+		It("should correctly filter the resources", func(ctx SpecContext) {
+			t.pod = t.assertCreateSuccess(ctx, t.pod)
 
 			select {
 			case event, ok := <-watcher.ResultChan():
@@ -264,7 +264,7 @@ var _ = Describe("Watch", func() {
 				Fail("Did not receive expected watch event")
 			}
 
-			t.assertCreateSuccess(&corev1.Pod{
+			t.assertCreateSuccess(ctx, &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "other-pod",
 				},
@@ -282,28 +282,28 @@ var _ = Describe("Watch", func() {
 var _ = Describe("DeleteCollection", func() {
 	t := newBasicReactorsTestDriver()
 
-	JustBeforeEach(func() {
-		t.pod = t.assertCreateSuccess(t.pod)
+	JustBeforeEach(func(ctx SpecContext) {
+		t.pod = t.assertCreateSuccess(ctx, t.pod)
 	})
 
-	It("should delete the correct resources", func() {
-		otherPod := t.assertCreateSuccess(&corev1.Pod{
+	It("should delete the correct resources", func(ctx SpecContext) {
+		otherPod := t.assertCreateSuccess(ctx, &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "other-pod",
 			},
 		})
 
-		err := t.client.CoreV1().Pods(testNamespace).DeleteCollection(context.Background(), metav1.DeleteOptions{},
+		err := t.client.CoreV1().Pods(testNamespace).DeleteCollection(ctx, metav1.DeleteOptions{},
 			metav1.ListOptions{
 				LabelSelector: k8slabels.SelectorFromSet(t.pod.Labels).String(),
 			})
 
 		Expect(err).To(Succeed())
 
-		_, err = t.doGet(t.pod.Name)
+		_, err = t.doGet(ctx, t.pod.Name)
 		Expect(apierrors.IsNotFound(err)).To(BeTrue())
 
-		t.assertGetSuccess(otherPod)
+		t.assertGetSuccess(ctx, otherPod)
 	})
 })
 
@@ -319,70 +319,70 @@ var _ = Describe("Namespace verification", func() {
 		Expect(resource.ExtractMissingNamespaceFromErr(err)).To(Equal(testNamespace))
 	}
 
-	createNamespace := func(name string) {
-		_, err := t.client.CoreV1().Namespaces().Create(context.TODO(), &corev1.Namespace{
+	createNamespace := func(ctx context.Context, name string) {
+		_, err := t.client.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{Name: name},
 		}, metav1.CreateOptions{})
 		Expect(err).To(Succeed())
 	}
 
 	When("a namespace does not exist", func() {
-		Specify("requests should return the appropriate error", func() {
-			_, err := t.doCreate(t.pod)
+		Specify("requests should return the appropriate error", func(ctx SpecContext) {
+			_, err := t.doCreate(ctx, t.pod)
 			assertMissingNamespaceErr(err)
 
-			_, err = t.doGet(t.pod.Name)
+			_, err = t.doGet(ctx, t.pod.Name)
 			assertMissingNamespaceErr(err)
 
-			_, err = t.doUpdate()
+			_, err = t.doUpdate(ctx)
 			assertMissingNamespaceErr(err)
 
-			assertMissingNamespaceErr(t.doDelete(metav1.DeleteOptions{}))
+			assertMissingNamespaceErr(t.doDelete(ctx, metav1.DeleteOptions{}))
 
-			_, err = t.client.CoreV1().Pods(testNamespace).List(context.Background(), metav1.ListOptions{})
+			_, err = t.client.CoreV1().Pods(testNamespace).List(ctx, metav1.ListOptions{})
 			assertMissingNamespaceErr(err)
 		})
 	})
 
 	When("a request has no namespace", func() {
-		It("should succeed", func() {
-			_, err := t.client.CoreV1().Pods("").Create(context.Background(), t.pod, metav1.CreateOptions{})
+		It("should succeed", func(ctx SpecContext) {
+			_, err := t.client.CoreV1().Pods("").Create(ctx, t.pod, metav1.CreateOptions{})
 			Expect(err).To(Succeed())
 		})
 	})
 
 	When("a namespace does exist", func() {
-		Specify("requests should succeed", func() {
-			createNamespace(testNamespace)
+		Specify("requests should succeed", func(ctx SpecContext) {
+			createNamespace(ctx, testNamespace)
 
 			t.pod.Name = "test-pod"
-			t.assertCreateSuccess(t.pod)
+			t.assertCreateSuccess(ctx, t.pod)
 
-			_, err := t.client.CoreV1().Pods(testNamespace).List(context.Background(), metav1.ListOptions{})
+			_, err := t.client.CoreV1().Pods(testNamespace).List(ctx, metav1.ListOptions{})
 			Expect(err).To(Succeed())
 
-			Expect(t.doDelete(metav1.DeleteOptions{})).To(Succeed())
+			Expect(t.doDelete(ctx, metav1.DeleteOptions{})).To(Succeed())
 		})
 	})
 
 	When("a namespace is deleted", func() {
 		const noDeleteNS = "no-delete"
 
-		It("should delete all contained resources", func() {
-			createNamespace(testNamespace)
-			createNamespace(noDeleteNS)
+		It("should delete all contained resources", func(ctx SpecContext) {
+			createNamespace(ctx, testNamespace)
+			createNamespace(ctx, noDeleteNS)
 
 			t.pod.Name = "test-pod"
-			t.assertCreateSuccess(t.pod)
+			t.assertCreateSuccess(ctx, t.pod)
 
-			_, err := t.client.CoreV1().Services(testNamespace).Create(context.TODO(), &corev1.Service{
+			_, err := t.client.CoreV1().Services(testNamespace).Create(ctx, &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "should-delete",
 				},
 			}, metav1.CreateOptions{})
 			Expect(err).To(Succeed())
 
-			_, err = t.client.CoreV1().Services(noDeleteNS).Create(context.TODO(), &corev1.Service{
+			_, err = t.client.CoreV1().Services(noDeleteNS).Create(ctx, &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "should-not-delete",
 				},
@@ -391,24 +391,24 @@ var _ = Describe("Namespace verification", func() {
 
 			// Delete the namespace
 
-			Expect(t.client.CoreV1().Namespaces().Delete(context.TODO(), testNamespace, metav1.DeleteOptions{})).To(Succeed())
+			Expect(t.client.CoreV1().Namespaces().Delete(ctx, testNamespace, metav1.DeleteOptions{})).To(Succeed())
 
-			_, err = t.doGet(t.pod.Name)
+			_, err = t.doGet(ctx, t.pod.Name)
 			assertMissingNamespaceErr(err)
 
 			// Recreate the namespace
 
-			createNamespace(testNamespace)
+			createNamespace(ctx, testNamespace)
 
-			_, err = t.doGet(t.pod.Name)
+			_, err = t.doGet(ctx, t.pod.Name)
 			Expect(err).To(HaveOccurred())
 			Expect(apierrors.IsNotFound(err)).To(BeTrue())
 
-			_, err = t.client.CoreV1().Services(testNamespace).Get(context.TODO(), "should-delete", metav1.GetOptions{})
+			_, err = t.client.CoreV1().Services(testNamespace).Get(ctx, "should-delete", metav1.GetOptions{})
 			Expect(err).To(HaveOccurred())
 			Expect(apierrors.IsNotFound(err)).To(BeTrue())
 
-			_, err = t.client.CoreV1().Services(noDeleteNS).Get(context.TODO(), "should-not-delete", metav1.GetOptions{})
+			_, err = t.client.CoreV1().Services(noDeleteNS).Get(ctx, "should-not-delete", metav1.GetOptions{})
 			Expect(err).To(Succeed())
 		})
 	})
@@ -446,41 +446,41 @@ func newBasicReactorsTestDriver() *basicReactorsTestDriver {
 	return t
 }
 
-func (t *basicReactorsTestDriver) doGet(name string) (*corev1.Pod, error) {
-	return t.client.CoreV1().Pods(testNamespace).Get(context.Background(), name, metav1.GetOptions{})
+func (t *basicReactorsTestDriver) doGet(ctx context.Context, name string) (*corev1.Pod, error) {
+	return t.client.CoreV1().Pods(testNamespace).Get(ctx, name, metav1.GetOptions{})
 }
 
-func (t *basicReactorsTestDriver) assertGetSuccess(p *corev1.Pod) *corev1.Pod {
-	actual, err := t.doGet(p.Name)
+func (t *basicReactorsTestDriver) assertGetSuccess(ctx context.Context, p *corev1.Pod) *corev1.Pod {
+	actual, err := t.doGet(ctx, p.Name)
 	Expect(err).To(Succeed())
 	Expect(actual).To(Equal(p))
 
 	return actual
 }
 
-func (t *basicReactorsTestDriver) doCreate(pod *corev1.Pod) (*corev1.Pod, error) {
-	return t.client.CoreV1().Pods(testNamespace).Create(context.Background(), pod, metav1.CreateOptions{})
+func (t *basicReactorsTestDriver) doCreate(ctx context.Context, pod *corev1.Pod) (*corev1.Pod, error) {
+	return t.client.CoreV1().Pods(testNamespace).Create(ctx, pod, metav1.CreateOptions{})
 }
 
-func (t *basicReactorsTestDriver) assertCreateSuccess(pod *corev1.Pod) *corev1.Pod {
-	created, err := t.doCreate(pod)
+func (t *basicReactorsTestDriver) assertCreateSuccess(ctx context.Context, pod *corev1.Pod) *corev1.Pod {
+	created, err := t.doCreate(ctx, pod)
 	Expect(err).To(Succeed())
 
-	return t.assertGetSuccess(created)
+	return t.assertGetSuccess(ctx, created)
 }
 
-func (t *basicReactorsTestDriver) doUpdate() (*corev1.Pod, error) {
-	return t.client.CoreV1().Pods(testNamespace).Update(context.Background(), t.pod, metav1.UpdateOptions{})
+func (t *basicReactorsTestDriver) doUpdate(ctx context.Context) (*corev1.Pod, error) {
+	return t.client.CoreV1().Pods(testNamespace).Update(ctx, t.pod, metav1.UpdateOptions{})
 }
 
-func (t *basicReactorsTestDriver) doUpdateSuccess() *corev1.Pod {
-	updated, err := t.doUpdate()
+func (t *basicReactorsTestDriver) doUpdateSuccess(ctx context.Context) *corev1.Pod {
+	updated, err := t.doUpdate(ctx)
 	Expect(err).To(Succeed())
 
-	return t.assertGetSuccess(updated)
+	return t.assertGetSuccess(ctx, updated)
 }
 
 //nolint:gocritic // Ignore hugeParam
-func (t *basicReactorsTestDriver) doDelete(opts metav1.DeleteOptions) error {
-	return t.client.CoreV1().Pods(testNamespace).Delete(context.Background(), t.pod.Name, opts)
+func (t *basicReactorsTestDriver) doDelete(ctx context.Context, opts metav1.DeleteOptions) error {
+	return t.client.CoreV1().Pods(testNamespace).Delete(ctx, t.pod.Name, opts)
 }

--- a/pkg/federate/federator_test.go
+++ b/pkg/federate/federator_test.go
@@ -46,8 +46,6 @@ import (
 const GenerateNamePrefix = "prefix-"
 
 var (
-	ctx = context.Background()
-
 	_ = Describe("CreateOrUpdate Federator", testCreateOrUpdateFederator)
 	_ = Describe("Create Federator", testCreateFederator)
 	_ = Describe("Update Federator", testUpdateFederator)
@@ -84,7 +82,7 @@ func testCreateOrUpdateFederator() {
 
 	When("the resource does not already exist in the datastore", func() {
 		Context("and a local cluster ID is specified", func() {
-			It("should create the resource with the cluster ID label", func() {
+			It("should create the resource with the cluster ID label", func(ctx SpecContext) {
 				Expect(f.Distribute(ctx, t.resource)).To(Succeed())
 				t.verifyResource()
 			})
@@ -95,7 +93,7 @@ func testCreateOrUpdateFederator() {
 				t.localClusterID = ""
 			})
 
-			It("should create the resource without the cluster ID label", func() {
+			It("should create the resource without the cluster ID label", func(ctx SpecContext) {
 				Expect(f.Distribute(ctx, t.resource)).To(Succeed())
 				t.verifyResource()
 			})
@@ -109,7 +107,7 @@ func testCreateOrUpdateFederator() {
 				}
 			})
 
-			It("should create the resource with the Status data", func() {
+			It("should create the resource with the Status data", func(ctx SpecContext) {
 				Expect(f.Distribute(ctx, t.resource)).To(Succeed())
 				t.verifyResource()
 			})
@@ -126,7 +124,7 @@ func testCreateOrUpdateFederator() {
 				}
 			})
 
-			It("should create the resource with the OwnerReferences", func() {
+			It("should create the resource with the OwnerReferences", func(ctx SpecContext) {
 				Expect(f.Distribute(ctx, t.resource)).To(Succeed())
 				t.verifyResource()
 			})
@@ -137,7 +135,7 @@ func testCreateOrUpdateFederator() {
 				fake.FailOnAction(&t.dynClient.Fake, "pods", "create", apierrors.NewServiceUnavailable("fake"), false)
 			})
 
-			It("should return an error", func() {
+			It("should return an error", func(ctx SpecContext) {
 				Expect(f.Distribute(ctx, t.resource)).ToNot(Succeed())
 			})
 		})
@@ -154,7 +152,7 @@ func testCreateOrUpdateFederator() {
 					t.resource.GetName()), true)
 			})
 
-			It("should update the resource", func() {
+			It("should update the resource", func(ctx SpecContext) {
 				Expect(f.Distribute(ctx, t.resource)).To(Succeed())
 				t.verifyResource()
 			})
@@ -168,7 +166,7 @@ func testCreateOrUpdateFederator() {
 			t.resource = test.NewPodWithImage(test.LocalNamespace, "apache")
 		})
 
-		It("should update the resource", func() {
+		It("should update the resource", func(ctx SpecContext) {
 			Expect(f.Distribute(ctx, t.resource)).To(Succeed())
 			t.verifyResource()
 		})
@@ -179,7 +177,7 @@ func testCreateOrUpdateFederator() {
 					apierrors.NewConflict(schema.GroupResource{}, "", errors.New("fake")), true)
 			})
 
-			It("should retry until it succeeds", func() {
+			It("should retry until it succeeds", func(ctx SpecContext) {
 				Expect(f.Distribute(ctx, t.resource)).To(Succeed())
 				t.verifyResource()
 			})
@@ -190,7 +188,7 @@ func testCreateOrUpdateFederator() {
 				fake.FailOnAction(&t.dynClient.Fake, "pods", "update", apierrors.NewServiceUnavailable("fake"), false)
 			})
 
-			It("should return an error", func() {
+			It("should return an error", func(ctx SpecContext) {
 				Expect(f.Distribute(ctx, t.resource)).ToNot(Succeed())
 			})
 		})
@@ -204,17 +202,17 @@ func testCreateOrUpdateFederator() {
 			t.resource.GenerateName = GenerateNamePrefix
 		})
 
-		It("should create and update the resource", func() {
+		It("should create and update the resource", func(ctx SpecContext) {
 			Expect(f.Distribute(ctx, t.resource)).To(Succeed())
 
-			list, err := t.resourceClient.List(context.TODO(), metav1.ListOptions{})
+			list, err := t.resourceClient.List(ctx, metav1.ListOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(list.Items).To(HaveLen(1))
 
 			t.resource.Name = list.Items[0].GetName()
 			t.verifyResource()
 
-			_, err = t.resourceClient.Create(context.TODO(), resource.MustToUnstructured(&corev1.Pod{
+			_, err = t.resourceClient.Create(ctx, resource.MustToUnstructured(&corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "another-pod",
 				},
@@ -239,7 +237,7 @@ func testCreateOrUpdateFederator() {
 			fake.FailOnAction(&t.dynClient.Fake, "pods", "get", apierrors.NewServiceUnavailable("fake"), false)
 		})
 
-		It("should return an error", func() {
+		It("should return an error", func(ctx SpecContext) {
 			Expect(f.Distribute(ctx, t.resource)).ToNot(Succeed())
 		})
 	})
@@ -250,7 +248,7 @@ func testCreateOrUpdateFederator() {
 			t.resource.SetNamespace(t.targetNamespace)
 		})
 
-		It("should create the resource in the source namespace", func() {
+		It("should create the resource in the source namespace", func(ctx SpecContext) {
 			Expect(f.Distribute(ctx, t.resource)).To(Succeed())
 			t.verifyResource()
 		})
@@ -274,7 +272,7 @@ func testCreateFederator() {
 	})
 
 	When("the resource does not already exist in the datastore", func() {
-		It("create the resource", func() {
+		It("create the resource", func(ctx SpecContext) {
 			Expect(f.Distribute(ctx, t.resource)).To(Succeed())
 			t.verifyResource()
 		})
@@ -284,7 +282,7 @@ func testCreateFederator() {
 				fake.FailOnAction(&t.dynClient.Fake, "pods", "create", apierrors.NewServiceUnavailable("fake"), false)
 			})
 
-			It("should return an error", func() {
+			It("should return an error", func(ctx SpecContext) {
 				Expect(f.Distribute(ctx, t.resource)).ToNot(Succeed())
 			})
 		})
@@ -296,7 +294,7 @@ func testCreateFederator() {
 			test.CreateResource(t.resourceClient, t.resource)
 		})
 
-		It("should succeed and not update the resource", func() {
+		It("should succeed and not update the resource", func(ctx SpecContext) {
 			Expect(f.Distribute(ctx, test.NewPodWithImage(test.LocalNamespace, "apache"))).To(Succeed())
 			assert.EnsureNoActionsForResource(&t.dynClient.Fake, "pods", "update")
 		})
@@ -327,7 +325,7 @@ func testUpdateFederator() {
 			t.resource.Annotations["newAnnotation"] = "abc"
 		})
 
-		It("should update the resource", func() {
+		It("should update the resource", func(ctx SpecContext) {
 			Expect(f.Distribute(ctx, t.resource)).To(Succeed())
 			t.verifyResource()
 		})
@@ -338,7 +336,7 @@ func testUpdateFederator() {
 					errors.New("fake")), true)
 			})
 
-			It("should retry until it succeeds", func() {
+			It("should retry until it succeeds", func(ctx SpecContext) {
 				Expect(f.Distribute(ctx, t.resource)).To(Succeed())
 				t.verifyResource()
 			})
@@ -348,7 +346,7 @@ func testUpdateFederator() {
 					fake.FailOnAction(&t.dynClient.Fake, "pods", "get", apierrors.NewServiceUnavailable("fake"), false)
 				})
 
-				It("should return an error", func() {
+				It("should return an error", func(ctx SpecContext) {
 					Expect(f.Distribute(ctx, t.resource)).ToNot(Succeed())
 				})
 			})
@@ -359,14 +357,14 @@ func testUpdateFederator() {
 				fake.FailOnAction(&t.dynClient.Fake, "pods", "update", apierrors.NewServiceUnavailable("fake"), false)
 			})
 
-			It("should return an error", func() {
+			It("should return an error", func(ctx SpecContext) {
 				Expect(f.Distribute(ctx, t.resource)).ToNot(Succeed())
 			})
 		})
 	})
 
 	When("the resource does not exist in the datastore", func() {
-		It("should succeed", func() {
+		It("should succeed", func(ctx SpecContext) {
 			Expect(f.Distribute(ctx, t.resource)).To(Succeed())
 		})
 	})
@@ -391,7 +389,7 @@ func testUpdateStatusFederator() {
 	})
 
 	When("no previous status is present", func() {
-		It("should add the new status", func() {
+		It("should add the new status", func(ctx SpecContext) {
 			t.resource.Status = corev1.PodStatus{
 				Phase: corev1.PodRunning,
 				PodIP: "1.2.3.4",
@@ -415,7 +413,7 @@ func testUpdateStatusFederator() {
 			}
 		})
 
-		It("should replace it", func() {
+		It("should replace it", func(ctx SpecContext) {
 			t.resource.Status = corev1.PodStatus{
 				Phase: corev1.PodRunning,
 				PodIP: "1.2.3.4",
@@ -431,7 +429,7 @@ func testUpdateStatusFederator() {
 			t.resource.Spec.NodeName = "raiders"
 		})
 
-		It("should not update them", func() {
+		It("should not update them", func(ctx SpecContext) {
 			t.resource.Status = corev1.PodStatus{
 				Phase: corev1.PodRunning,
 			}
@@ -479,7 +477,7 @@ func testDelete() {
 			test.CreateResource(t.resourceClient, existing)
 		})
 
-		It("should delete the resource", func() {
+		It("should delete the resource", func(ctx SpecContext) {
 			Expect(f.Delete(ctx, t.resource)).To(Succeed())
 
 			_, err := test.GetResourceAndError(t.resourceClient, t.resource)
@@ -491,7 +489,7 @@ func testDelete() {
 				fake.FailOnAction(&t.dynClient.Fake, "pods", "delete", apierrors.NewServiceUnavailable("fake"), false)
 			})
 
-			It("should return an error", func() {
+			It("should return an error", func(ctx SpecContext) {
 				Expect(f.Delete(ctx, t.resource)).ToNot(Succeed())
 			})
 		})
@@ -502,7 +500,7 @@ func testDelete() {
 				t.resource.SetNamespace(t.targetNamespace)
 			})
 
-			It("should delete the resource from the source namespace", func() {
+			It("should delete the resource from the source namespace", func(ctx SpecContext) {
 				Expect(f.Delete(ctx, t.resource)).To(Succeed())
 
 				_, err := test.GetResourceAndError(t.resourceClient, t.resource)
@@ -528,7 +526,7 @@ func testDelete() {
 				t.resource.Name = ""
 			})
 
-			It("should delete the resource", func() {
+			It("should delete the resource", func(ctx SpecContext) {
 				Expect(f.Delete(ctx, t.resource)).To(Succeed())
 
 				_, err := test.GetResourceAndError(t.resourceClient, t.resource)
@@ -545,7 +543,7 @@ func testDelete() {
 					})
 				})
 
-				It("should fail", func() {
+				It("should fail", func(ctx SpecContext) {
 					err := f.Delete(ctx, t.resource)
 					Expect(err).NotTo(Succeed())
 					Expect(apierrors.IsNotFound(f.Delete(ctx, t.resource))).To(BeFalse())
@@ -555,7 +553,7 @@ func testDelete() {
 	})
 
 	When("the resource does not exist in the datastore", func() {
-		It("should return NotFound error", func() {
+		It("should return NotFound error", func(ctx SpecContext) {
 			Expect(apierrors.IsNotFound(f.Delete(ctx, t.resource))).To(BeTrue())
 		})
 
@@ -564,7 +562,7 @@ func testDelete() {
 				t.setIdentifyingLabels()
 			})
 
-			It("should return NotFound error", func() {
+			It("should return NotFound error", func(ctx SpecContext) {
 				t.resource.Name = ""
 
 				Expect(apierrors.IsNotFound(f.Delete(ctx, t.resource))).To(BeTrue())
@@ -580,7 +578,7 @@ func testFederatorFuncs() {
 		t = newTestDriver()
 	})
 
-	It("should invoke the proxied functions", func() {
+	It("should invoke the proxied functions", func(ctx SpecContext) {
 		f := federate.NewCreateOrUpdateFederator(federate.CreateOrUpdateOptions{
 			Client:          t.dynClient,
 			RestMapper:      t.restMapper,
@@ -609,7 +607,7 @@ func testNoopFederator() {
 		t = newTestDriver()
 	})
 
-	It("should not fail", func() {
+	It("should not fail", func(ctx SpecContext) {
 		f := federate.NewNoopFederator()
 
 		Expect(f.Distribute(ctx, t.resource)).To(Succeed())
@@ -662,7 +660,7 @@ func testCompositeFederator() {
 		composite = federate.NewCompositeFederator(federator1, federator2)
 	})
 
-	It("should invoke all the functions", func() {
+	It("should invoke all the functions", func(ctx SpecContext) {
 		Expect(composite.Distribute(ctx, t.resource)).To(Succeed())
 		Expect(federator1Distribute).To(Receive())
 		Expect(federator1Distribute).NotTo(Receive())
@@ -677,7 +675,7 @@ func testCompositeFederator() {
 	})
 
 	When("the first Federator fails", func() {
-		It("should fail fast and not invoke the second", func() {
+		It("should fail fast and not invoke the second", func(ctx SpecContext) {
 			federator1.DistributeFunc = func(_ context.Context, _ runtime.Object) error {
 				return errors.New("mock error")
 			}

--- a/pkg/finalizer/finalizer_test.go
+++ b/pkg/finalizer/finalizer_test.go
@@ -51,9 +51,9 @@ var _ = Describe("Add", func() {
 		t = newTestDriver()
 	})
 
-	JustBeforeEach(func() {
-		t.justBeforeEach()
-		added, err = finalizer.Add(context.TODO(), t.client, t.pod, finalizerName)
+	JustBeforeEach(func(ctx SpecContext) {
+		t.justBeforeEach(ctx)
+		added, err = finalizer.Add(ctx, t.client, t.pod, finalizerName)
 	})
 
 	When("the resource has no Finalizers", func() {
@@ -137,9 +137,9 @@ var _ = Describe("Remove", func() {
 		t.pod.Finalizers = []string{finalizerName}
 	})
 
-	JustBeforeEach(func() {
-		t.justBeforeEach()
-		err = finalizer.Remove(context.TODO(), t.client, t.pod, finalizerName)
+	JustBeforeEach(func(ctx SpecContext) {
+		t.justBeforeEach(ctx)
+		err = finalizer.Remove(ctx, t.client, t.pod, finalizerName)
 	})
 
 	When("the Finalizer is present", func() {
@@ -215,10 +215,10 @@ func newTestDriver() *testDriver {
 	return t
 }
 
-func (t *testDriver) justBeforeEach() {
+func (t *testDriver) justBeforeEach(ctx context.Context) {
 	t.client = resource.ForPod(t.kubeClient, t.pod.Namespace)
 
-	_, err := t.client.Create(context.TODO(), t.pod, metav1.CreateOptions{})
+	_, err := t.client.Create(ctx, t.pod, metav1.CreateOptions{})
 	Expect(err).To(Succeed())
 
 	t.kubeClient.Fake.ClearActions()

--- a/pkg/resource/interface_test.go
+++ b/pkg/resource/interface_test.go
@@ -19,8 +19,6 @@ limitations under the License.
 package resource_test
 
 import (
-	"context"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/submariner-io/admiral/pkg/resource"
@@ -257,7 +255,7 @@ var _ = Describe("MustExtractList", func() {
 })
 
 func testInterfaceFuncs[T runtime.Object](newInterface func() resource.Interface[T], initialObj T, updateStatus func(T) T) {
-	Specify("verify functions", func() {
+	Specify("verify functions", func(ctx SpecContext) {
 		sanitize := func(o T) T {
 			m := resource.MustToMeta(o)
 			m.SetResourceVersion("")
@@ -279,7 +277,7 @@ func testInterfaceFuncs[T runtime.Object](newInterface func() resource.Interface
 		resource.MustToMeta(another).SetName(resource.MustToMeta(initialObj).GetName() + "-2")
 
 		// Create
-		actual, err := i.Create(context.Background(), initialObj, metav1.CreateOptions{})
+		actual, err := i.Create(ctx, initialObj, metav1.CreateOptions{})
 		Expect(err).To(Succeed())
 
 		objMeta := resource.MustToMeta(actual)
@@ -287,38 +285,38 @@ func testInterfaceFuncs[T runtime.Object](newInterface func() resource.Interface
 		Expect(actual).To(Equal(initialObj))
 
 		// Get
-		obj, err := i.Get(context.Background(), objMeta.GetName(), metav1.GetOptions{})
+		obj, err := i.Get(ctx, objMeta.GetName(), metav1.GetOptions{})
 		Expect(err).To(Succeed())
 		Expect(sanitize(obj)).To(Equal(actual))
 
 		// Update
 		objMeta.SetLabels(map[string]string{"foo": "bar"})
 
-		obj, err = i.Update(context.Background(), actual, metav1.UpdateOptions{})
+		obj, err = i.Update(ctx, actual, metav1.UpdateOptions{})
 		Expect(err).To(Succeed())
 		Expect(sanitize(obj)).To(Equal(actual))
 
 		if updateStatus != nil {
 			actual = updateStatus(actual)
-			obj, err = i.UpdateStatus(context.Background(), actual, metav1.UpdateOptions{})
+			obj, err = i.UpdateStatus(ctx, actual, metav1.UpdateOptions{})
 			Expect(err).To(Succeed())
 			Expect(sanitize(obj)).To(Equal(actual))
 		} else {
-			_, err = i.UpdateStatus(context.Background(), actual, metav1.UpdateOptions{})
+			_, err = i.UpdateStatus(ctx, actual, metav1.UpdateOptions{})
 			Expect(err).To(HaveOccurred())
 		}
 
 		// List
-		list, err := i.List(context.Background(), metav1.ListOptions{})
+		list, err := i.List(ctx, metav1.ListOptions{})
 		Expect(err).To(Succeed())
 		Expect(list).To(HaveLen(1))
 		Expect(sanitize(list[0])).To(Equal(actual))
 
 		// List with label selector
-		_, err = i.Create(context.Background(), another, metav1.CreateOptions{})
+		_, err = i.Create(ctx, another, metav1.CreateOptions{})
 		Expect(err).To(Succeed())
 
-		list, err = i.List(context.Background(), metav1.ListOptions{
+		list, err = i.List(ctx, metav1.ListOptions{
 			LabelSelector: labels.SelectorFromSet(objMeta.GetLabels()).String(),
 		})
 		Expect(err).To(Succeed())
@@ -326,9 +324,9 @@ func testInterfaceFuncs[T runtime.Object](newInterface func() resource.Interface
 		Expect(sanitize(list[0])).To(Equal(actual))
 
 		// Delete
-		err = i.Delete(context.Background(), objMeta.GetName(), metav1.DeleteOptions{})
+		err = i.Delete(ctx, objMeta.GetName(), metav1.DeleteOptions{})
 		Expect(err).To(Succeed())
-		_, err = i.Get(context.Background(), objMeta.GetName(), metav1.GetOptions{})
+		_, err = i.Get(ctx, objMeta.GetName(), metav1.GetOptions{})
 		Expect(apierrors.IsNotFound(err)).To(BeTrue())
 	})
 }

--- a/pkg/syncer/await_stopped_test.go
+++ b/pkg/syncer/await_stopped_test.go
@@ -42,7 +42,7 @@ func testAwaitStopped() {
 		t.config.DrainWorkQueueTimeout = time.Millisecond * 80
 	})
 
-	It("should time out if the work queue is delayed stopping", func() {
+	It("should time out if the work queue is delayed stopping", func(ctx SpecContext) {
 		defer func() {
 			t.stopCh = nil
 		}()
@@ -52,18 +52,18 @@ func testAwaitStopped() {
 
 		close(t.stopCh)
 
-		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*300)
+		timeoutContext, cancel := context.WithTimeout(ctx, time.Millisecond*300)
 		defer cancel()
 
-		Expect(t.syncer.AwaitStopped(ctx)).NotTo(Succeed())
+		Expect(t.syncer.AwaitStopped(timeoutContext)).NotTo(Succeed())
 
 		t.config.Federator.(*blockingFederator).distributeContinue <- true
 
-		ctx, cancel = context.WithTimeout(context.Background(), time.Second)
+		timeoutContext, cancel = context.WithTimeout(ctx, time.Second)
 		defer cancel()
 
-		Expect(t.syncer.AwaitStopped(ctx)).To(Succeed())
-		Expect(t.syncer.AwaitStopped(ctx)).To(Succeed())
+		Expect(t.syncer.AwaitStopped(timeoutContext)).To(Succeed())
+		Expect(t.syncer.AwaitStopped(timeoutContext)).To(Succeed())
 	})
 }
 

--- a/pkg/syncer/broker/syncer_test.go
+++ b/pkg/syncer/broker/syncer_test.go
@@ -19,7 +19,6 @@ limitations under the License.
 package broker_test
 
 import (
-	"context"
 	"crypto/x509"
 	"encoding/base64"
 	"errors"
@@ -68,8 +67,6 @@ var _ = Describe("Broker Syncer", func() {
 		actualBrokerRestConfig *rest.Config
 		expectInitError        bool
 	)
-
-	ctx := context.TODO()
 
 	BeforeEach(func() {
 		os.Unsetenv("BROKER_K8S_APISERVER")
@@ -193,7 +190,7 @@ var _ = Describe("Broker Syncer", func() {
 		})
 
 		Context("and then deleted", func() {
-			It("should be deleted from the broker datastore", func() {
+			It("should be deleted from the broker datastore", func(ctx SpecContext) {
 				Expect(localClient.Delete(ctx, resource.GetName(), metav1.DeleteOptions{})).To(Succeed())
 				test.AwaitNoResource(brokerClient, resource.GetName())
 
@@ -226,7 +223,7 @@ var _ = Describe("Broker Syncer", func() {
 		})
 
 		Context("and then deleted", func() {
-			It("should be deleted from the broker datastore", func() {
+			It("should be deleted from the broker datastore", func(ctx SpecContext) {
 				Expect(brokerClient.Delete(ctx, resource.GetName(), metav1.DeleteOptions{})).To(Succeed())
 				test.AwaitNoResource(localClient, resource.GetName())
 
@@ -524,12 +521,12 @@ var _ = Describe("Broker Syncer", func() {
 		})
 	})
 
-	Specify("GetBrokerFederator should return the correct instance", func() {
+	Specify("GetBrokerFederator should return the correct instance", func(ctx SpecContext) {
 		f := syncer.GetBrokerFederator()
 		Expect(f).ToNot(BeNil())
 
 		name := string(uuid.NewUUID())
-		Expect(f.Distribute(context.Background(), &corev1.Pod{
+		Expect(f.Distribute(ctx, &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
 			},
@@ -546,12 +543,12 @@ var _ = Describe("Broker Syncer", func() {
 		Expect(syncer.GetBrokerNamespace()).To(Equal(test.RemoteNamespace))
 	})
 
-	Specify("GetLocalFederator should return the correct instance", func() {
+	Specify("GetLocalFederator should return the correct instance", func(ctx SpecContext) {
 		f := syncer.GetLocalFederator()
 		Expect(f).ToNot(BeNil())
 
 		name := string(uuid.NewUUID())
-		Expect(f.Distribute(context.Background(), &corev1.Pod{
+		Expect(f.Distribute(ctx, &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
 			},

--- a/pkg/syncer/event_ordering_test.go
+++ b/pkg/syncer/event_ordering_test.go
@@ -31,7 +31,7 @@ func testEventOrdering() {
 	t := newEventOrderingTestDriver()
 
 	When("a create occurs immediately following a delete", func() {
-		It("should process both events in order", func() {
+		It("should process both events in order", func(ctx SpecContext) {
 			first := test.CreateResource(t.sourceClient, t.resource)
 			t.federator.VerifyDistribute(first)
 			Eventually(t.opChan).Should(Receive(Equal(syncer.Create)))
@@ -50,7 +50,7 @@ func testEventOrdering() {
 	})
 
 	When("a delete occurs immediately following a create", func() {
-		It("should process both events in order", func() {
+		It("should process both events in order", func(ctx SpecContext) {
 			r := test.CreateResource(t.sourceClient, t.resource)
 			Expect(t.sourceClient.Delete(ctx, r.GetName(), metav1.DeleteOptions{})).To(Succeed())
 
@@ -64,7 +64,7 @@ func testEventOrdering() {
 	})
 
 	When("a delete occurs immediately following an update", func() {
-		It("should process both events in order", func() {
+		It("should process both events in order", func(ctx SpecContext) {
 			t.federator.VerifyDistribute(test.CreateResource(t.sourceClient, t.resource))
 			Eventually(t.opChan).Should(Receive(Equal(syncer.Create)))
 

--- a/pkg/syncer/missing_namespace_test.go
+++ b/pkg/syncer/missing_namespace_test.go
@@ -119,7 +119,7 @@ func testWithMissingNamespace() {
 			createNamespace(otherNS)
 		})
 
-		It("should eventually redistribute when the namespace is recreated", func() {
+		It("should eventually redistribute when the namespace is recreated", func(ctx SpecContext) {
 			resource := test.CreateResource(t.sourceClient, t.resource)
 			resource.SetNamespace(transformedNamespace)
 			t.federator.VerifyDistribute(resource)

--- a/pkg/syncer/on_successful_sync_func_test.go
+++ b/pkg/syncer/on_successful_sync_func_test.go
@@ -66,7 +66,7 @@ func testOnSuccessfulSyncFunction() {
 			t.addInitialResource(t.resource)
 		})
 
-		It("should invoke the OnSuccessfulSync function", func() {
+		It("should invoke the OnSuccessfulSync function", func(ctx SpecContext) {
 			expected := test.GetResource(t.sourceClient, t.resource)
 			t.federator.VerifyDistribute(expected)
 			Eventually(t.expOperation).Should(Receive(Equal(syncer.Create)))
@@ -119,7 +119,7 @@ func testOnSuccessfulSyncFunction() {
 				t.federator.ResetOnFailure.Store(false)
 			})
 
-			It("should not invoke the OnSuccessfulSync function", func() {
+			It("should not invoke the OnSuccessfulSync function", func(ctx SpecContext) {
 				Expect(t.sourceClient.Delete(ctx, t.resource.GetName(), metav1.DeleteOptions{})).To(Succeed())
 				Consistently(t.expOperation, 300*time.Millisecond).ShouldNot(Receive())
 			})
@@ -130,7 +130,7 @@ func testOnSuccessfulSyncFunction() {
 				t.federator.FailOnDelete(apierrors.NewNotFound(schema.GroupResource{}, ""))
 			})
 
-			It("should invoke the OnSuccessfulSync function", func() {
+			It("should invoke the OnSuccessfulSync function", func(ctx SpecContext) {
 				Expect(t.sourceClient.Delete(ctx, t.resource.GetName(), metav1.DeleteOptions{})).To(Succeed())
 				Eventually(t.expOperation).Should(Receive(Equal(syncer.Delete)))
 			})
@@ -142,7 +142,7 @@ func testOnSuccessfulSyncFunction() {
 			t.onSuccessfulSyncReturn.Store(true)
 		})
 
-		It("should retry", func() {
+		It("should retry", func(ctx SpecContext) {
 			t.federator.VerifyDistribute(test.CreateResource(t.sourceClient, t.resource))
 			Eventually(t.expOperation).Should(Receive(Equal(syncer.Create)))
 			Eventually(t.expOperation).Should(Receive(Equal(syncer.Create)))

--- a/pkg/syncer/resource_syncer_test.go
+++ b/pkg/syncer/resource_syncer_test.go
@@ -220,7 +220,7 @@ func testSyncErrors() {
 			d.addInitialResource(d.resource)
 		})
 
-		It("should log the error and retry until it succeeds", func() {
+		It("should log the error and retry until it succeeds", func(ctx SpecContext) {
 			expected := test.GetResource(d.sourceClient, d.resource)
 			d.federator.VerifyDistribute(expected)
 
@@ -236,7 +236,7 @@ func testSyncErrors() {
 			d.addInitialResource(d.resource)
 		})
 
-		It("should not log the error nor retry", func() {
+		It("should not log the error nor retry", func(ctx SpecContext) {
 			expected := test.GetResource(d.sourceClient, d.resource)
 			d.federator.VerifyDistribute(expected)
 

--- a/pkg/syncer/should_process_func_test.go
+++ b/pkg/syncer/should_process_func_test.go
@@ -92,7 +92,7 @@ func testShouldProcessFunction() {
 		})
 
 		When("the ShouldProcess function returns true", func() {
-			It("should delete it", func() {
+			It("should delete it", func(ctx SpecContext) {
 				expected := test.GetResource(t.sourceClient, t.resource)
 				t.federator.VerifyDistribute(expected)
 				Eventually(t.expOperation).Should(Receive(Equal(syncer.Create)))
@@ -108,7 +108,7 @@ func testShouldProcessFunction() {
 				t.shouldProcess = false
 			})
 
-			It("should not delete it", func() {
+			It("should not delete it", func(ctx SpecContext) {
 				t.federator.VerifyNoDistribute()
 				Eventually(t.expOperation).Should(Receive(Equal(syncer.Create)))
 

--- a/pkg/syncer/syncer_suite_test.go
+++ b/pkg/syncer/syncer_suite_test.go
@@ -66,8 +66,6 @@ func init() {
 	prometheus.DefaultRegisterer = &EmptyRegisterer{}
 }
 
-var ctx = context.TODO()
-
 var _ = Describe("", func() {
 	kzerolog.InitK8sLogging()
 })
@@ -168,7 +166,7 @@ func newTestDriver(sourceNamespace, localClusterID string, syncDirection syncer.
 		Expect(d.syncer.Start(d.stopCh)).To(Succeed())
 	})
 
-	JustAfterEach(func() {
+	JustAfterEach(func(ctx SpecContext) {
 		if d.stopCh != nil {
 			close(d.stopCh)
 		}
@@ -231,7 +229,7 @@ func (t *testDriver) verifyDistributeOnDeleteTest(clusterID string) {
 		t.addInitialResource(test.SetClusterIDLabel(t.resource, clusterID))
 	})
 
-	It("should delete it", func() {
+	It("should delete it", func(ctx SpecContext) {
 		expected := test.GetResource(t.sourceClient, t.resource)
 		t.federator.VerifyDistribute(expected)
 
@@ -245,7 +243,7 @@ func (t *testDriver) verifyNoDistributeOnDeleteTest(clusterID string) {
 		t.addInitialResource(test.SetClusterIDLabel(t.resource, clusterID))
 	})
 
-	It("should not delete it", func() {
+	It("should not delete it", func(ctx SpecContext) {
 		t.federator.VerifyNoDistribute()
 
 		Expect(t.sourceClient.Delete(ctx, t.resource.GetName(), metav1.DeleteOptions{})).To(Succeed())

--- a/pkg/syncer/transform_func_test.go
+++ b/pkg/syncer/transform_func_test.go
@@ -88,7 +88,7 @@ func testTransformFunction() {
 			atomic.StoreInt32(&t.invocationCount, 0)
 		})
 
-		It("should delete the transformed resource", func() {
+		It("should delete the transformed resource", func(ctx SpecContext) {
 			Expect(t.sourceClient.Delete(ctx, t.resource.GetName(), metav1.DeleteOptions{})).To(Succeed())
 			t.verifyDelete()
 			Eventually(t.expOperation).Should(Receive(Equal(syncer.Delete)))
@@ -102,7 +102,7 @@ func testTransformFunction() {
 				t.requeueOnOp = ptr.To(syncer.Delete)
 			})
 
-			It("should eventually retry", func() {
+			It("should eventually retry", func(ctx SpecContext) {
 				Expect(t.sourceClient.Delete(ctx, t.resource.GetName(), metav1.DeleteOptions{})).To(Succeed())
 				Eventually(func() int {
 					return int(atomic.LoadInt32(&t.invocationCount))
@@ -115,7 +115,7 @@ func testTransformFunction() {
 				t.requeueOnOp = ptr.To(syncer.Create)
 			})
 
-			It("should not retry the create operation", func() {
+			It("should not retry the create operation", func(ctx SpecContext) {
 				Expect(t.sourceClient.Delete(ctx, t.resource.GetName(), metav1.DeleteOptions{})).To(Succeed())
 				Eventually(t.expOperation).Should(Receive(Equal(syncer.Delete)))
 				Consistently(t.expOperation).ShouldNot(Receive(Equal(syncer.Create)))
@@ -129,7 +129,7 @@ func testTransformFunction() {
 			t.addInitialResource(t.resource)
 		})
 
-		It("should retry until it succeeds", func() {
+		It("should retry until it succeeds", func(ctx SpecContext) {
 			t.verifyDistribute()
 			Eventually(t.expOperation).Should(Receive(Equal(syncer.Create)))
 
@@ -177,7 +177,7 @@ func testTransformFunction() {
 				t.addInitialResource(t.resource)
 			})
 
-			It("should not delete the resource", func() {
+			It("should not delete the resource", func(ctx SpecContext) {
 				t.federator.VerifyNoDistribute()
 				atomic.StoreInt32(&t.invocationCount, 0)
 				Eventually(t.expOperation).Should(Receive(Equal(syncer.Create)))
@@ -221,7 +221,7 @@ func testTransformFunction() {
 				t.addInitialResource(t.resource)
 			})
 
-			It("should eventually delete the resource", func() {
+			It("should eventually delete the resource", func(ctx SpecContext) {
 				t.verifyDistribute()
 				Eventually(t.expOperation).Should(Receive(Equal(syncer.Create)))
 				returnNil.Store(true)

--- a/pkg/util/create_or_update_test.go
+++ b/pkg/util/create_or_update_test.go
@@ -48,13 +48,13 @@ import (
 var _ = Describe("CreateAnew function", func() {
 	t := newCreateOrUpdateTestDiver()
 
-	createAnew := func() (runtime.Object, error) {
-		return util.CreateAnew[*unstructured.Unstructured](context.TODO(), resource.ForDynamic(t.client),
+	createAnew := func(ctx context.Context) (runtime.Object, error) {
+		return util.CreateAnew(ctx, resource.ForDynamic(t.client),
 			resource.MustToUnstructured(t.pod), metav1.CreateOptions{}, metav1.DeleteOptions{})
 	}
 
-	createAnewSuccess := func() *corev1.Pod {
-		o, err := createAnew()
+	createAnewSuccess := func(ctx context.Context) *corev1.Pod {
+		o, err := createAnew(ctx)
 		Expect(err).To(Succeed())
 		Expect(o).ToNot(BeNil())
 
@@ -64,14 +64,14 @@ var _ = Describe("CreateAnew function", func() {
 		return actual
 	}
 
-	createAnewError := func() error {
-		_, err := createAnew()
+	createAnewError := func(ctx context.Context) error {
+		_, err := createAnew(ctx)
 		return err
 	}
 
 	When("the resource doesn't exist", func() {
-		It("should successfully create the resource", func() {
-			t.compareWithPod(createAnewSuccess())
+		It("should successfully create the resource", func(ctx SpecContext) {
+			t.compareWithPod(createAnewSuccess(ctx))
 		})
 	})
 
@@ -85,8 +85,8 @@ var _ = Describe("CreateAnew function", func() {
 				t.pod.Spec.Containers[0].Image = "updated"
 			})
 
-			It("should delete the existing resource and create a new one", func() {
-				t.compareWithPod(createAnewSuccess())
+			It("should delete the existing resource and create a new one", func(ctx SpecContext) {
+				t.compareWithPod(createAnewSuccess(ctx))
 			})
 
 			Context("and Delete returns not found", func() {
@@ -94,8 +94,8 @@ var _ = Describe("CreateAnew function", func() {
 					fake.FailOnAction(t.testingFake, "pods", "delete", apierrors.NewNotFound(schema.GroupResource{}, t.pod.Name), true)
 				})
 
-				It("should successfully create the resource", func() {
-					t.compareWithPod(createAnewSuccess())
+				It("should successfully create the resource", func(ctx SpecContext) {
+					t.compareWithPod(createAnewSuccess(ctx))
 				})
 			})
 
@@ -105,8 +105,8 @@ var _ = Describe("CreateAnew function", func() {
 					fake.FailOnAction(t.testingFake, "pods", "delete", t.expectedErr, false)
 				})
 
-				It("should return an error", func() {
-					Expect(createAnewError()).To(ContainErrorSubstring(t.expectedErr))
+				It("should return an error", func(ctx SpecContext) {
+					Expect(createAnewError(ctx)).To(ContainErrorSubstring(t.expectedErr))
 				})
 			})
 
@@ -116,8 +116,8 @@ var _ = Describe("CreateAnew function", func() {
 						t.pod.Name), false)
 				})
 
-				It("should return an error", func() {
-					Expect(createAnewError()).ToNot(Succeed())
+				It("should return an error", func(ctx SpecContext) {
+					Expect(createAnewError(ctx)).ToNot(Succeed())
 				})
 			})
 		})
@@ -127,8 +127,8 @@ var _ = Describe("CreateAnew function", func() {
 				t.pod.Status.Phase = corev1.PodRunning
 			})
 
-			It("should not recreate it", func() {
-				createAnewSuccess()
+			It("should not recreate it", func(ctx SpecContext) {
+				createAnewSuccess(ctx)
 				tests.EnsureNoActionsForResource(t.testingFake, "pods", "delete")
 			})
 		})
@@ -140,8 +140,8 @@ var _ = Describe("CreateAnew function", func() {
 			fake.FailOnAction(t.testingFake, "pods", "create", t.expectedErr, false)
 		})
 
-		It("should return an error", func() {
-			Expect(createAnewError()).To(ContainErrorSubstring(t.expectedErr))
+		It("should return an error", func(ctx SpecContext) {
+			Expect(createAnewError(ctx)).To(ContainErrorSubstring(t.expectedErr))
 		})
 	})
 })
@@ -149,7 +149,7 @@ var _ = Describe("CreateAnew function", func() {
 var _ = Describe("CreateOrUpdate function", func() {
 	t := newCreateOrUpdateTestDiver()
 
-	createOrUpdate := func(expResult util.OperationResult) error {
+	createOrUpdate := func(ctx context.Context, expResult util.OperationResult) error {
 		options := util.CreateOrUpdateOptions[*unstructured.Unstructured]{
 			Client:         resource.ForDynamic(t.client),
 			MutateOnUpdate: t.mutateFn,
@@ -164,7 +164,7 @@ var _ = Describe("CreateOrUpdate function", func() {
 
 		options.Obj = resource.MustToUnstructured(t.pod)
 
-		result, retObj, err := util.CreateOrUpdateWithOptions[*unstructured.Unstructured](context.TODO(), options)
+		result, retObj, err := util.CreateOrUpdateWithOptions(ctx, options)
 		if err != nil && expResult != util.OperationResultNone {
 			return err
 		}
@@ -180,15 +180,15 @@ var _ = Describe("CreateOrUpdate function", func() {
 	}
 
 	When("the resource doesn't exist", func() {
-		It("should successfully create the resource", func() {
-			Expect(createOrUpdate(util.OperationResultCreated)).To(Succeed())
-			t.verifyPod()
+		It("should successfully create the resource", func(ctx SpecContext) {
+			Expect(createOrUpdate(ctx, util.OperationResultCreated)).To(Succeed())
+			t.verifyPod(ctx)
 			tests.EnsureNoActionsForResource(t.testingFake, "pods/status", "update")
 		})
 
 		Context("and a mutation function specified", func() {
-			It("should invoke the function on create", func() {
-				result, created, err := util.CreateOrUpdateWithOptions[*unstructured.Unstructured](context.TODO(),
+			It("should invoke the function on create", func(ctx SpecContext) {
+				result, created, err := util.CreateOrUpdateWithOptions(ctx,
 					util.CreateOrUpdateOptions[*unstructured.Unstructured]{
 						Client: resource.ForDynamic(t.client),
 						Obj:    resource.MustToUnstructured(t.pod),
@@ -200,15 +200,15 @@ var _ = Describe("CreateOrUpdate function", func() {
 				Expect(err).To(Succeed())
 				Expect(result).To(Equal(util.OperationResultCreated))
 
-				actual := t.verifyPod()
+				actual := t.verifyPod(ctx)
 				Expect(actual.Annotations).To(HaveKeyWithValue("on-create-invoked", "true"))
 
 				Expect(resource.MustFromUnstructured(created, &corev1.Pod{})).To(Equal(actual))
 			})
 
 			Context("which returns an error", func() {
-				It("should return an error", func() {
-					_, _, err := util.CreateOrUpdateWithOptions[*unstructured.Unstructured](context.TODO(),
+				It("should return an error", func(ctx SpecContext) {
+					_, _, err := util.CreateOrUpdateWithOptions(ctx,
 						util.CreateOrUpdateOptions[*unstructured.Unstructured]{
 							Client: resource.ForDynamic(t.client),
 							Obj:    resource.MustToUnstructured(t.pod),
@@ -228,9 +228,9 @@ var _ = Describe("CreateOrUpdate function", func() {
 				t.pod.Labels = map[string]string{"label1": "value1", "label2": "value2"}
 			})
 
-			It("should successfully create the resource", func() {
-				Expect(createOrUpdate(util.OperationResultCreated)).To(Succeed())
-				actual := t.verifyPod()
+			It("should successfully create the resource", func(ctx SpecContext) {
+				Expect(createOrUpdate(ctx, util.OperationResultCreated)).To(Succeed())
+				actual := t.verifyPod(ctx)
 				Expect(actual.Name).To(HavePrefix("name-prefix-"))
 			})
 		})
@@ -240,9 +240,9 @@ var _ = Describe("CreateOrUpdate function", func() {
 				t.pod.Status = corev1.PodStatus{Phase: corev1.PodRunning}
 			})
 
-			It("should create the resource with the status field set via UpdateStatus", func() {
-				Expect(createOrUpdate(util.OperationResultCreated)).To(Succeed())
-				t.verifyPod()
+			It("should create the resource with the status field set via UpdateStatus", func(ctx SpecContext) {
+				Expect(createOrUpdate(ctx, util.OperationResultCreated)).To(Succeed())
+				t.verifyPod(ctx)
 				tests.EnsureActionsForResource(t.testingFake, "pods/status", "update")
 			})
 
@@ -251,9 +251,9 @@ var _ = Describe("CreateOrUpdate function", func() {
 					fake.FailOnAction(t.testingFake, "pods/status", "update", apierrors.NewNotFound(schema.GroupResource{}, ""), false)
 				})
 
-				It("should successfully create the resource", func() {
-					Expect(createOrUpdate(util.OperationResultCreated)).To(Succeed())
-					t.verifyPod()
+				It("should successfully create the resource", func(ctx SpecContext) {
+					Expect(createOrUpdate(ctx, util.OperationResultCreated)).To(Succeed())
+					t.verifyPod(ctx)
 				})
 			})
 
@@ -262,8 +262,8 @@ var _ = Describe("CreateOrUpdate function", func() {
 					fake.FailOnAction(t.testingFake, "pods/status", "update", apierrors.NewServiceUnavailable("fake"), false)
 				})
 
-				It("should return an error", func() {
-					Expect(createOrUpdate(util.OperationResultNone)).ToNot(Succeed())
+				It("should return an error", func(ctx SpecContext) {
+					Expect(createOrUpdate(ctx, util.OperationResultNone)).ToNot(Succeed())
 				})
 			})
 		})
@@ -274,8 +274,8 @@ var _ = Describe("CreateOrUpdate function", func() {
 				fake.FailOnAction(t.testingFake, "pods", "create", t.expectedErr, false)
 			})
 
-			It("should return an error", func() {
-				Expect(createOrUpdate(util.OperationResultNone)).To(ContainErrorSubstring(t.expectedErr))
+			It("should return an error", func(ctx SpecContext) {
+				Expect(createOrUpdate(ctx, util.OperationResultNone)).To(ContainErrorSubstring(t.expectedErr))
 			})
 		})
 
@@ -292,9 +292,9 @@ var _ = Describe("CreateOrUpdate function", func() {
 					t.pod.GetName()), true)
 			})
 
-			It("should eventually update the resource", func() {
-				Expect(createOrUpdate(util.OperationResultUpdated)).To(Succeed())
-				t.verifyPod()
+			It("should eventually update the resource", func(ctx SpecContext) {
+				Expect(createOrUpdate(ctx, util.OperationResultUpdated)).To(Succeed())
+				t.verifyPod(ctx)
 			})
 		})
 	})
@@ -307,46 +307,46 @@ var _ = Describe("CreateOrUpdate function", func() {
 var _ = Describe("Update function", func() {
 	t := newCreateOrUpdateTestDiver()
 
-	update := func() error {
-		return util.Update[*unstructured.Unstructured](context.TODO(), resource.ForDynamic(t.client), resource.MustToUnstructured(t.pod),
+	update := func(ctx context.Context) error {
+		return util.Update(ctx, resource.ForDynamic(t.client), resource.MustToUnstructured(t.pod),
 			t.mutateFn)
 	}
 
 	When("the resource doesn't exist", func() {
-		It("shouldn't return an error", func() {
-			Expect(update()).To(Succeed())
+		It("shouldn't return an error", func(ctx SpecContext) {
+			Expect(update(ctx)).To(Succeed())
 		})
 	})
 
-	t.testUpdate(func(_ util.OperationResult) error {
-		return update()
+	t.testUpdate(func(ctx context.Context, _ util.OperationResult) error {
+		return update(ctx)
 	})
 
-	t.testGetFailure(func(_ util.OperationResult) error {
-		return update()
+	t.testGetFailure(func(ctx context.Context, _ util.OperationResult) error {
+		return update(ctx)
 	})
 })
 
 var _ = Describe("MustUpdate function", func() {
 	t := newCreateOrUpdateTestDiver()
 
-	mustUpdate := func() error {
-		return util.MustUpdate[*unstructured.Unstructured](context.TODO(), resource.ForDynamic(t.client),
+	mustUpdate := func(ctx context.Context) error {
+		return util.MustUpdate(ctx, resource.ForDynamic(t.client),
 			resource.MustToUnstructured(t.pod), t.mutateFn)
 	}
 
 	When("the resource doesn't exist", func() {
-		It("should return an error", func() {
-			Expect(mustUpdate()).ToNot(Succeed())
+		It("should return an error", func(ctx SpecContext) {
+			Expect(mustUpdate(ctx)).ToNot(Succeed())
 		})
 	})
 
-	t.testUpdate(func(_ util.OperationResult) error {
-		return mustUpdate()
+	t.testUpdate(func(ctx context.Context, _ util.OperationResult) error {
+		return mustUpdate(ctx)
 	})
 
-	t.testGetFailure(func(_ util.OperationResult) error {
-		return mustUpdate()
+	t.testGetFailure(func(ctx context.Context, _ util.OperationResult) error {
+		return mustUpdate(ctx)
 	})
 })
 
@@ -395,20 +395,20 @@ func newCreateOrUpdateTestDiver() *createOrUpdateTestDriver {
 	return t
 }
 
-func (t *createOrUpdateTestDriver) testGetFailure(doOper func(util.OperationResult) error) {
+func (t *createOrUpdateTestDriver) testGetFailure(doOper func(context.Context, util.OperationResult) error) {
 	When("resource retrieval fails", func() {
 		JustBeforeEach(func() {
 			t.expectedErr = apierrors.NewServiceUnavailable("fake")
 			fake.FailOnAction(t.testingFake, "pods", "get", t.expectedErr, false)
 		})
 
-		It("should return an error", func() {
-			Expect(doOper(util.OperationResultNone)).To(ContainErrorSubstring(t.expectedErr))
+		It("should return an error", func(ctx SpecContext) {
+			Expect(doOper(ctx, util.OperationResultNone)).To(ContainErrorSubstring(t.expectedErr))
 		})
 	})
 }
 
-func (t *createOrUpdateTestDriver) testUpdate(doUpdate func(util.OperationResult) error) {
+func (t *createOrUpdateTestDriver) testUpdate(doUpdate func(context.Context, util.OperationResult) error) {
 	When("the resource already exists", func() {
 		JustBeforeEach(func() {
 			labels := t.pod.Labels
@@ -420,9 +420,9 @@ func (t *createOrUpdateTestDriver) testUpdate(doUpdate func(util.OperationResult
 			t.pod.Labels = labels
 		})
 
-		It("should update the resource", func() {
-			Expect(doUpdate(util.OperationResultUpdated)).To(Succeed())
-			t.verifyPod()
+		It("should update the resource", func(ctx SpecContext) {
+			Expect(doUpdate(ctx, util.OperationResultUpdated)).To(Succeed())
+			t.verifyPod(ctx)
 			tests.EnsureNoActionsForResource(t.testingFake, "pods/status", "update")
 		})
 
@@ -437,7 +437,7 @@ func (t *createOrUpdateTestDriver) testUpdate(doUpdate func(util.OperationResult
 				t.pod.Name = ""
 			})
 
-			It("should update the resource", func() {
+			It("should update the resource", func(ctx SpecContext) {
 				test.CreateResource(t.client, &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						GenerateName: "other-prefix",
@@ -445,19 +445,19 @@ func (t *createOrUpdateTestDriver) testUpdate(doUpdate func(util.OperationResult
 					},
 				})
 
-				Expect(doUpdate(util.OperationResultUpdated)).To(Succeed())
-				t.verifyPod()
+				Expect(doUpdate(ctx, util.OperationResultUpdated)).To(Succeed())
+				t.verifyPod(ctx)
 			})
 
 			Context("but more than one matching resources exist", func() {
-				It("should return an error", func() {
+				It("should return an error", func(ctx SpecContext) {
 					test.CreateResource(t.client, &corev1.Pod{
 						ObjectMeta: metav1.ObjectMeta{
 							GenerateName: t.pod.GenerateName,
 							Labels:       t.pod.Labels,
 						},
 					})
-					Expect(doUpdate(util.OperationResultNone)).ToNot(Succeed())
+					Expect(doUpdate(ctx, util.OperationResultNone)).ToNot(Succeed())
 				})
 			})
 		})
@@ -467,9 +467,9 @@ func (t *createOrUpdateTestDriver) testUpdate(doUpdate func(util.OperationResult
 				t.pod.Status = corev1.PodStatus{Phase: corev1.PodRunning}
 			})
 
-			It("should update the resource", func() {
-				Expect(doUpdate(util.OperationResultUpdated)).To(Succeed())
-				t.verifyPod()
+			It("should update the resource", func(ctx SpecContext) {
+				Expect(doUpdate(ctx, util.OperationResultUpdated)).To(Succeed())
+				t.verifyPod(ctx)
 			})
 
 			Context("and UpdateStatus fails", func() {
@@ -477,8 +477,8 @@ func (t *createOrUpdateTestDriver) testUpdate(doUpdate func(util.OperationResult
 					fake.FailOnAction(t.testingFake, "pods/status", "update", apierrors.NewServiceUnavailable("fake"), false)
 				})
 
-				It("should return an error", func() {
-					Expect(doUpdate(util.OperationResultNone)).ToNot(Succeed())
+				It("should return an error", func(ctx SpecContext) {
+					Expect(doUpdate(ctx, util.OperationResultNone)).ToNot(Succeed())
 				})
 			})
 		})
@@ -493,8 +493,8 @@ func (t *createOrUpdateTestDriver) testUpdate(doUpdate func(util.OperationResult
 				t.pod.Status = corev1.PodStatus{Phase: corev1.PodRunning}
 			})
 
-			It("should only update the status", func() {
-				Expect(doUpdate(util.OperationResultUpdated)).To(Succeed())
+			It("should only update the status", func(ctx SpecContext) {
+				Expect(doUpdate(ctx, util.OperationResultUpdated)).To(Succeed())
 				Expect(test.GetResource(t.client, t.pod).Status).To(Equal(t.pod.Status))
 				tests.EnsureNoActionsForResource(t.testingFake, "pods", "update")
 			})
@@ -504,8 +504,8 @@ func (t *createOrUpdateTestDriver) testUpdate(doUpdate func(util.OperationResult
 					fake.FailOnAction(t.testingFake, "pods/status", "update", apierrors.NewNotFound(schema.GroupResource{}, ""), false)
 				})
 
-				It("should update the status", func() {
-					Expect(doUpdate(util.OperationResultUpdated)).To(Succeed())
+				It("should update the status", func(ctx SpecContext) {
+					Expect(doUpdate(ctx, util.OperationResultUpdated)).To(Succeed())
 					Expect(test.GetResource(t.client, t.pod).Status).To(Equal(t.pod.Status))
 				})
 			})
@@ -521,8 +521,8 @@ func (t *createOrUpdateTestDriver) testUpdate(doUpdate func(util.OperationResult
 				t.pod.Status = corev1.PodStatus{}
 			})
 
-			It("should not update the resource", func() {
-				Expect(doUpdate(util.OperationResultNone)).To(Succeed())
+			It("should not update the resource", func(ctx SpecContext) {
+				Expect(doUpdate(ctx, util.OperationResultNone)).To(Succeed())
 				tests.EnsureNoActionsForResource(t.testingFake, "pods", "update")
 				tests.EnsureNoActionsForResource(t.testingFake, "pods/status", "update")
 			})
@@ -534,9 +534,9 @@ func (t *createOrUpdateTestDriver) testUpdate(doUpdate func(util.OperationResult
 					errors.New("conflict")), true)
 			})
 
-			It("should eventually update the resource", func() {
-				Expect(doUpdate(util.OperationResultUpdated)).To(Succeed())
-				t.verifyPod()
+			It("should eventually update the resource", func(ctx SpecContext) {
+				Expect(doUpdate(ctx, util.OperationResultUpdated)).To(Succeed())
+				t.verifyPod(ctx)
 			})
 		})
 
@@ -545,8 +545,8 @@ func (t *createOrUpdateTestDriver) testUpdate(doUpdate func(util.OperationResult
 				fake.FailOnAction(t.testingFake, "pods", "update", t.expectedErr, false)
 			})
 
-			It("should return an error", func() {
-				Expect(doUpdate(util.OperationResultNone)).To(ContainErrorSubstring(t.expectedErr))
+			It("should return an error", func(ctx SpecContext) {
+				Expect(doUpdate(ctx, util.OperationResultNone)).To(ContainErrorSubstring(t.expectedErr))
 			})
 		})
 
@@ -557,8 +557,8 @@ func (t *createOrUpdateTestDriver) testUpdate(doUpdate func(util.OperationResult
 				}
 			})
 
-			It("should not update the resource", func() {
-				Expect(doUpdate(util.OperationResultNone)).To(Succeed())
+			It("should not update the resource", func(ctx SpecContext) {
+				Expect(doUpdate(ctx, util.OperationResultNone)).To(Succeed())
 				tests.EnsureNoActionsForResource(t.testingFake, "pods", "update")
 				tests.EnsureNoActionsForResource(t.testingFake, "pods/status", "update")
 			})
@@ -572,8 +572,8 @@ func (t *createOrUpdateTestDriver) testUpdate(doUpdate func(util.OperationResult
 				}
 			})
 
-			It("should return an error", func() {
-				Expect(doUpdate(util.OperationResultNone)).ToNot(Succeed())
+			It("should return an error", func(ctx SpecContext) {
+				Expect(doUpdate(ctx, util.OperationResultNone)).ToNot(Succeed())
 			})
 		})
 	})
@@ -583,11 +583,11 @@ func (t *createOrUpdateTestDriver) createPod() {
 	test.CreateResource(t.client, t.pod)
 }
 
-func (t *createOrUpdateTestDriver) verifyPod() *corev1.Pod {
+func (t *createOrUpdateTestDriver) verifyPod(ctx context.Context) *corev1.Pod {
 	pod := t.pod.DeepCopy()
 
 	if pod.Name == "" {
-		list, err := t.client.List(context.Background(), metav1.ListOptions{})
+		list, err := t.client.List(ctx, metav1.ListOptions{})
 		Expect(err).To(Succeed())
 		Expect(scheme.Scheme.Convert(&list.Items[0], pod, nil)).To(Succeed())
 	}

--- a/pkg/watcher/resource_watcher_test.go
+++ b/pkg/watcher/resource_watcher_test.go
@@ -19,7 +19,6 @@ limitations under the License.
 package watcher_test
 
 import (
-	"context"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -124,7 +123,7 @@ var _ = Describe("Resource Watcher", func() {
 	})
 
 	When("a Pod is created, updated and deleted", func() {
-		It("should notify the appropriate handler of each event", func() {
+		It("should notify the appropriate handler of each event", func(ctx SpecContext) {
 			pod := test.CreateResource(pods, pod)
 
 			Eventually(createdPods).Should(Receive(Equal(pod)))
@@ -136,7 +135,7 @@ var _ = Describe("Resource Watcher", func() {
 			Eventually(updatedPods).Should(Receive(Equal(pod)))
 			Consistently(updatedPods).ShouldNot(Receive())
 
-			Expect(pods.Delete(context.TODO(), pod.GetName(), metav1.DeleteOptions{})).To(Succeed())
+			Expect(pods.Delete(ctx, pod.GetName(), metav1.DeleteOptions{})).To(Succeed())
 
 			Eventually(deletedPods).Should(Receive(Equal(pod)))
 			Consistently(deletedPods).ShouldNot(Receive())

--- a/pkg/workqueue/queue_test.go
+++ b/pkg/workqueue/queue_test.go
@@ -317,7 +317,7 @@ var _ = Describe("Work Queue", func() {
 			}
 		})
 
-		It("should process all previously queued items", func() {
+		It("should process all previously queued items", func(ctx SpecContext) {
 			count := 10
 
 			var keys []string
@@ -333,7 +333,7 @@ var _ = Describe("Work Queue", func() {
 			Eventually(processStart).Should(Receive())
 
 			processContinue <- true
-			Expect(wq.ShutDownWithDrain(context.TODO())).To(Succeed())
+			Expect(wq.ShutDownWithDrain(ctx)).To(Succeed())
 
 			for _, key := range keys {
 				_, ok := processed.Load(key)
@@ -341,7 +341,7 @@ var _ = Describe("Work Queue", func() {
 			}
 		})
 
-		It("should time out if the current item processing is delayed", func() {
+		It("should time out if the current item processing is delayed", func(ctx SpecContext) {
 			itemKey := "item"
 
 			wq.EnqueueWithOpts(cache.ExplicitKey(itemKey),
@@ -349,17 +349,17 @@ var _ = Describe("Work Queue", func() {
 
 			Eventually(processStart).Should(Receive())
 
-			ctx, cancel := context.WithTimeout(context.TODO(), time.Millisecond*100)
+			timeoutContext, cancel := context.WithTimeout(ctx, time.Millisecond*100)
 			defer cancel()
 
-			Expect(wq.ShutDownWithDrain(ctx)).NotTo(Succeed())
+			Expect(wq.ShutDownWithDrain(timeoutContext)).NotTo(Succeed())
 
 			processContinue <- true
 
-			ctx, cancel = context.WithTimeout(context.TODO(), time.Second*3)
+			timeoutContext, cancel = context.WithTimeout(ctx, time.Second*3)
 			defer cancel()
 
-			Expect(wq.ShutDownWithDrain(ctx)).To(Succeed())
+			Expect(wq.ShutDownWithDrain(timeoutContext)).To(Succeed())
 
 			_, ok := processed.Load(itemKey)
 			Expect(ok).To(BeTrue(), "Item was not processed")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure to use modern context handling patterns across test suites.

* **Refactor**
  * Simplified public utility function signatures by removing unnecessary generic type parameters for cleaner, more accessible APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->