### PR TITLE
Automated backport of #1298: Replace slash with dot in ConfigMap keys for K8s compliance

### DIFF
--- a/pkg/workqueue/config.go
+++ b/pkg/workqueue/config.go
@@ -79,5 +79,5 @@ func ConfigFromGlobal(keyPrefix string, defaultConfig *Config) *Config {
 }
 
 func ToConfigMapDataKey(prefix, name string) string {
-	return fmt.Sprintf("%s.workqueue/%s", prefix, name)
+	return fmt.Sprintf("%s.workqueue.%s", prefix, name)
 }


### PR DESCRIPTION
Backport of #1298 on release-0.22.

#1298: Replace slash with dot in ConfigMap keys for K8s compliance

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Updated workqueue configuration key format: delimiter changed from "/" to "." notation in configuration settings lookups, affecting rate-limiter and max-verbosity configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->