### PR TITLE
Add configurable number of workers for workqueues

### DIFF
--- a/pkg/workqueue/config.go
+++ b/pkg/workqueue/config.go
@@ -32,6 +32,7 @@ const (
 	BucketRateLimiterItemsPerSecKey = "bucket-rate-limiter-items-per-sec"
 	BucketRateLimiterMaxBurstKey    = "bucket-rate-limiter-max-burst"
 	MaxVerbosityKey                 = "max-verbosity"
+	NumWorkersKey                   = "num-workers"
 )
 
 type Config struct {
@@ -41,6 +42,7 @@ type Config struct {
 	BucketRateLimiterItemsPerSec int
 	BucketRateLimiterMaxBurst    int
 	MaxVerbosity                 int
+	NumWorkers                   int
 }
 
 func DefaultConfig() Config {
@@ -50,6 +52,7 @@ func DefaultConfig() Config {
 		OverallRateLimiterMaxDelay:   5 * time.Minute,
 		BucketRateLimiterItemsPerSec: 10,
 		BucketRateLimiterMaxBurst:    500,
+		NumWorkers:                   1,
 	}
 }
 
@@ -74,6 +77,7 @@ func ConfigFromGlobal(keyPrefix string, defaultConfig *Config) *Config {
 	config.BucketRateLimiterMaxBurst = global.Get(ToConfigMapDataKey(keyPrefix, BucketRateLimiterMaxBurstKey),
 		config.BucketRateLimiterMaxBurst)
 	config.MaxVerbosity = global.Get(ToConfigMapDataKey(keyPrefix, MaxVerbosityKey), config.MaxVerbosity)
+	config.NumWorkers = global.Get(ToConfigMapDataKey(keyPrefix, NumWorkersKey), config.NumWorkers)
 
 	return &config
 }

--- a/pkg/workqueue/config_test.go
+++ b/pkg/workqueue/config_test.go
@@ -35,6 +35,7 @@ var customConfig = workqueue.Config{
 	BucketRateLimiterItemsPerSec: 99,
 	BucketRateLimiterMaxBurst:    9999,
 	MaxVerbosity:                 2,
+	NumWorkers:                   3,
 }
 
 var _ = Describe("DefaultConfigIfNil", func() {
@@ -81,6 +82,7 @@ var _ = Describe("ConfigFromGlobal", func() {
 					workqueue.ToConfigMapDataKey(keyPrefix, workqueue.BucketRateLimiterItemsPerSecKey): "99",
 					workqueue.ToConfigMapDataKey(keyPrefix, workqueue.BucketRateLimiterMaxBurstKey):    "999",
 					workqueue.ToConfigMapDataKey(keyPrefix, workqueue.MaxVerbosityKey):                 "2",
+					workqueue.ToConfigMapDataKey(keyPrefix, workqueue.NumWorkersKey):                   "5",
 				},
 			})
 			Expect(mustConfigFromGlobal(keyPrefix, nil)).To(Equal(workqueue.Config{
@@ -90,6 +92,7 @@ var _ = Describe("ConfigFromGlobal", func() {
 				BucketRateLimiterItemsPerSec: 99,
 				BucketRateLimiterMaxBurst:    999,
 				MaxVerbosity:                 2,
+				NumWorkers:                   5,
 			}))
 		})
 	})
@@ -114,6 +117,7 @@ var _ = Describe("ConfigFromGlobal", func() {
 					BucketRateLimiterItemsPerSec: 99,
 					BucketRateLimiterMaxBurst:    workqueue.DefaultConfig().BucketRateLimiterMaxBurst,
 					MaxVerbosity:                 2,
+					NumWorkers:                   1,
 				}))
 			})
 		})
@@ -127,6 +131,7 @@ var _ = Describe("ConfigFromGlobal", func() {
 					BucketRateLimiterItemsPerSec: 99,
 					BucketRateLimiterMaxBurst:    customConfig.BucketRateLimiterMaxBurst,
 					MaxVerbosity:                 2,
+					NumWorkers:                   3,
 				}))
 			})
 		})

--- a/pkg/workqueue/queue.go
+++ b/pkg/workqueue/queue.go
@@ -59,6 +59,7 @@ type queueType struct {
 	priorityQueue *PriorityQueue
 	name          string
 	logger        log.Logger
+	numWorkers    int
 }
 
 func New(name string) Interface {
@@ -102,7 +103,8 @@ func NewWithConfig(name string, config Config) Interface {
 					}),
 				}),
 			}),
-		name: name,
+		name:       name,
+		numWorkers: config.NumWorkers,
 	}
 
 	q.logger.SetMaxVerbosity(config.MaxVerbosity)
@@ -131,11 +133,20 @@ func (q *queueType) EnqueueWithOpts(obj any, opts EnqueueOpts) {
 	}
 }
 
+// Run starts NumWorkers goroutines that concurrently process items from the queue.
+// When NumWorkers > 1, the ProcessFunc must be safe for concurrent invocation.
 func (q *queueType) Run(process ProcessFunc) {
-	go func() {
-		for q.processNextWorkItem(process) {
-		}
-	}()
+	numWorkers := q.numWorkers
+	if numWorkers <= 0 {
+		numWorkers = 1
+	}
+
+	for range numWorkers {
+		go func() {
+			for q.processNextWorkItem(process) {
+			}
+		}()
+	}
 }
 
 func (q *queueType) processNextWorkItem(process ProcessFunc) bool {

--- a/pkg/workqueue/queue_test.go
+++ b/pkg/workqueue/queue_test.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -286,6 +287,85 @@ var _ = Describe("Work Queue", func() {
 
 			It("should not affect functionality", func() {
 			})
+		})
+	})
+
+	Context("with multiple workers", func() {
+		var (
+			processedItems sync.Map
+			maxConcurrent  atomic.Int32
+			processingGate chan struct{}
+		)
+
+		BeforeEach(func() {
+			processedItems = sync.Map{}
+			maxConcurrent = atomic.Int32{}
+			processingGate = make(chan struct{})
+
+			c := workqueue.DefaultConfig()
+			c.NumWorkers = 5
+			c.ItemRateLimiterBaseDelay = 0
+			config = &c
+
+			var currentActive atomic.Int32
+
+			processFn = func(key, _, _ string) (bool, error) {
+				defer GinkgoRecover()
+
+				// Track concurrent execution
+				current := currentActive.Add(1)
+
+				// Update max concurrent if needed
+				for {
+					currentMax := maxConcurrent.Load()
+					if current <= currentMax || maxConcurrent.CompareAndSwap(currentMax, current) {
+						break
+					}
+				}
+
+				// Wait for gate to open to ensure items pile up
+				<-processingGate
+
+				// Simulate some work
+				time.Sleep(10 * time.Millisecond)
+
+				// Mark item as processed
+				processedItems.Store(key, true)
+
+				currentActive.Add(-1)
+
+				return false, nil
+			}
+		})
+
+		It("should process items concurrently with multiple workers", func() {
+			itemCount := 500
+
+			for i := 1; i <= itemCount; i++ {
+				wq.EnqueueWithOpts(cache.ExplicitKey("item"+strconv.Itoa(i)),
+					workqueue.EnqueueOpts{Priority: workqueue.NormalPriority, RateLimited: false})
+			}
+
+			// Give workers time to pick up items and block on the gate
+			time.Sleep(500 * time.Millisecond)
+
+			// Close the gate to allow all workers to proceed
+			close(processingGate)
+
+			// Wait for all items to be processed
+			Eventually(func(g Gomega) {
+				count := 0
+				processedItems.Range(func(_, _ any) bool {
+					count++
+					return true
+				})
+
+				g.Expect(count).To(Equal(itemCount))
+			}).Within(5 * time.Second).Should(Succeed())
+
+			// Verify that multiple workers were active concurrently
+			Expect(maxConcurrent.Load()).To(BeNumerically(">", 1), "Expected multiple workers to be active concurrently")
+			Expect(maxConcurrent.Load()).To(BeNumerically("<=", 5), "Expected at most 5 workers to be active concurrently")
 		})
 	})
 


### PR DESCRIPTION
Introduce `NumWorkers` configuration to allow multiple concurrent workers processing items from the same workqueue, improving throughput for parallel processing scenarios.

Fixes https://github.com/submariner-io/admiral/issues/1292


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Work queue configuration now supports configurable concurrent workers, enabling parallel processing of tasks instead of sequential execution.

* **Tests**
  * Added comprehensive tests validating concurrent worker behavior, including verification that all items are processed correctly and concurrent execution operates within configured worker limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->