### PR TITLE
Add syncer metrics for federation, transform and queue wait time

### DIFF
--- a/pkg/syncer/broker/syncer.go
+++ b/pkg/syncer/broker/syncer.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/submariner-io/admiral/pkg/federate"
 	"github.com/submariner-io/admiral/pkg/global"
 	"github.com/submariner-io/admiral/pkg/log"
@@ -111,8 +110,8 @@ type ResourceConfig struct {
 	// BrokerWorkQueueConfig if specified, configures the underlying work queue for processing broker resources.
 	BrokerWorkQueueConfig *workqueue.Config
 
-	// SyncCounterOpts used to pass name and help text to resource syncer Gauge
-	SyncCounterOpts *prometheus.GaugeOpts
+	// Metrics if specified, configures optional Prometheus metrics for federation, transform, and queue operations.
+	Metrics syncer.MetricsConfig
 }
 
 type SyncerConfig struct {
@@ -214,18 +213,7 @@ func NewSyncer(config SyncerConfig) (*Syncer, error) { //nolint:gocritic // Mini
 	for i := range config.ResourceConfigs {
 		rc := &config.ResourceConfigs[i]
 
-		var syncCounter *prometheus.GaugeVec
-		if rc.SyncCounterOpts != nil {
-			syncCounter = prometheus.NewGaugeVec(
-				*rc.SyncCounterOpts,
-				[]string{
-					syncer.DirectionLabel,
-					syncer.OperationLabel,
-					syncer.SyncerNameLabel,
-				},
-			)
-			prometheus.MustRegister(syncCounter)
-		}
+		metrics := syncer.ResolveMetricsConfig(rc.Metrics)
 
 		federator := rc.BrokerFederator
 		if federator == nil {
@@ -255,7 +243,7 @@ func NewSyncer(config SyncerConfig) (*Syncer, error) { //nolint:gocritic // Mini
 			WorkQueueConfig:     rc.LocalWorkQueueConfig,
 			Scheme:              config.Scheme,
 			ResyncPeriod:        rc.LocalResyncPeriod,
-			SyncCounter:         syncCounter,
+			Metrics:             metrics,
 			MaxLogVerbosity:     config.MaxLogVerbosity,
 		})
 		if err != nil {
@@ -295,7 +283,7 @@ func NewSyncer(config SyncerConfig) (*Syncer, error) { //nolint:gocritic // Mini
 			WorkQueueConfig:     rc.BrokerWorkQueueConfig,
 			Scheme:              config.Scheme,
 			ResyncPeriod:        rc.BrokerResyncPeriod,
-			SyncCounter:         syncCounter,
+			Metrics:             metrics,
 			NamespaceInformer:   config.NamespaceInformer,
 			MaxLogVerbosity:     config.MaxLogVerbosity,
 		})

--- a/pkg/syncer/broker/syncer_test.go
+++ b/pkg/syncer/broker/syncer_test.go
@@ -179,7 +179,7 @@ var _ = Describe("Broker Syncer", func() {
 
 	When("a local resource is created in the local datastore", func() {
 		BeforeEach(func() {
-			config.ResourceConfigs[0].SyncCounterOpts = &prometheus.GaugeOpts{
+			config.ResourceConfigs[0].Metrics.SyncCounterOpts = &prometheus.GaugeOpts{
 				Namespace: "ns",
 				Name:      utilrand.String(5),
 			}

--- a/pkg/syncer/metrics.go
+++ b/pkg/syncer/metrics.go
@@ -1,0 +1,250 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package syncer
+
+import (
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// MetricsConfig configures optional Prometheus metrics for syncer operations.
+// For each metric, either pass Opts to let the syncer create and register it,
+// or pass a pre-created collector to share it across syncers.
+//
+// When a MetricsConfig is shared between multiple syncers (e.g. the local and
+// remote syncers created by broker/syncer.go), callers should pre-resolve
+// once and pass the live collectors.
+type MetricsConfig struct {
+	// SyncCounterOpts if specified, used to create a gauge to record sync counter metrics.
+	// Alternatively the gauge can be created directly and passed via SyncCounter,
+	// in which case SyncCounterOpts is ignored.
+	SyncCounterOpts *prometheus.GaugeOpts
+
+	// SyncCounter if specified, used to record counter metrics.
+	SyncCounter *prometheus.GaugeVec
+
+	// Federation duration in ms (Distribute/Delete).
+	FederationDurationMsOpts *prometheus.HistogramOpts
+	FederationDurationMs     *prometheus.HistogramVec
+
+	// Transform function duration in ms.
+	TransformDurationMsOpts *prometheus.HistogramOpts
+	TransformDurationMs     *prometheus.HistogramVec
+
+	// Time items spend waiting in the work queue, in ms.
+	QueueWaitDurationMsOpts *prometheus.HistogramOpts
+	QueueWaitDurationMs     *prometheus.HistogramVec
+
+	// Queue depth sampled on each enqueue/dequeue. Histogram captures the
+	// distribution so you can query max via histogram_quantile(1.0, ...).
+	QueueLengthOpts *prometheus.HistogramOpts
+	QueueLength     *prometheus.HistogramVec
+}
+
+var (
+	defaultDurationMsBuckets  = []float64{1, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000}
+	defaultQueueLengthBuckets = []float64{0, 1, 2, 3, 5, 8, 10, 15, 20, 50, 100, 500}
+)
+
+type syncerMetrics struct {
+	MetricsConfig
+	enqueueTimes sync.Map
+}
+
+// resolveHistogram creates and registers a HistogramVec from opts if the collector is nil.
+// Returns the existing or newly created collector, and nils out the opts pointer field on creation.
+func resolveHistogram(collector **prometheus.HistogramVec, opts **prometheus.HistogramOpts,
+	defaultBuckets []float64, labels []string,
+) {
+	if *collector != nil || *opts == nil {
+		return
+	}
+
+	o := **opts
+	if o.Buckets == nil {
+		o.Buckets = defaultBuckets
+	}
+
+	*collector = prometheus.NewHistogramVec(o, labels)
+	prometheus.MustRegister(*collector)
+
+	*opts = nil
+}
+
+// ResolveMetricsConfig pre-resolves any Opts-based fields in the MetricsConfig
+// into live HistogramVec collectors. The returned config has live collectors set
+// and Opts fields niled out. This is useful when sharing a MetricsConfig between
+// multiple syncers (e.g. broker local and remote syncers) to avoid duplicate
+// registration.
+//
+//nolint:gocritic // hugeParam: this function is used in setup so copying MetricsConfig is negligible.
+func ResolveMetricsConfig(cfg MetricsConfig) MetricsConfig {
+	resolved := cfg
+
+	metricLabels := []string{DirectionLabel, OperationLabel, SyncerNameLabel}
+	queueLabels := []string{SyncerNameLabel}
+
+	if resolved.SyncCounter == nil && resolved.SyncCounterOpts != nil {
+		resolved.SyncCounter = prometheus.NewGaugeVec(
+			*resolved.SyncCounterOpts,
+			metricLabels,
+		)
+		prometheus.MustRegister(resolved.SyncCounter)
+		resolved.SyncCounterOpts = nil
+	}
+
+	resolveHistogram(&resolved.FederationDurationMs, &resolved.FederationDurationMsOpts, defaultDurationMsBuckets, metricLabels)
+	resolveHistogram(&resolved.TransformDurationMs, &resolved.TransformDurationMsOpts, defaultDurationMsBuckets, metricLabels)
+	resolveHistogram(&resolved.QueueWaitDurationMs, &resolved.QueueWaitDurationMsOpts, defaultDurationMsBuckets, queueLabels)
+	resolveHistogram(&resolved.QueueLength, &resolved.QueueLengthOpts, defaultQueueLengthBuckets, queueLabels)
+
+	return resolved
+}
+
+//nolint:gocritic // hugeParam: this function is used in setup so copying MetricsConfig is negligible.
+func newSyncerMetrics(cfg MetricsConfig) *syncerMetrics {
+	resolved := ResolveMetricsConfig(cfg)
+	markOwnership(&resolved, &cfg)
+
+	return &syncerMetrics{
+		MetricsConfig: resolved,
+	}
+}
+
+// markOwnership resets Opts fields on the resolved config for collectors that
+// we created ourselves using these fields so we know to unregister them later.
+func markOwnership(resolved, original *MetricsConfig) {
+	if original.SyncCounterOpts != nil && original.SyncCounter == nil {
+		resolved.SyncCounterOpts = original.SyncCounterOpts
+	}
+
+	if original.FederationDurationMsOpts != nil && original.FederationDurationMs == nil {
+		resolved.FederationDurationMsOpts = original.FederationDurationMsOpts
+	}
+
+	if original.TransformDurationMsOpts != nil && original.TransformDurationMs == nil {
+		resolved.TransformDurationMsOpts = original.TransformDurationMsOpts
+	}
+
+	if original.QueueWaitDurationMsOpts != nil && original.QueueWaitDurationMs == nil {
+		resolved.QueueWaitDurationMsOpts = original.QueueWaitDurationMsOpts
+	}
+
+	if original.QueueLengthOpts != nil && original.QueueLength == nil {
+		resolved.QueueLengthOpts = original.QueueLengthOpts
+	}
+}
+
+func (m *syncerMetrics) unregister() {
+	if m.SyncCounterOpts != nil {
+		prometheus.Unregister(m.SyncCounter)
+	}
+
+	if m.FederationDurationMsOpts != nil {
+		prometheus.Unregister(m.FederationDurationMs)
+	}
+
+	if m.TransformDurationMsOpts != nil {
+		prometheus.Unregister(m.TransformDurationMs)
+	}
+
+	if m.QueueWaitDurationMsOpts != nil {
+		prometheus.Unregister(m.QueueWaitDurationMs)
+	}
+
+	if m.QueueLengthOpts != nil {
+		prometheus.Unregister(m.QueueLength)
+	}
+}
+
+func (m *syncerMetrics) incSyncCounter(direction SyncDirection, op Operation, syncerName string) {
+	if m.SyncCounter == nil {
+		return
+	}
+
+	m.SyncCounter.With(prometheus.Labels{
+		DirectionLabel:  direction.String(),
+		OperationLabel:  op.String(),
+		SyncerNameLabel: syncerName,
+	}).Inc()
+}
+
+func (m *syncerMetrics) observeFederationDurationMs(direction SyncDirection, op Operation, syncerName string, duration time.Duration) {
+	if m.FederationDurationMs == nil {
+		return
+	}
+
+	m.FederationDurationMs.With(prometheus.Labels{
+		DirectionLabel:  direction.String(),
+		OperationLabel:  op.String(),
+		SyncerNameLabel: syncerName,
+	}).Observe(float64(duration.Milliseconds()))
+}
+
+func (m *syncerMetrics) observeTransformDurationMs(direction SyncDirection, op Operation, syncerName string, duration time.Duration) {
+	if m.TransformDurationMs == nil {
+		return
+	}
+
+	m.TransformDurationMs.With(prometheus.Labels{
+		DirectionLabel:  direction.String(),
+		OperationLabel:  op.String(),
+		SyncerNameLabel: syncerName,
+	}).Observe(float64(duration.Milliseconds()))
+}
+
+func (m *syncerMetrics) observeQueueWaitDurationMs(syncerName string, duration time.Duration) {
+	if m.QueueWaitDurationMs == nil {
+		return
+	}
+
+	m.QueueWaitDurationMs.With(prometheus.Labels{
+		SyncerNameLabel: syncerName,
+	}).Observe(float64(duration.Milliseconds()))
+}
+
+func (m *syncerMetrics) observeQueueLength(syncerName string, length int) {
+	if m.QueueLength == nil {
+		return
+	}
+
+	m.QueueLength.With(prometheus.Labels{
+		SyncerNameLabel: syncerName,
+	}).Observe(float64(length))
+}
+
+func (m *syncerMetrics) trackEnqueue(key string) {
+	if m.QueueWaitDurationMs == nil {
+		return
+	}
+
+	m.enqueueTimes.Store(key, time.Now())
+}
+
+func (m *syncerMetrics) recordDequeue(syncerName, key string) {
+	if m.QueueWaitDurationMs == nil {
+		return
+	}
+
+	if enqueueTime, ok := m.enqueueTimes.LoadAndDelete(key); ok {
+		m.observeQueueWaitDurationMs(syncerName, time.Since(enqueueTime.(time.Time)))
+	}
+}

--- a/pkg/syncer/notifications.go
+++ b/pkg/syncer/notifications.go
@@ -20,6 +20,7 @@ package syncer
 
 import (
 	"reflect"
+	"time"
 
 	"github.com/submariner-io/admiral/pkg/federate"
 	"github.com/submariner-io/admiral/pkg/log"
@@ -42,6 +43,8 @@ func (r *resourceSyncer) onCreate(obj any, isInInitialList bool) {
 
 	r.operationQueues.add(key, createOperation(resource))
 
+	r.metrics.trackEnqueue(key)
+
 	// If this is from the initial listing on startup then enqueue with low priority to prioritize newly
 	// created or updated resources. Also don't enqueue with rate limiting since we already know this is
 	// part of a one-time burst.
@@ -50,6 +53,8 @@ func (r *resourceSyncer) onCreate(obj any, isInInitialList bool) {
 	} else {
 		r.workQueue.Enqueue(resource)
 	}
+
+	r.metrics.observeQueueLength(r.config.Name, r.workQueue.Len())
 }
 
 func (r *resourceSyncer) onUpdate(oldObj, newObj any) {
@@ -67,6 +72,10 @@ func (r *resourceSyncer) onUpdate(oldObj, newObj any) {
 		return
 	}
 
+	key, _ := cache.MetaNamespaceKeyFunc(newResource)
+
+	r.metrics.trackEnqueue(key)
+
 	// If the resource version didn't change, that indicates a re-sync by the informer so enqueue at low priority.
 	// We want to prioritize processing resources that did actually change.
 	if oldResource.GetResourceVersion() == newResource.GetResourceVersion() {
@@ -74,6 +83,8 @@ func (r *resourceSyncer) onUpdate(oldObj, newObj any) {
 	} else {
 		r.workQueue.Enqueue(newObj)
 	}
+
+	r.metrics.observeQueueLength(r.config.Name, r.workQueue.Len())
 }
 
 func (r *resourceSyncer) onDelete(obj any) {
@@ -92,7 +103,12 @@ func (r *resourceSyncer) onDelete(obj any) {
 	key, _ := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 
 	r.operationQueues.add(key, deleteOperation(resource))
+
+	r.metrics.trackEnqueue(key)
+
 	r.workQueue.Enqueue(obj)
+
+	r.metrics.observeQueueLength(r.config.Name, r.workQueue.Len())
 }
 
 func (r *resourceSyncer) onSuccessfulSync(resource, converted runtime.Object, op Operation) bool {
@@ -120,7 +136,12 @@ func (r *resourceSyncer) transform(from *unstructured.Unstructured, key string,
 
 	converted := r.mustConvert(from)
 
+	transformStart := time.Now()
+
 	transformed, requeue := r.config.Transform(converted, r.workQueue.NumRequeues(key), op)
+
+	r.metrics.observeTransformDurationMs(r.config.Direction, op, r.config.Name, time.Since(transformStart))
+
 	if transformed == nil || reflect.ValueOf(transformed).IsNil() {
 		r.log.V(log.DEBUG).Infof("Syncer %q: transform function returned nil - not syncing - requeue: %v", r.config.Name, requeue)
 		return nil, nil, requeue

--- a/pkg/syncer/process_resource.go
+++ b/pkg/syncer/process_resource.go
@@ -20,6 +20,7 @@ package syncer
 
 import (
 	"context"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/log"
@@ -32,6 +33,8 @@ import (
 )
 
 func (r *resourceSyncer) processNextWorkItem(key, name, ns string) (bool, error) {
+	r.metrics.recordDequeue(r.config.Name, key)
+
 	resourceOp := r.operationQueues.peek(key)
 
 	if ns == namespaceKey {
@@ -111,7 +114,12 @@ func (r *resourceSyncer) handleCreatedOrUpdated(key string, created *unstructure
 
 		r.log.V(log.DEBUG).Infof("Syncer %q syncing resource %q", r.config.Name, resource.GetName())
 
+		federateStart := time.Now()
+
 		err = r.config.Federator.Distribute(context.Background(), resource)
+
+		r.metrics.observeFederationDurationMs(r.config.Direction, op, r.config.Name, time.Since(federateStart))
+
 		if err != nil || r.onSuccessfulSync(resource, transformed, op) {
 			namespace := resourceUtil.ExtractMissingNamespaceFromErr(err)
 			if namespace != "" {
@@ -149,7 +157,12 @@ func (r *resourceSyncer) handleDeleted(key string, deletedResource *unstructured
 
 		deleted := true
 
+		federateStart := time.Now()
+
 		err := r.config.Federator.Delete(context.Background(), resource)
+
+		r.metrics.observeFederationDurationMs(r.config.Direction, Delete, r.config.Name, time.Since(federateStart))
+
 		if apierrors.IsNotFound(err) {
 			r.log.V(log.DEBUG).Infof("Syncer %q: resource %q not found", r.config.Name, resource.GetName())
 

--- a/pkg/syncer/resource_syncer.go
+++ b/pkg/syncer/resource_syncer.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/submariner-io/admiral/pkg/federate"
 	"github.com/submariner-io/admiral/pkg/log"
 	resourceUtil "github.com/submariner-io/admiral/pkg/resource"
@@ -145,19 +144,7 @@ func newResourceSyncer(config *ResourceSyncerConfig) (*resourceSyncer, error) {
 		syncer.config.DrainWorkQueueTimeout = time.Second * 5
 	}
 
-	if syncer.config.SyncCounter != nil {
-		syncer.syncCounter = syncer.config.SyncCounter
-	} else if syncer.config.SyncCounterOpts != nil {
-		syncer.syncCounter = prometheus.NewGaugeVec(
-			*syncer.config.SyncCounterOpts,
-			[]string{
-				DirectionLabel,
-				OperationLabel,
-				SyncerNameLabel,
-			},
-		)
-		prometheus.MustRegister(syncer.syncCounter)
-	}
+	syncer.metrics = newSyncerMetrics(syncer.config.Metrics)
 
 	workqueueConfig := workqueue.DefaultConfigIfNil(syncer.config.WorkQueueConfig)
 	if config.MaxLogVerbosity > workqueueConfig.MaxVerbosity {
@@ -222,9 +209,7 @@ func (r *resourceSyncer) Start(stopCh <-chan struct{}) error {
 
 	go func() {
 		defer func() {
-			if r.config.SyncCounterOpts != nil {
-				prometheus.Unregister(r.syncCounter)
-			}
+			r.metrics.unregister()
 
 			if r.unregHandler != nil {
 				r.unregHandler()
@@ -340,13 +325,7 @@ func (r *resourceSyncer) ListResourcesBySelector(selector k8slabels.Selector) []
 }
 
 func (r *resourceSyncer) incOpCounter(op Operation) {
-	if r.syncCounter != nil {
-		r.syncCounter.With(prometheus.Labels{
-			DirectionLabel:  r.config.Direction.String(),
-			OperationLabel:  op.String(),
-			SyncerNameLabel: r.config.Name,
-		}).Inc()
-	}
+	r.metrics.incSyncCounter(r.config.Direction, op, r.config.Name)
 }
 
 func (r *resourceSyncer) mustConvert(from any) runtime.Object {

--- a/pkg/syncer/resource_syncer_test.go
+++ b/pkg/syncer/resource_syncer_test.go
@@ -72,9 +72,19 @@ func testLocalToRemote() {
 	d := newTestDriver(test.LocalNamespace, "", syncer.LocalToRemote)
 
 	BeforeEach(func() {
-		d.config.SyncCounterOpts = &prometheus.GaugeOpts{
-			Namespace: "ns",
-			Name:      "test",
+		d.config.Metrics = syncer.MetricsConfig{
+			SyncCounterOpts: &prometheus.GaugeOpts{
+				Name: "sync-counter",
+			},
+			FederationDurationMsOpts: &prometheus.HistogramOpts{
+				Name: "federation",
+			},
+			QueueWaitDurationMsOpts: &prometheus.HistogramOpts{
+				Name: "queue-wait",
+			},
+			QueueLengthOpts: &prometheus.HistogramOpts{
+				Name: "queue-length",
+			},
 		}
 	})
 
@@ -119,7 +129,7 @@ func testRemoteToLocalWithLocalClusterID() {
 	d := newTestDriver(test.RemoteNamespace, "local", syncer.RemoteToLocal)
 
 	BeforeEach(func() {
-		d.config.SyncCounter = prometheus.NewGaugeVec(
+		d.config.Metrics.SyncCounter = prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{},
 			[]string{
 				syncer.DirectionLabel,

--- a/pkg/syncer/transform_func_test.go
+++ b/pkg/syncer/transform_func_test.go
@@ -24,6 +24,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/submariner-io/admiral/pkg/syncer"
 	"github.com/submariner-io/admiral/pkg/syncer/test"
 	corev1 "k8s.io/api/core/v1"
@@ -252,6 +253,12 @@ func newTransformFunctionTestDriver() *transformFuncTestDriver {
 		t.expOperation = make(chan syncer.Operation, 20)
 		t.transformed = test.NewPodWithImage(t.config.SourceNamespace, "transformed")
 		t.requeueOnOp = nil
+
+		t.config.Metrics = syncer.MetricsConfig{
+			TransformDurationMsOpts: &prometheus.HistogramOpts{
+				Name: "transform",
+			},
+		}
 
 		t.config.Transform = func(from runtime.Object, _ int, op syncer.Operation) (runtime.Object, bool) {
 			defer GinkgoRecover()

--- a/pkg/syncer/types.go
+++ b/pkg/syncer/types.go
@@ -21,7 +21,6 @@ package syncer
 import (
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/submariner-io/admiral/pkg/federate"
 	"github.com/submariner-io/admiral/pkg/log"
 	"github.com/submariner-io/admiral/pkg/workqueue"
@@ -163,19 +162,14 @@ type ResourceSyncerConfig struct {
 	// ResyncPeriod if non-zero, the period at which resources will be re-synced regardless if anything changed. Default is 0.
 	ResyncPeriod time.Duration
 
-	// SyncCounterOpts if specified, used to create a gauge to record counter metrics.
-	// Alternatively the gauge can be created directly and passed via the SyncCounter field,
-	// in which case SyncCounterOpts is ignored.
-	SyncCounterOpts *prometheus.GaugeOpts
-
-	// SyncCounter if specified, used to record counter metrics.
-	SyncCounter *prometheus.GaugeVec
-
 	// NamespaceInformer if specified, used to retry resources that initially failed due to missing namespace.
 	NamespaceInformer cache.SharedInformer
 
 	// WorkQueueConfig if specified, configures the underlying work queue
 	WorkQueueConfig *workqueue.Config
+
+	// Metrics if specified, configures optional Prometheus metrics for federation, transform, and queue operations.
+	Metrics MetricsConfig
 
 	// DrainWorkQueueTimeout configures the maximum amount of time to wait for the work queue to drain on shutdown.
 	// Default is 5 seconds.
@@ -194,7 +188,7 @@ type resourceSyncer struct {
 	config            ResourceSyncerConfig
 	operationQueues   *operationQueueMap
 	stopped           chan struct{}
-	syncCounter       *prometheus.GaugeVec
+	metrics           *syncerMetrics
 	stopCh            <-chan struct{}
 	log               log.Logger
 	missingNamespaces map[string]set.Set[string]

--- a/pkg/workqueue/queue.go
+++ b/pkg/workqueue/queue.go
@@ -44,6 +44,7 @@ type Interface interface {
 	Enqueue(obj any)
 	EnqueueWithOpts(obj any, opts EnqueueOpts)
 	NumRequeues(key string) int
+	Len() int
 	Run(process ProcessFunc)
 	ShutDown()
 	ShutDownWithDrain(ctx context.Context) error


### PR DESCRIPTION

Adds optional Prometheus histogram metrics to ResourceSyncer for observing federation latency, transform latency, queue wait time, and queue depth distribution.
Fixes #1294 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized, configurable metrics subsystem for syncers with optional custom collectors and default buckets.
  * Instrumentation added for enqueue/dequeue, transform, federation durations, queue wait time, queue length, and per-operation counters.
  * Work‑queue length query exposed for observability.
  * Configurable max log verbosity added for syncer components.

* **Tests**
  * Tests updated to initialize and validate the new metrics configuration and collectors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->