### PR TITLE
Automated backport of #1298: Replace slash with dot in ConfigMap keys for K8s compliance

### DIFF
--- a/pkg/workqueue/config.go
+++ b/pkg/workqueue/config.go
@@ -106,5 +106,5 @@ func ConfigFromConfigMap(configMap *corev1.ConfigMap, keyPrefix string, defaultC
 }
 
 func ToConfigMapDataKey(prefix, name string) string {
-	return fmt.Sprintf("%s.workqueue/%s", prefix, name)
+	return fmt.Sprintf("%s.workqueue.%s", prefix, name)
 }


### PR DESCRIPTION
Backport of #1298 on release-0.20.

#1298: Replace slash with dot in ConfigMap keys for K8s compliance

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated config map data key formatting to use dot separators instead of slash separators for improved consistency and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->