### PR TITLE
Use dedicated mux in HTTP server

### DIFF
--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -54,14 +54,18 @@ func StartServer(endpoints EndpointType, port int) StopFunc {
 		return func() {}
 	}
 
-	srv := &http.Server{Addr: fmt.Sprintf(":%d", port), ReadHeaderTimeout: 60 * time.Second}
+	// Use a dedicated mux so only the handlers registered below are reachable on this listener,
+	// regardless of what other packages may have registered on http.DefaultServeMux.
+	mux := http.NewServeMux()
+
+	srv := &http.Server{Addr: fmt.Sprintf(":%d", port), Handler: mux, ReadHeaderTimeout: 60 * time.Second}
 
 	if endpoints&Metrics != 0 {
-		http.Handle("/metrics", promhttp.Handler())
+		mux.Handle("/metrics", promhttp.Handler())
 	}
 
 	if endpoints&Profile != 0 {
-		http.HandleFunc("/debug", pprof.Profile)
+		mux.HandleFunc("/debug", pprof.Profile)
 	}
 
 	go func() {


### PR DESCRIPTION
`StartServer(`) registered `promhttp` and `net/http/pprof.Profile` on `http.DefaultServeMux` and served them via plain `ListenAndServe()` on 0.0.0.0 with no authentication. The pprof CPU-profile handler exposes stack traces and symbols to any network-adjacent caller. The handler set is now bound to a dedicated `ServeMux` (so only the explicitly registered paths are reachable on this listener).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved HTTP server route isolation so only explicitly supported endpoints are available.
  - Reduced the risk of unintended handlers being exposed through the server.
  - Metrics and profiling endpoints continue to function as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->