### PR TITLE
Switch to govulncheck for Go scanning

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -106,24 +106,13 @@ jobs:
   vulnerability-scan:
     name: Vulnerability Scanning
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Check out the repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - name: Run Anchore vulnerability scanner
-        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2
-        id: scan
-        with:
-          path: "."
-          fail-build: true
-          severity-cutoff: high
-      - name: Show Anchore scan SARIF report
-        if: always()
-        run: cat ${{ steps.scan.outputs.sarif }}
-      - name: Upload Anchore scan SARIF report
-        if: always()
-        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225
-        with:
-          sarif_file: ${{ steps.scan.outputs.sarif }}
+      - name: Run govulncheck (producing a text report and failing the build if necessary)
+        run: make govulncheck
 
   yaml-lint:
     name: YAML

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -30,3 +30,49 @@ jobs:
           title: Broken link detected by periodic linting
           content-filepath: .github/ISSUE_TEMPLATE/broken-link.md
           labels: automated, broken link
+
+  maintained-branches:
+    name: List maintained branches
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
+      - name: Determine the supported branches (release-0.25 and later)
+        id: set-matrix
+        run: |
+          printf 'matrix={"branch":["devel"' >> $GITHUB_OUTPUT
+          printf ',"%s"' $(git branch -r --list 'origin/release-*' |
+            awk -F- '{ sub("origin/", ""); split($2, v, ".") } (v[1] > 0 || (v[1] == 0 && v[2] >= 18))') >> $GITHUB_OUTPUT
+          printf ']}' >> $GITHUB_OUTPUT
+
+  vulnerability-scan-periodic:
+    name: Vulnerability Scanning
+    if: github.repository_owner == 'submariner-io'
+    needs: maintained-branches
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.maintained-branches.outputs.matrix) }}
+    steps:
+      - name: Check out the repository
+        id: checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          ref: ${{ matrix.branch }}
+      - name: Run govulncheck (producing a SARIF report)
+        run: make govulncheck.sarif
+      - name: Upload SARIF report
+        if: always()
+        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13  # v4.35.1
+        with:
+          sarif_file: govulncheck.sarif
+          category: govulncheck-${{ matrix.branch }}
+          ref: ${{ steps.checkout.outputs.ref }}
+          sha: ${{ steps.checkout.outputs.commit }}

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -28,25 +28,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-
-  vulnerability-scan:
-    name: Vulnerability Scanning
-    if: github.repository_owner == 'submariner-io'
-    runs-on: ubuntu-latest
-    permissions:
-      security-events: write
-    steps:
-      - name: Check out the repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - name: Run Anchore vulnerability scanner
-        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2
-        id: scan
-        with:
-          path: "."
-          fail-build: false
-      - name: Show Anchore scan SARIF report
-        run: cat ${{ steps.scan.outputs.sarif }}
-      - name: Upload Anchore scan SARIF report
-        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225
-        with:
-          sarif_file: ${{ steps.scan.outputs.sarif }}


### PR DESCRIPTION
govulncheck only reports vulnerabilities in reachable packages, which will greatly reduce the number of false positives.

This changes CI linting to use govulncheck, using targets provided by Shipyard.

PR checks no longer upload SARIF reports, and SARIF uploads are changed to periodic rather than per-push. This ensures that security issues are caught in a timely fashion even if no development activity occurs in the repository.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Moved vulnerability scanning to a periodic job that runs across maintained release branches.
  * Removed inline vulnerability scan steps from regular workflows to simplify CI runs.
  * Switched to branch-scoped vulnerability reporting with centralized uploads to ensure scan results are produced and retained per branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->