### PR TITLE
Automated backport of #1297: Replace slash with dot in ConfigMap keys for K8s compliance

### DIFF
--- a/pkg/workqueue/config.go
+++ b/pkg/workqueue/config.go
@@ -79,5 +79,5 @@ func ConfigFromGlobal(keyPrefix string, defaultConfig *Config) *Config {
 }
 
 func ToConfigMapDataKey(prefix, name string) string {
-	return fmt.Sprintf("%s.workqueue/%s", prefix, name)
+	return fmt.Sprintf("%s.workqueue.%s", prefix, name)
 }


### PR DESCRIPTION
Backport of #1297 on release-0.23.

#1297: Replace slash with dot in ConfigMap keys for K8s compliance

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated configuration key formatting to use dot notation instead of slash notation for improved consistency in configuration lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->