### PR TITLE
Change convention of using slash to dot to comply with ConfigMap regex

### DIFF
--- a/pkg/global/config.go
+++ b/pkg/global/config.go
@@ -33,10 +33,10 @@ type ValueType interface {
 }
 
 const (
-	K8sClientQPS         = "k8s.client/qps"
-	K8sClientBurst       = "k8s.client/burst"
-	K8sBrokerClientQPS   = "k8s.broker.client/qps"
-	K8sBrokerClientBurst = "k8s.broker.client/burst"
+	K8sClientQPS         = "k8s.client.qps"
+	K8sClientBurst       = "k8s.client.burst"
+	K8sBrokerClientQPS   = "k8s.broker.client.qps"
+	K8sBrokerClientBurst = "k8s.broker.client.burst"
 )
 
 var (

--- a/pkg/workqueue/config.go
+++ b/pkg/workqueue/config.go
@@ -83,5 +83,5 @@ func ConfigFromGlobal(keyPrefix string, defaultConfig *Config) *Config {
 }
 
 func ToConfigMapDataKey(prefix, name string) string {
-	return fmt.Sprintf("%s.workqueue/%s", prefix, name)
+	return fmt.Sprintf("%s.workqueue.%s", prefix, name)
 }


### PR DESCRIPTION
 Replace `/` with `.` in ConfigMap global keys

Fixes https://github.com/submariner-io/admiral/issues/1296

### Problem

Several global configuration keys used in the `submariner-global` expected ConfigMap to contain `/` characters (e.g., `k8s.client/qps`, `<resource>.workqueue/num-workers`). Kubernetes ConfigMap data keys must match `[-._a-zA-Z0-9]+`, so any key with `/` is rejected by the API server


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated configuration key format from slash-delimited to dot-delimited notation for Kubernetes client and broker settings and for workqueue keys, ensuring consistent global configuration key formatting across the system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->