### PR TITLE
Fix wsl_v5 linter warnings reported in golangci-lint 2.9.0

### DIFF
--- a/pkg/resource/interface_test.go
+++ b/pkg/resource/interface_test.go
@@ -122,6 +122,7 @@ var _ = Describe("Interface", func() {
 				Type:   "type",
 				Status: metav1.ConditionTrue,
 			})
+
 			return s
 		})
 	})

--- a/pkg/workqueue/queue_test.go
+++ b/pkg/workqueue/queue_test.go
@@ -245,6 +245,7 @@ var _ = Describe("Work Queue", func() {
 			}
 
 			done := make(chan struct{})
+
 			go func() {
 				for i := 1; i <= itemCount; i++ {
 					Eventually(itemCh).Should(Receive())


### PR DESCRIPTION
Add blank lines before return and go statements to satisfy wsl_v5 whitespace requirements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Applied minor formatting improvements to test files for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->