### PR TITLE
Automated backport of #1379: Use dedicated mux in HTTP server

### DIFF
--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -54,14 +54,18 @@ func StartServer(endpoints EndpointType, port int) StopFunc {
 		return func() {}
 	}
 
-	srv := &http.Server{Addr: fmt.Sprintf(":%d", port), ReadHeaderTimeout: 60 * time.Second}
+	// Use a dedicated mux so only the handlers registered below are reachable on this listener,
+	// regardless of what other packages may have registered on http.DefaultServeMux.
+	mux := http.NewServeMux()
+
+	srv := &http.Server{Addr: fmt.Sprintf(":%d", port), Handler: mux, ReadHeaderTimeout: 60 * time.Second}
 
 	if endpoints&Metrics != 0 {
-		http.Handle("/metrics", promhttp.Handler())
+		mux.Handle("/metrics", promhttp.Handler())
 	}
 
 	if endpoints&Profile != 0 {
-		http.HandleFunc("/debug", pprof.Profile)
+		mux.HandleFunc("/debug", pprof.Profile)
 	}
 
 	go func() {


### PR DESCRIPTION
Backport of #1379 on release-0.24.

#1379: Use dedicated mux in HTTP server

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP endpoint isolation by routing metrics and debugging endpoints through the server’s dedicated handler.
  * Prevented unintended interactions with other HTTP handlers running in the same process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->