### PR TITLE
Fix broker CA loading race condition

### DIFF
--- a/pkg/resource/rest.go
+++ b/pkg/resource/rest.go
@@ -42,22 +42,14 @@ var NewSPDYExecutor = remotecommand.NewSPDYExecutor
 func GetAuthorizedRestConfigFromData(ctx context.Context, apiServer, apiServerToken, caData string, tls *rest.TLSClientConfig,
 	gvr schema.GroupVersionResource, namespace string,
 ) (*rest.Config, bool, error) {
-	// First try a REST config without the CA trust chain
-	restConfig, err := BuildRestConfigFromData(apiServer, apiServerToken, "", tls)
+	// Always load the CA when provided to avoid startup race conditions where the API server
+	// may be temporarily unreachable, causing the no-CA attempt to fail with a non-x509 error.
+	restConfig, err := BuildRestConfigFromData(apiServer, apiServerToken, caData, tls)
 	if err != nil {
 		return nil, false, err
 	}
 
 	authorized, err := IsAuthorizedFor(ctx, restConfig, gvr, namespace)
-	if !authorized {
-		// Now try with the trust chain
-		restConfig, err = BuildRestConfigFromData(apiServer, apiServerToken, caData, tls)
-		if err != nil {
-			return nil, false, err
-		}
-
-		authorized, err = IsAuthorizedFor(ctx, restConfig, gvr, namespace)
-	}
 
 	return restConfig, authorized, err
 }
@@ -65,15 +57,10 @@ func GetAuthorizedRestConfigFromData(ctx context.Context, apiServer, apiServerTo
 func GetAuthorizedRestConfigFromFiles(ctx context.Context, apiServer, apiServerTokenFile, caFile string, tls *rest.TLSClientConfig,
 	gvr schema.GroupVersionResource, namespace string,
 ) (*rest.Config, bool, error) {
-	// First try a REST config without the CA trust chain
-	restConfig := BuildRestConfigFromFiles(apiServer, apiServerTokenFile, "", tls)
+	// Always load the CA when provided to avoid startup race conditions where the API server
+	// may be temporarily unreachable, causing the no-CA attempt to fail with a non-x509 error.
+	restConfig := BuildRestConfigFromFiles(apiServer, apiServerTokenFile, caFile, tls)
 	authorized, err := IsAuthorizedFor(ctx, restConfig, gvr, namespace)
-
-	if !authorized {
-		// Now try with the trust chain
-		restConfig = BuildRestConfigFromFiles(apiServer, apiServerTokenFile, caFile, tls)
-		authorized, err = IsAuthorizedFor(ctx, restConfig, gvr, namespace)
-	}
 
 	return restConfig, authorized, err
 }

--- a/pkg/resource/rest_test.go
+++ b/pkg/resource/rest_test.go
@@ -46,7 +46,7 @@ var _ = Describe("GetAuthorizedRestConfigFromData", func() {
 
 	d := newDynamicClientInfo()
 
-	When("a CA trust chain is not needed", func() {
+	When("TLS is insecure", func() {
 		It("should succeed when authorized", func(ctx context.Context) {
 			restConfig, authorized, err := resource.GetAuthorizedRestConfigFromData(ctx, apiServer, apiServerToken, caDataEncoded,
 				&rest.TLSClientConfig{Insecure: true}, gvr, "test-ns")
@@ -67,12 +67,8 @@ var _ = Describe("GetAuthorizedRestConfigFromData", func() {
 		})
 	})
 
-	When("a CA trust chain is needed", func() {
-		BeforeEach(func() {
-			fake.FailOnAction(&d.clientWithoutCAData.Fake, gvr.Resource, "*", x509.UnknownAuthorityError{}, false)
-		})
-
-		It("should succeed when authorized", func(ctx context.Context) {
+	When("CA data is provided", func() {
+		It("should always load the CA and succeed when authorized", func(ctx context.Context) {
 			restConfig, authorized, err := resource.GetAuthorizedRestConfigFromData(ctx, apiServer, apiServerToken, caDataEncoded,
 				&rest.TLSClientConfig{Insecure: false}, gvr, "test-ns")
 			Expect(err).To(Succeed())
@@ -122,10 +118,14 @@ var _ = Describe("GetAuthorizedRestConfigFromFiles", func() {
 
 	d := newDynamicClientInfo()
 
-	When("a CA trust chain is not needed", func() {
+	testInsecureTLS := func(ctx context.Context) (*rest.Config, bool, error) {
+		return resource.GetAuthorizedRestConfigFromFiles(ctx, apiServer, apiServerTokenFile, caFile,
+			&rest.TLSClientConfig{Insecure: true}, gvr, "test-ns")
+	}
+
+	When("TLS is insecure", func() {
 		It("should succeed when authorized", func(ctx context.Context) {
-			restConfig, authorized, err := resource.GetAuthorizedRestConfigFromFiles(ctx, apiServer, apiServerTokenFile, caFile,
-				&rest.TLSClientConfig{Insecure: true}, gvr, "test-ns")
+			restConfig, authorized, err := testInsecureTLS(ctx)
 			Expect(err).To(Succeed())
 			Expect(authorized).To(BeTrue())
 			Expect(restConfig.Host).To(ContainSubstring(apiServer))
@@ -136,19 +136,14 @@ var _ = Describe("GetAuthorizedRestConfigFromFiles", func() {
 		It("should fail when an API server error occurs", func(ctx context.Context) {
 			fake.FailOnAction(&d.clientWithoutCAData.Fake, gvr.Resource, "*", nil, false)
 
-			_, authorized, err := resource.GetAuthorizedRestConfigFromFiles(ctx, apiServer, apiServerTokenFile, caFile,
-				nil, gvr, "test-ns")
+			_, authorized, err := testInsecureTLS(ctx)
 			Expect(err).ToNot(Succeed())
 			Expect(authorized).To(BeTrue())
 		})
 	})
 
-	When("a CA trust chain is needed", func() {
-		BeforeEach(func() {
-			fake.FailOnAction(&d.clientWithoutCAData.Fake, gvr.Resource, "*", x509.UnknownAuthorityError{}, false)
-		})
-
-		It("should succeed when authorized", func(ctx context.Context) {
+	When("CA file is provided", func() {
+		It("should always load the CA and succeed when authorized", func(ctx context.Context) {
 			restConfig, authorized, err := resource.GetAuthorizedRestConfigFromFiles(ctx, apiServer, apiServerTokenFile, caFile,
 				&rest.TLSClientConfig{Insecure: false}, gvr, "test-ns")
 			Expect(err).To(Succeed())


### PR DESCRIPTION
Solves #1363 
GetAuthorizedRestConfigFromData() and GetAuthorizedRestConfigFromFiles() use a two-pass approach to load the broker CA:
1. Try connecting without CA
2. If x509.UnknownAuthorityError, retry with CA

This fails when the API server is temporarily unreachable at startup (e.g., pod initialization, network policies not ready). The error is a network timeout or connection refused, not x509.UnknownAuthorityError, so IsAuthorizedFor() returns authorized=true with a non-nil error. The retry-with-CA path is never taken.

When the API server later becomes reachable, the rest config still has no CA loaded, causing permanent x509.UnknownAuthorityError failures.

Fix:

Always load the CA when provided, eliminating the two-pass logic. This is safe because BuildRestConfigFromData already guards CA loading with !tls.Insecure && caData != "".

Before: try without CA, conditionally retry with CA
After: always load CA when provided in a single pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated REST configuration initialization to consistently apply provided CA data during setup, eliminating fallback attempts.

* **Tests**
  * Improved test clarity with refined naming conventions for CA and TLS scenarios and added test helpers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->