### PR TITLE
Extend fake SPDY Executor and add fake Pods implementation to mock pod logs 

### DIFF
--- a/pkg/fake/pod_logs.go
+++ b/pkg/fake/pod_logs.go
@@ -1,0 +1,88 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	restclient "k8s.io/client-go/rest"
+	fakerest "k8s.io/client-go/rest/fake"
+)
+
+// WrapClientWithPodLogs wraps a fake Kubernetes client to return custom pod logs.
+func WrapClientWithPodLogs(client kubernetes.Interface, logs map[string]string) kubernetes.Interface {
+	return &clientWithPodLogs{
+		Interface: client,
+		logs:      logs,
+	}
+}
+
+type clientWithPodLogs struct {
+	kubernetes.Interface
+	logs map[string]string
+}
+
+func (c *clientWithPodLogs) CoreV1() typedcorev1.CoreV1Interface {
+	return &coreV1WithPodLogs{
+		CoreV1Interface: c.Interface.CoreV1(),
+		logs:            c.logs,
+	}
+}
+
+type coreV1WithPodLogs struct {
+	typedcorev1.CoreV1Interface
+	logs map[string]string
+}
+
+func (c *coreV1WithPodLogs) Pods(namespace string) typedcorev1.PodInterface {
+	return &podsWithCustomLogs{
+		PodInterface: c.CoreV1Interface.Pods(namespace),
+		logs:         c.logs,
+		namespace:    namespace,
+	}
+}
+
+type podsWithCustomLogs struct {
+	typedcorev1.PodInterface
+	logs      map[string]string
+	namespace string
+}
+
+func (p *podsWithCustomLogs) GetLogs(name string, opts *v1.PodLogOptions) *restclient.Request {
+	fakeClient := &fakerest.RESTClient{
+		Client: fakerest.CreateHTTPClient(func(request *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(p.logs[name])),
+			}, nil
+		}),
+		NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
+		GroupVersion:         v1.SchemeGroupVersion,
+		VersionedAPIPath:     fmt.Sprintf("/api/v1/namespaces/%s/pods/%s/log", p.namespace, name),
+	}
+
+	return fakeClient.Request()
+}

--- a/pkg/fake/spdy_executor.go
+++ b/pkg/fake/spdy_executor.go
@@ -22,41 +22,61 @@ import (
 	"context"
 	"net/url"
 
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
 	"github.com/submariner-io/admiral/pkg/resource"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
 )
 
-type fakeExecutor struct {
-	stdout string
-	stderr string
-	err    error
+type SPDYExecutor struct {
+	Stdout     string
+	Stderr     string
+	Err        error
+	URLMatcher types.GomegaMatcher
 }
 
 func SetSPDYExecutor(stdout, stderr string, err error) {
-	resource.NewSPDYExecutor = func(_ *rest.Config, _ string, _ *url.URL) (remotecommand.Executor, error) {
-		return &fakeExecutor{stdout: stdout, stderr: stderr, err: err}, nil
+	SetSPDYExecutors(SPDYExecutor{Stdout: stdout, Stderr: stderr, Err: err})
+}
+
+func SetSPDYExecutors(executors ...SPDYExecutor) {
+	resource.NewSPDYExecutor = func(_ *rest.Config, _ string, url *url.URL) (remotecommand.Executor, error) {
+		for _, e := range executors {
+			if e.URLMatcher == nil {
+				return &e, nil
+			}
+
+			ok, err := e.URLMatcher.Match(url.String())
+			Expect(err).ToNot(HaveOccurred())
+
+			if ok {
+				return &e, nil
+			}
+		}
+
+		return &SPDYExecutor{}, nil
 	}
 }
 
-func (f *fakeExecutor) Stream(options remotecommand.StreamOptions) error {
+func (f *SPDYExecutor) Stream(options remotecommand.StreamOptions) error {
 	return f.StreamWithContext(context.TODO(), options)
 }
 
-func (f *fakeExecutor) StreamWithContext(_ context.Context, options remotecommand.StreamOptions) error {
-	if f.err != nil {
-		return f.err
+func (f *SPDYExecutor) StreamWithContext(_ context.Context, options remotecommand.StreamOptions) error {
+	if f.Err != nil {
+		return f.Err
 	}
 
 	if options.Stdout != nil {
-		_, err := options.Stdout.Write([]byte(f.stdout))
+		_, err := options.Stdout.Write([]byte(f.Stdout))
 		if err != nil {
 			return err
 		}
 	}
 
 	if options.Stderr != nil {
-		_, err := options.Stderr.Write([]byte(f.stderr))
+		_, err := options.Stderr.Write([]byte(f.Stderr))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
See commits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * New test utility enables testing Kubernetes pod log reading without real API server access.
  * Enhanced test executor now supports URL-based selection and multiple executor configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->