### PR TITLE
Use contextual logging in util package

### DIFF
--- a/pkg/util/create_or_update.go
+++ b/pkg/util/create_or_update.go
@@ -24,6 +24,7 @@ import (
 	"slices"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/log"
 	"github.com/submariner-io/admiral/pkg/resource"
@@ -36,7 +37,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type OperationResult string
@@ -64,8 +64,6 @@ var backOff wait.Backoff = wait.Backoff{
 	Cap:      40 * time.Second,
 }
 
-var logger = log.Logger{Logger: logf.Log}
-
 type CreateOrUpdateOptions[T runtime.Object] struct {
 	Client         resource.Interface[T]
 	Obj            T
@@ -73,10 +71,6 @@ type CreateOrUpdateOptions[T runtime.Object] struct {
 	MutateOnCreate MutateFn[T]
 	// IdentifyingLabels is used to find an existing resource if GenerateName is set in the target resource.
 	IdentifyingLabels map[string]string
-}
-
-func init() {
-	logger.SetMaxVerbosity(0)
 }
 
 func CreateOrUpdateWithOptions[T runtime.Object](ctx context.Context, options CreateOrUpdateOptions[T]) (OperationResult, T, error) {
@@ -126,6 +120,7 @@ func maybeCreateOrUpdate[T runtime.Object](ctx context.Context, options CreateOr
 	result := OperationResultNone
 
 	objMeta := resource.MustToMeta(options.Obj)
+	logger := log.Logger{Logger: logr.FromContextOrDiscard(ctx)}
 
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		existing, err := getResource(ctx, &options)
@@ -262,6 +257,8 @@ func createResource[T runtime.Object](ctx context.Context, client resource.Inter
 
 		obj = mutated
 	}
+
+	logger := log.Logger{Logger: logr.FromContextOrDiscard(ctx)}
 
 	logger.V(log.DEBUG).Infof("Creating resource: %#v", obj)
 

--- a/pkg/util/create_or_update_test.go
+++ b/pkg/util/create_or_update_test.go
@@ -24,6 +24,7 @@ import (
 	"maps"
 	"time"
 
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/submariner-io/admiral/pkg/fake"
@@ -43,13 +44,14 @@ import (
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/testing"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 var _ = Describe("CreateAnew function", func() {
 	t := newCreateOrUpdateTestDiver()
 
 	createAnew := func(ctx context.Context) (runtime.Object, error) {
-		return util.CreateAnew(ctx, resource.ForDynamic(t.client),
+		return util.CreateAnew(t.ctx(ctx), resource.ForDynamic(t.client),
 			resource.MustToUnstructured(t.pod), metav1.CreateOptions{}, metav1.DeleteOptions{})
 	}
 
@@ -164,7 +166,7 @@ var _ = Describe("CreateOrUpdate function", func() {
 
 		options.Obj = resource.MustToUnstructured(t.pod)
 
-		result, retObj, err := util.CreateOrUpdateWithOptions(ctx, options)
+		result, retObj, err := util.CreateOrUpdateWithOptions(t.ctx(ctx), options)
 		if err != nil && expResult != util.OperationResultNone {
 			return err
 		}
@@ -188,7 +190,7 @@ var _ = Describe("CreateOrUpdate function", func() {
 
 		Context("and a mutation function specified", func() {
 			It("should invoke the function on create", func(ctx SpecContext) {
-				result, created, err := util.CreateOrUpdateWithOptions(ctx,
+				result, created, err := util.CreateOrUpdateWithOptions(t.ctx(ctx),
 					util.CreateOrUpdateOptions[*unstructured.Unstructured]{
 						Client: resource.ForDynamic(t.client),
 						Obj:    resource.MustToUnstructured(t.pod),
@@ -208,7 +210,7 @@ var _ = Describe("CreateOrUpdate function", func() {
 
 			Context("which returns an error", func() {
 				It("should return an error", func(ctx SpecContext) {
-					_, _, err := util.CreateOrUpdateWithOptions(ctx,
+					_, _, err := util.CreateOrUpdateWithOptions(t.ctx(ctx),
 						util.CreateOrUpdateOptions[*unstructured.Unstructured]{
 							Client: resource.ForDynamic(t.client),
 							Obj:    resource.MustToUnstructured(t.pod),
@@ -230,6 +232,7 @@ var _ = Describe("CreateOrUpdate function", func() {
 
 			It("should successfully create the resource", func(ctx SpecContext) {
 				Expect(createOrUpdate(ctx, util.OperationResultCreated)).To(Succeed())
+
 				actual := t.verifyPod(ctx)
 				Expect(actual.Name).To(HavePrefix("name-prefix-"))
 			})
@@ -308,7 +311,7 @@ var _ = Describe("Update function", func() {
 	t := newCreateOrUpdateTestDiver()
 
 	update := func(ctx context.Context) error {
-		return util.Update(ctx, resource.ForDynamic(t.client), resource.MustToUnstructured(t.pod),
+		return util.Update(t.ctx(ctx), resource.ForDynamic(t.client), resource.MustToUnstructured(t.pod),
 			t.mutateFn)
 	}
 
@@ -331,7 +334,7 @@ var _ = Describe("MustUpdate function", func() {
 	t := newCreateOrUpdateTestDiver()
 
 	mustUpdate := func(ctx context.Context) error {
-		return util.MustUpdate(ctx, resource.ForDynamic(t.client),
+		return util.MustUpdate(t.ctx(ctx), resource.ForDynamic(t.client),
 			resource.MustToUnstructured(t.pod), t.mutateFn)
 	}
 
@@ -393,6 +396,10 @@ func newCreateOrUpdateTestDiver() *createOrUpdateTestDriver {
 	})
 
 	return t
+}
+
+func (t *createOrUpdateTestDriver) ctx(ctx context.Context) context.Context {
+	return logr.NewContext(ctx, logf.Log)
 }
 
 func (t *createOrUpdateTestDriver) testGetFailure(doOper func(context.Context, util.OperationResult) error) {
@@ -587,7 +594,7 @@ func (t *createOrUpdateTestDriver) verifyPod(ctx context.Context) *corev1.Pod {
 	pod := t.pod.DeepCopy()
 
 	if pod.Name == "" {
-		list, err := t.client.List(ctx, metav1.ListOptions{})
+		list, err := t.client.List(t.ctx(ctx), metav1.ListOptions{})
 		Expect(err).To(Succeed())
 		Expect(scheme.Scheme.Convert(&list.Items[0], pod, nil)).To(Succeed())
 	}

--- a/pkg/util/helpers.go
+++ b/pkg/util/helpers.go
@@ -24,6 +24,7 @@ import (
 	"sync/atomic"
 
 	"github.com/pkg/errors"
+	"github.com/submariner-io/admiral/pkg/log"
 	"github.com/submariner-io/admiral/pkg/resource"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -33,6 +34,7 @@ import (
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const (
@@ -42,7 +44,11 @@ const (
 	StatusField      = "status"
 )
 
-var lastBadCertificate atomic.Value
+var (
+	lastBadCertificate atomic.Value
+	// helperLogger is used for error hooks which need to be package-level variables.
+	helperLogger = log.Logger{Logger: logf.Log}
+)
 
 var BuildRestMapper = func(restConfig *rest.Config) (meta.RESTMapper, error) {
 	discoveryClient, err := discovery.NewDiscoveryClientForConfig(restConfig)
@@ -146,8 +152,8 @@ func DeeplyEmpty(m map[string]any) bool {
 }
 
 var (
-	ErrorHook = logger.Errorf
-	FatalHook = logger.FatalfOnError
+	ErrorHook = helperLogger.Errorf
+	FatalHook = helperLogger.FatalfOnError
 )
 
 func AddCertificateErrorHandler(fatal bool) {


### PR DESCRIPTION
Remove static logger from _create_or_update.go_ and use context-based logging via `logr.FromContextOrDiscard()`. This allows callers to optionally provide a logger through the context, making logging opt-in rather than globally enabled/disabled.

The previous implementation had a race condition where the static logger was initialized with `logf.Log` at package init time, then `SetMaxVerbosity(0)` was called in `init()` to disable logging. However, if the global `logf.Log` logger sink was configured after the package was initialized, the `SetMaxVerbosity(0)` call would be ineffective, causing unwanted debug logs to appear. With contextual logging, the logger is retrieved at runtime from the context, eliminating this timing issue and giving callers explicit control over logging.

Changes:
    - Remove static logger and init() function from create_or_update.go
    - Retrieve logger from context in maybeCreateOrUpdate() and createResource()
    - Preserve static helperLogger in helpers.go for package-level error hooks that cannot use context
    - Update tests to pass a context logger



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved logging to use per-operation context-aware loggers for clearer, more accurate diagnostics across resource operations.
* **Tests**
  * Test harness updated to propagate and verify context-aware logging during test runs, improving test reliability and observability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->